### PR TITLE
remove vestigal "Reset" and "OSD" mapping options in MAME menu

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -403,8 +403,6 @@ const char ipdn_defaultstrings[][MAX_DEFSTR_LEN] =
 struct ipd inputport_defaults[] =
 {
 	{ IPT_UI_CONFIGURE,         "Config Menu",			SEQ_DEF_3(KEYCODE_TAB, CODE_OR, JOYCODE_1_BUTTON8) },
-	{ IPT_UI_ON_SCREEN_DISPLAY, "On Screen Display",	SEQ_DEF_1(KEYCODE_TILDE) },
-	{ IPT_UI_RESET_MACHINE,     "Reset Game",			SEQ_DEF_1(KEYCODE_NONE) },
 	{ IPT_UI_SHOW_GFX,          "Show Gfx",				SEQ_DEF_1(KEYCODE_NONE) },
 	{ IPT_UI_TOGGLE_CHEAT,      "Toggle Cheat",			SEQ_DEF_1(KEYCODE_NONE) },
 	{ IPT_UI_UP,                "UI Up",				SEQ_DEF_3(KEYCODE_UP, CODE_OR, JOYCODE_1_UP) },

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3072,11 +3072,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
 				sel |= 1 << SEL_BITS;
 				schedule_full_refresh();
 				break;
-
-			case UI_RESET:
-				machine_reset();
-				break;
-            
+           
       case UI_GENERATE_NEW_XML_DAT:
           print_mame_xml(0);
           break;
@@ -3209,10 +3205,6 @@ int handle_user_interface(struct mame_bitmap *bitmap)
 	if (!mame_debug)
 #endif
 
-	/* if the user pressed F3, reset the emulation */
-	/*if (input_ui_pressed(IPT_UI_RESET_MACHINE))
-		machine_reset();*/
-
 	/* show popup message if any */
 	if (messagecounter > 0)
 	{
@@ -3222,8 +3214,7 @@ int handle_user_interface(struct mame_bitmap *bitmap)
 			schedule_full_refresh();
 	}
 
-
-	/* if the user pressed F4, show the character set */
+	/* if the user pressed IPT_UI_SHOW_GFX, show the character set */
 	if (input_ui_pressed(IPT_UI_SHOW_GFX))
 	{
 		showcharset(bitmap);


### PR DESCRIPTION
I wanted to submit this as a PR so that is easier to track. 

I thought I removed the Reset and OSD mapping options a while back, since they already don't do anything. Maybe that was in mame2003. :man_shrugging: 

That being said this is a straightforward change that I have tested here in mame_keyboard and retropad modes just to make sure it doesn't knock off any of our other mapping code. I'll merge it now as well.