### PR TITLE
[HOLD] add disabled toggle for native mame backdrop art

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -473,7 +473,7 @@ static void update_variables(void)
     
     options.use_samples = 1;
     options.cheat = 1;
-
+    /*options.use_artwork = ARTWORK_USE_BACKDROPS;*/
 }
 
 void retro_get_system_av_info(struct retro_system_av_info *info)


### PR DESCRIPTION
This PR can wait till a quiet moment in the buildbot.

After some preliminary tests I don't know if this function is working so I'm simply adding a commented-out toggle for now to facilitate further testing.