### PR TITLE
use default sound filter codepaths

### DIFF
--- a/src/mame.h
+++ b/src/mame.h
@@ -35,18 +35,10 @@ extern unsigned vector_resolution_multiplier;
 #define MAX_GFX_ELEMENTS 32
 #define MAX_MEMORY_REGIONS 32
 
-#ifndef MESS
 #define APPNAME					"MAME"
 #define APPLONGNAME				"M.A.M.E."
 #define GAMENOUN				"game"
 #define GAMESNOUN				"games"
-#else
-#define APPNAME					"MESS"
-#define APPLONGNAME				"M.E.S.S."
-#define GAMENOUN				"system"
-#define GAMESNOUN				"systems"
-#endif
-
 
 
 /***************************************************************************
@@ -172,19 +164,6 @@ struct RunningMachine
 #define ARTWORK_USE_BEZELS		0x04
 
 
-#ifdef MESS
-#define MAX_IMAGES	32
-/*
- * This is a filename and it's associated peripheral type
- * The types are defined in mess.h (IO_...)
- */
-struct ImageFile
-{
-	const char *name;
-	int type;
-};
-#endif
-
 /* The host platform should fill these fields with the preferences specified in the GUI */
 /* or on the commandline. */
 struct GameOptions
@@ -193,19 +172,17 @@ struct GameOptions
 	mame_file *	playback;		/* handle to file to playback input from */
 	mame_file *	language_file;	/* handle to file for localization */
 
-	int		mame_debug;		/* 1 to enable debugging */
-	int		cheat;			/* 1 to enable cheating */
-	int 	gui_host;		/* 1 to tweak some UI-related things for better GUI integration */
-	int 	skip_disclaimer;	/* 1 to skip the disclaimer screen at startup */
-	int 	skip_gameinfo;		/* 1 to skip the game info screen at startup */
-        int     skip_warnings;          /* 1 to skip the game warning screen at startup */
+	int		mame_debug;		             /* 1 to enable debugging */
+	int		cheat;			             /* 1 to enable cheating */
+	int 	skip_disclaimer;	         /* 1 to skip the disclaimer screen at startup */
+	int 	skip_gameinfo;		         /* 1 to skip the game info screen at startup */
+    int     skip_warnings;               /* 1 to skip the game warning screen at startup */
 
-	int		samplerate;		/* sound sample playback rate, in Hz */
-	int		use_samples;	/* 1 to enable external .wav samples */
-	int		use_filter;		/* 1 to enable FIR filter on final mixer output */
+	int		samplerate;		             /* sound sample playback rate, in Hz */
+	int		use_samples;	             /* 1 to enable external .wav samples */
 
-	float	brightness;		/* brightness of the display */
-	float	pause_bright;		/* additional brightness when in pause */
+	float	brightness;		             /* brightness of the display */
+	float	pause_bright;		         /* additional brightness when in pause */
 	float	gamma;			/* gamma correction of the display */
 	int		color_depth;	/* 15, 16, or 32, any other value means auto */
 	int		vector_width;	/* requested width for vector games; 0 means default (640) */
@@ -230,16 +207,6 @@ struct GameOptions
 	int		debug_height;	/* requested height of debugger bitmap */
 	int		debug_depth;	/* requested depth of debugger bitmap */
 
-	#ifdef MESS
-	UINT32 ram;
-	struct ImageFile image_files[MAX_IMAGES];
-	int		image_count;
-	int		(*mess_printf_output)(const char *fmt, va_list arg);
-	int disable_normal_ui;
-
-	int		min_width;		/* minimum width for the display */
-	int		min_height;		/* minimum height for the display */
-	#endif
 };
 
 
@@ -374,9 +341,5 @@ const struct performance_info *mame_get_performance_info(void);
 
 /* return the index of the given CPU, or -1 if not found */
 int mame_find_cpu_index(const char *tag);
-
-#ifdef MESS
-#include "mess.h"
-#endif /* MESS */
 
 #endif

--- a/src/sound/2151intf.c
+++ b/src/sound/2151intf.c
@@ -117,8 +117,7 @@ static int my_YM2151_sh_start(const struct MachineSound *msound,int mode)
 #if (HAS_YM2151_ALT)
 	case CHIP_YM2151_ALT:	/* Jarek's */
 
-		if (options.use_filter)
-			rate = intf->baseclock/64;
+        rate = intf->baseclock/64;
 
 		/* stream system initialize */
 		for (i = 0;i < intf->num;i++)

--- a/src/sound/2413intf.c
+++ b/src/sound/2413intf.c
@@ -42,8 +42,7 @@ int YM2413_sh_start (const struct MachineSound *msound)
 	intf = msound->sound_interface;
 	if( intf->num > MAX_2413 ) return 1;
 
-	if (options.use_filter)
-		rate = intf->baseclock/72;
+	rate = intf->baseclock/72;
 
 
 	/* emulator create */

--- a/src/sound/262intf.c
+++ b/src/sound/262intf.c
@@ -49,8 +49,7 @@ int YMF262_sh_start(const struct MachineSound *msound)
 	intf_262 = msound->sound_interface;
 	if( intf_262->num > MAX_262 ) return 1;
 
-	if (options.use_filter)
-		rate = intf_262->baseclock/288;
+	rate = intf_262->baseclock/288;
 
 	/* Timer state clear */
 	memset(Timer_262,0,sizeof(Timer_262));

--- a/src/sound/3812intf.c
+++ b/src/sound/3812intf.c
@@ -59,8 +59,7 @@ int YM3812_sh_start(const struct MachineSound *msound)
 	intf_3812 = msound->sound_interface;
 	if( intf_3812->num > MAX_3812 ) return 1;
 
-	if (options.use_filter)
-		rate = intf_3812->baseclock/72;
+	rate = intf_3812->baseclock/72;
 
 	/* Timer state clear */
 	memset(Timer_3812,0,sizeof(Timer_3812));
@@ -177,8 +176,7 @@ int YM3526_sh_start(const struct MachineSound *msound)
 	if( intf_3526->num > MAX_3526 ) return 1;
 
 
-	if (options.use_filter)
-		rate = intf_3526->baseclock/72;
+	rate = intf_3526->baseclock/72;
 
 	/* Timer state clear */
 	memset(Timer_3526,0,sizeof(Timer_3526));
@@ -313,9 +311,7 @@ int Y8950_sh_start(const struct MachineSound *msound)
 	intf_8950 = msound->sound_interface;
 	if( intf_8950->num > MAX_8950 ) return 1;
 
-	if (options.use_filter)
-		rate = intf_8950->baseclock/72;
-
+	rate = intf_8950->baseclock/72;
 
 	/* Timer state clear */
 	memset(Timer_8950,0,sizeof(Timer_8950));

--- a/src/sound/mixer.c
+++ b/src/sound/mixer.c
@@ -16,9 +16,6 @@
 /***************************************************************************/
 /* Options */
 
-/* Define it to enable the check of the flag options.use_filter as condition for the filter use */
-#define MIXER_USE_OPTION_FILTER
-
 /* Define it to enable the logerror output */
 /* #define MIXER_USE_LOGERROR */
 
@@ -153,9 +150,6 @@ static void mixer_channel_resample_set(struct mixer_channel_data *channel, unsig
 		}
 
 		/* make a new filter */
-#ifdef MIXER_USE_OPTION_FILTER
-		if (options.use_filter)
-#endif
 		if ((from_frequency != 0 && to_frequency != 0 && (from_frequency != to_frequency || lowpass_frequency != 0)))
 		{
 			double cut;
@@ -1257,4 +1251,3 @@ void mixer_sound_enable_global_w(int enable)
 
 	mixer_sound_enabled = enable;
 }
-


### PR DESCRIPTION
In mame 0.78 there are two ways to handle the audio filtering code. One is to `#define` so that `options.use_filter` is set from the commandline, or maybe `mame.ini`. The other is a default codepath equivalent `options.use_filter` being set.

Also there is some more `mame.h` cleanup here. I accidentally committed these changes in a previous commit.
