### PR TITLE
de mess-ify fileio source

### DIFF
--- a/src/fileio.h
+++ b/src/fileio.h
@@ -38,10 +38,7 @@ enum
 	FILETYPE_CHEAT,
 	FILETYPE_LANGUAGE,
 	FILETYPE_CTRLR,
-#ifdef MESS
-	FILETYPE_CRC,
-#endif
-    FILETYPE_XML_DAT,
+        FILETYPE_XML_DAT,
 	FILETYPE_end /* dummy last entry */
 };
 


### PR DESCRIPTION
The MESS codepath is inoperable. It's not my main purpose to eliminate MESS code but I thought I would do so in order to have it clean as possible to track the problem with the sample path.