### PR TITLE
determine bios region from core options

### DIFF
--- a/src/drivers/neogeo.c
+++ b/src/drivers/neogeo.c
@@ -1454,13 +1454,13 @@ aof3
  ****/
 
 SYSTEM_BIOS_START( neogeo )
-	SYSTEM_BIOS_ADD( 0, "euro",       "Europe MVS (Ver. 2)" )
-	SYSTEM_BIOS_ADD( 1, "euro-s1",    "Europe MVS (Ver. 1)" )
-	SYSTEM_BIOS_ADD( 2, "us",         "US MVS (Ver. 2?)" )
-	SYSTEM_BIOS_ADD( 3, "us-e",       "US MVS (Ver. 1)" )
+	SYSTEM_BIOS_ADD( 0, "us",         "US MVS (Ver. 2?)" )
+	SYSTEM_BIOS_ADD( 1, "europe",       "Europe MVS (Ver. 2)" )
+	SYSTEM_BIOS_ADD( 2, "europe-a",    "Europe MVS (Ver. 1)" )
+	SYSTEM_BIOS_ADD( 3, "us-a",       "US MVS (Ver. 1)" )
 	SYSTEM_BIOS_ADD( 4, "asia",       "Asia MVS (Ver. 3)" )
 	SYSTEM_BIOS_ADD( 5, "japan",      "Japan MVS (Ver. 3)" )
-	SYSTEM_BIOS_ADD( 6, "japan-s2",   "Japan MVS (Ver. 2)" )
+	SYSTEM_BIOS_ADD( 6, "japan-a",   "Japan MVS (Ver. 2)" )
 
 //	SYSTEM_BIOS_ADD( 7, "uni-bios.10","Unibios MVS (Hack, Ver. 1.0)" )
 //	SYSTEM_BIOS_ADD( 8, "uni-bios.11","Unibios MVS (Hack, Ver. 1.1)" )

--- a/src/drivers/stv.c
+++ b/src/drivers/stv.c
@@ -3759,9 +3759,9 @@ ROM_END
 
 SYSTEM_BIOS_START( stvbios )
 	SYSTEM_BIOS_ADD( 0, "japan",       "Japan (bios epr19730)" )
-	SYSTEM_BIOS_ADD( 1, "japana",      "Japan (bios mp17951a)" )
+	SYSTEM_BIOS_ADD( 1, "japan-a",      "Japan (bios mp17951a)" )
 	SYSTEM_BIOS_ADD( 2, "us",          "USA (bios mp17952a)" )
-	SYSTEM_BIOS_ADD( 3, "japanb",      "Japan (bios 20091)" )
+	SYSTEM_BIOS_ADD( 3, "japan-b",      "Japan (bios 20091)" )
 	SYSTEM_BIOS_ADD( 4, "taiwan",      "Taiwan (bios mp17953a)" )
 	SYSTEM_BIOS_ADD( 5, "europe",      "Europe (bios mp17954a)" )
 //	SYSTEM_BIOS_ADD( 7, "saturn",      "Saturn bios :)" )

--- a/src/libretro-common/include/file/file_path.h
+++ b/src/libretro-common/include/file/file_path.h
@@ -432,7 +432,7 @@ void path_basedir_wrapper(char *path);
 #endif
 
 /**
- * path_default_slash:
+ * path_default_slash and path_default_slash_c:
  *
  * Gets the default slash separator.
  *
@@ -440,8 +440,10 @@ void path_basedir_wrapper(char *path);
  */
 #ifdef _WIN32
 #define path_default_slash() "\\"
+#define path_default_slash_c() '\\'
 #else
 #define path_default_slash() "/"
+#define path_default_slash_c() '/'
 #endif
 
 /**

--- a/src/mame.c
+++ b/src/mame.c
@@ -844,18 +844,15 @@ static int init_game_options(void)
 	if (options.vector_height == 0) options.vector_height = 480;
 
 
-
 	/* get orientation right */
 	Machine->orientation = ROT0;
 	Machine->ui_orientation = options.ui_orientation;
 
-    /* catch any custom options needed on a per-game basis. this approach feels like a hack. */
+    /* catch any custom bios options needed on a per-game basis. this is a hack. */
     if(stricmp(Machine->gamedrv->name, "diehard") == 0) {
         options.bios = strdup("us");
     }
-    if(stricmp(Machine->gamedrv->name,"neobombe") == 0) {
-        options.bios = strdup("us");
-    }
+    printf("the curent bios option: %s\n", options.bios);
 
 	return 0;
 }


### PR DESCRIPTION
The one downside to this approach that I know of that it may require tweaking the 'internal' bios names for other drivers in order to make the region names standard like I have done here between `neogeo` and `stv`

The upside is that we can support more languages, etc.

Edit: I also rearranged the core options into my arbitrary idea of a better order, based on which settings people might go looking for first