### PR TITLE
restore mame_done call

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -787,7 +787,7 @@ bool retro_load_game(const struct retro_game_info *game)
 
 void retro_unload_game(void)
 {
-    /*mame_done();*/
+    mame_done();
     
     /*free(fallbackDir);
     systemDir = 0;*/


### PR DESCRIPTION
@grant2258 I must sincerely apologize. I do remember refactoring mame_frame() so that it is declared in a header file but I cannot explain why mame_done() got commented out of mame2003.c

It seems best to restore the call, right?