### PR TITLE
eliminate osd_fread and osd_fwrite

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -284,7 +284,7 @@ UINT32 mame_fread(mame_file *file, void *buffer, UINT32 length)
 	switch (file->type)
 	{
 		case PLAIN_FILE:
-			return osd_fread(file->file, buffer, length);
+			return fread(buffer, 1, length, file->file);
 
 		case ZIPPED_FILE:
 		case RAM_FILE:
@@ -317,7 +317,7 @@ UINT32 mame_fwrite(mame_file *file, const void *buffer, UINT32 length)
 	switch (file->type)
 	{
 		case PLAIN_FILE:
-			return osd_fwrite(file->file, buffer, length);
+			return fwrite(buffer, 1, length, file->file);
 	}
 
 	return 0;
@@ -439,7 +439,7 @@ int mame_fgetc(mame_file *file)
 	switch (file->type)
 	{
 		case PLAIN_FILE:
-			if (osd_fread(file->file, &buffer, 1) == 1)
+			if (fread(&buffer, 1, 1, file->file) == 1)
 				return buffer;
 			return EOF;
 
@@ -996,7 +996,7 @@ static int checksum_file(int pathtype, int pathindex, const char *file, UINT8 **
 		return -1;
 	}
 
-	if (osd_fread(f, data, length) != length)
+	if (fread(data, 1, length, f) != length)
 	{
 		free(data);
 		fclose(f);

--- a/src/libretro/osd.c
+++ b/src/libretro/osd.c
@@ -202,21 +202,7 @@ FILE* osd_fopen(int pathtype, int pathindex, const char *filename, const char *m
 
    out = fopen(buffer, mode);
 
-   if (out == 0)
-   {
-      return 0;
-   }
    return out;
-}
-
-UINT32 osd_fread(FILE* file, void *buffer, UINT32 length)
-{
-	return fread(buffer, 1, length, file);
-}
-
-UINT32 osd_fwrite(FILE* file, const void *buffer, UINT32 length)
-{
-	return fwrite(buffer, 1, length, file);
 }
 
 

--- a/src/mame_unzip.c
+++ b/src/mame_unzip.c
@@ -93,7 +93,7 @@ static int ecd_read(ZIP* zip) {
 			return -1;
 		}
 
-		if (osd_fread( zip->fp, buf, buf_length ) != buf_length) {
+		if (fread( buf, 1, buf_length, zip->fp ) != buf_length) {
 			free(buf);
 			return -1;
 		}
@@ -264,7 +264,7 @@ ZIP* openzip(int pathtype, int pathindex, const char* zipfile) {
 		return 0;
 	}
 
-	if (osd_fread(zip->fp, zip->cd, zip->size_of_cent_dir)!=zip->size_of_cent_dir) {
+	if (fread(zip->cd, 1, zip->size_of_cent_dir, zip->fp)!=zip->size_of_cent_dir) {
 		errormsg ("Reading central directory", ERROR_CORRUPT, zipfile);
 		free(zip->cd);
 		free(zip->ecd);
@@ -423,7 +423,7 @@ int seekcompresszip(ZIP* zip, struct zipent* ent) {
 		return -1;
 	}
 
-	if (osd_fread(zip->fp, buf, ZIPNAME)!=ZIPNAME) {
+	if (fread(buf, 1, ZIPNAME, zip->fp)!=ZIPNAME) {
 		errormsg ("Reading header", ERROR_CORRUPT, zip->zip);
 		return -1;
 	}
@@ -497,7 +497,7 @@ static int inflate_file(FILE* in_file, unsigned in_size, unsigned char* out_data
 			return -1;
 		}
 		d_stream.next_in  = in_buffer;
-		d_stream.avail_in = osd_fread (in_file, in_buffer, MIN(in_size, INFLATE_INPUT_BUFFER_MAX));
+		d_stream.avail_in = fread (in_buffer, 1, MIN(in_size, INFLATE_INPUT_BUFFER_MAX), in_file);
 		in_size -= d_stream.avail_in;
 		if (in_size == 0)
 			d_stream.avail_in++; /* add dummy byte at end of compressed data */
@@ -544,7 +544,7 @@ int readcompresszip(ZIP* zip, struct zipent* ent, char* data) {
 	if (err!=0)
 		return err;
 
-	if (osd_fread(zip->fp, data, ent->compressed_size)!=ent->compressed_size) {
+	if (fread(data, 1, ent->compressed_size, zip->fp)!=ent->compressed_size) {
 		errormsg ("Reading compressed data", ERROR_CORRUPT, zip->zip);
 		return -1;
 	}

--- a/src/osdepend.h
+++ b/src/osdepend.h
@@ -279,12 +279,6 @@ int osd_get_path_info(int pathtype, int pathindex, const char *filename);
 /* Attempt to open a file with the given name and mode using the specified path type */
 FILE* osd_fopen(int pathtype, int pathindex, const char *filename, const char *mode);
 
-/* Read bytes from a file */
-UINT32 osd_fread(FILE* file, void *buffer, UINT32 length);
-
-/* Write bytes to a file */
-UINT32 osd_fwrite(FILE* file, const void *buffer, UINT32 length);
-
 int osd_create_directory(const char *dir);
 
 


### PR DESCRIPTION
These are particularly annoying because the osd_ versions invert the order of the parameters in the standard c equivalents.