### PR TITLE
cleanups for rom loading code - no functional change

### DIFF
--- a/src/libretro-common/file/file_path.c
+++ b/src/libretro-common/file/file_path.c
@@ -383,15 +383,16 @@ const char *path_get_extension(const char *path)
  * Only '.'s after the last slash are considered.
  *
  * Returns: path with the extension part removed.
+ * If there is no extension at the end of path,
+ * returns a pointer to the unaltered original path.
  */
 char *path_remove_extension(char *path)
 {
    char *last = !string_is_empty(path) 
       ? (char*)strrchr(path_basename(path), '.') : NULL;
    if (!last)
-      return NULL;
-   if (*last)
-      *last = '\0';
+      return path;
+   *last = '\0';
    return path;
 }
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -722,10 +722,6 @@ bool retro_load_game(const struct retro_game_info *game)
     unsigned        rotateMode;
     static const int uiModes[] = {ROT0, ROT90, ROT180, ROT270};
 
-    /* because we set info->need_fullpath = true, the frontend is guaranteed to provide a 
-     * valid pathname in retro_game_info::path. */
- 
-
     retro_describe_buttons();
     
     log_cb(RETRO_LOG_INFO, LOGPRE "game->path: [%s].\n", game->path);
@@ -734,12 +730,10 @@ bool retro_load_game(const struct retro_game_info *game)
     log_cb(RETRO_LOG_INFO, LOGPRE "Content lookup name: [%s].\n", driver_lookup);
 
     if (driver_lookup == 0)
-   /*this is need if using command line*/
     {
       log_cb(RETRO_LOG_ERROR, LOGPRE "Content does not exist. Exiting!\n");
       return false;
     }
-
 
     /* Search list */
     for (driverIndex = 0; driverIndex < total_drivers; driverIndex++)


### PR DESCRIPTION
Hi @grant2258 I think it's good to leave your null check for the driver name in place, just for now. A little extra checking would not hurt!

So my proposal in this PR is to clean up the comments, update `file_path.c`, and leave the logic as it is for our long-term use.

If that makes sense to you, feel free to merge this on in or give me the word and I'll so so. Thanks!