### PR TITLE
split copyright notice and warnings back into two options

### DIFF
--- a/src/mame.h
+++ b/src/mame.h
@@ -164,11 +164,6 @@ struct RunningMachine
 #define RETROPAD_MODERN			1
 #define RETROPAD_SNES			2
 
-#define NO_NOTICES        0
-#define ALL_NOTICES       1
-#define COPYRIGHT_NOTICE  2
-#define WARNING_NOTICES   3
-
 /* The host platform should fill these fields with the preferences specified in the GUI */
 /* or on the commandline. */
 struct GameOptions
@@ -184,7 +179,8 @@ struct GameOptions
 
   int		   mame_debug;		       /* 1 to enable debugging */
   int 	   skip_gameinfo;		     /* 1 to skip the game info screen at startup */
-  int      display_notices;     /* 1 to skip the warning messages at startup */
+  bool 	   skip_disclaimer;	     /* 1 to skip the disclaimer screen at startup */
+  bool     skip_warnings;        /* 1 to skip the game warning screen at startup */
   int      display_setup;        /* 1 to display the MAME setup menu until reset to 0 */
 
   unsigned dial_share_xy;

--- a/src/mame.h
+++ b/src/mame.h
@@ -164,6 +164,10 @@ struct RunningMachine
 #define RETROPAD_MODERN			1
 #define RETROPAD_SNES			2
 
+#define NO_NOTICES        0
+#define ALL_NOTICES       1
+#define COPYRIGHT_NOTICE  2
+#define WARNING_NOTICES   3
 
 /* The host platform should fill these fields with the preferences specified in the GUI */
 /* or on the commandline. */
@@ -180,7 +184,7 @@ struct GameOptions
 
   int		   mame_debug;		       /* 1 to enable debugging */
   int 	   skip_gameinfo;		     /* 1 to skip the game info screen at startup */
-  int      skip_warnings;        /* 1 to skip the warning messages at startup */
+  int      display_notices;     /* 1 to skip the warning messages at startup */
   int      display_setup;        /* 1 to display the MAME setup menu until reset to 0 */
 
   unsigned dial_share_xy;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -121,7 +121,7 @@ void retro_set_environment(retro_environment_t cb)
     { APPNAME"_skip_rom_verify", "EXPERIMENTAL: Skip ROM verification (Restart); disabled|enabled" },
     { APPNAME"_sample_rate", "Sample Rate (KHz); 48000|8000|11025|22050|44100" },
     { APPNAME"_dcs_speedhack","DCS Speedhack; enabled|disabled"},
-    { APPNAME"_skip_warnings", "Display Warnings; all||enabled" },
+    { APPNAME"_display_notices", "Display Notices; all|warnings|copyright|none" },
     { NULL, NULL },
   };
   environ_cb = cb;
@@ -443,14 +443,18 @@ static void update_variables(bool first_time)
 
   var.value = NULL;
 
-  var.key = APPNAME"_skip_warnings";
-  options.skip_warnings = 0;
+  var.key = APPNAME"_display_notices";
+  options.display_notices = ALL_NOTICES;
   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
   {
-    if(strcmp(var.value, "enabled") == 0)
-      options.skip_warnings = 1;
-    else
-      options.skip_warnings = 0;
+    if(strcmp(var.value, "none") == 0)
+      options.display_notices = NO_NOTICES;
+    else if(strcmp(var.value, "all") == 0)
+      options.display_notices = ALL_NOTICES;     
+    else if(strcmp(var.value, "warnings") == 0)
+      options.display_notices = WARNING_NOTICES;
+    else if(strcmp(var.value, "copyright") == 0) 
+      options.display_notices = COPYRIGHT_NOTICE;      
   }
 
   var.value = NULL;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -121,7 +121,8 @@ void retro_set_environment(retro_environment_t cb)
     { APPNAME"_skip_rom_verify", "EXPERIMENTAL: Skip ROM verification (Restart); disabled|enabled" },
     { APPNAME"_sample_rate", "Sample Rate (KHz); 48000|8000|11025|22050|44100" },
     { APPNAME"_dcs_speedhack","DCS Speedhack; enabled|disabled"},
-    { APPNAME"_display_notices", "Display Notices; all|warnings|copyright|none" },
+    { APPNAME"_skip_disclaimer", "Skip Disclaimer; disabled|enabled" },
+    { APPNAME"_skip_warnings", "Skip Warnings; disabled|enabled" },
     { NULL, NULL },
   };
   environ_cb = cb;
@@ -443,18 +444,26 @@ static void update_variables(bool first_time)
 
   var.value = NULL;
 
-  var.key = APPNAME"_display_notices";
-  options.display_notices = ALL_NOTICES;
+  var.key = APPNAME"_skip_disclaimer";
+  options.skip_disclaimer = false;
   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
   {
-    if(strcmp(var.value, "none") == 0)
-      options.display_notices = NO_NOTICES;
-    else if(strcmp(var.value, "all") == 0)
-      options.display_notices = ALL_NOTICES;     
-    else if(strcmp(var.value, "warnings") == 0)
-      options.display_notices = WARNING_NOTICES;
-    else if(strcmp(var.value, "copyright") == 0) 
-      options.display_notices = COPYRIGHT_NOTICE;      
+    if(strcmp(var.value, "enabled") == 0)
+      options.skip_disclaimer = true;
+    else
+      options.skip_disclaimer = false;
+  }
+
+  var.value = NULL;
+
+  var.key = APPNAME"_skip_warnings";
+  options.skip_warnings = false;
+  if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+  {
+    if(strcmp(var.value, "enabled") == 0)
+      options.skip_warnings = true;
+    else
+      options.skip_warnings = false;
   }
 
   var.value = NULL;

--- a/src/ui_text.c
+++ b/src/ui_text.c
@@ -19,7 +19,7 @@ static const char *mame_default_text[] =
 	"MAME",
 
 	/* copyright stuff */
-	"       ----- Copyright Warning -----\nCopying game data without permission is forbidden by copyright law. If you are not entitled to emulate this system, please exit now.\n",
+	"         ----- Copyright Warning -----\nCopying game data without permission is forbidden by copyright law. If you are not entitled to emulate this system, please exit now.\n",
 
 	/* misc stuff */
 	"Return to Main Menu",

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -2387,28 +2387,21 @@ void ui_copyright_and_warnings(void)
   if(generate_warning_list())
   {
       log_cb(RETRO_LOG_WARN, LOGPRE "\n\n%s", message_buffer); /* log warning list to the console */
-      if(options.display_notices == WARNING_NOTICES) /* set to only display warnings */
+      if(options.skip_disclaimer && !options.skip_warnings) /* set to only display warnings */
       {
         usrintf_showmessage_secs(8, "%s - %s %s\n\n%s", Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer, message_buffer);
       }
-      else if(options.display_notices == NO_NOTICES)
+      else if(options.skip_disclaimer && options.skip_warnings)
         message_buffer[0] = '\0';     /* no need to hold the warnings in a string if not displaying them. 
                                          now we can also use string_is_empty on the buffer as a test */ 
   }
   
-  if(options.display_notices == ALL_NOTICES)
+  if(!options.skip_disclaimer)
   {
-    if(!string_is_empty(message_buffer)) 
+    if(!options.skip_warnings && !string_is_empty(message_buffer)) /* warnings present in the buffer */
     {
       usrintf_showmessage_secs(8, "%s\n%s - %s %s\n\n%s", ui_getstring(UI_copyright), Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer, message_buffer);
     }
-    else
-    {
-      usrintf_showmessage_secs(8, "%s", ui_getstring(UI_copyright));
-    }
-  }
-  else if(options.display_notices == COPYRIGHT_NOTICE)
-  {
     usrintf_showmessage_secs(8, "%s", ui_getstring(UI_copyright));
   }
 

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -2384,12 +2384,34 @@ void generate_gameinfo(void)
 
 void ui_copyright_and_warnings(void)
 {
-  if(!options.skip_warnings)   
-    usrintf_showmessage_secs(8, "%s\n%s - %s %s\n\n%s", ui_getstring(UI_copyright), Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer, (generate_warning_list() ? message_buffer : ""));
-  if(!string_is_empty(message_buffer))
+  if(generate_warning_list())
   {
-    log_cb(RETRO_LOG_WARN, LOGPRE "\n\n%s", message_buffer);
+      log_cb(RETRO_LOG_WARN, LOGPRE "\n\n%s", message_buffer); /* log warning list to the console */
+      if(options.display_notices == WARNING_NOTICES) /* set to only display warnings */
+      {
+        usrintf_showmessage_secs(8, "%s - %s %s\n\n%s", Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer, message_buffer);
+      }
+      else if(options.display_notices == NO_NOTICES)
+        message_buffer[0] = '\0';     /* no need to hold the warnings in a string if not displaying them. 
+                                         now we can also use string_is_empty on the buffer as a test */ 
   }
+  
+  if(options.display_notices == ALL_NOTICES)
+  {
+    if(!string_is_empty(message_buffer)) 
+    {
+      usrintf_showmessage_secs(8, "%s\n%s - %s %s\n\n%s", ui_getstring(UI_copyright), Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer, message_buffer);
+    }
+    else
+    {
+      usrintf_showmessage_secs(8, "%s", ui_getstring(UI_copyright));
+    }
+  }
+  else if(options.display_notices == COPYRIGHT_NOTICE)
+  {
+    usrintf_showmessage_secs(8, "%s", ui_getstring(UI_copyright));
+  }
+
   generate_gameinfo();
   log_cb(RETRO_LOG_INFO, LOGPRE "\n\n%s", message_buffer);
   
@@ -2494,7 +2516,7 @@ bool generate_warning_list(void)
   if(string_is_empty(buffer))
     return false;
   
-  snprintf(message_buffer, MAX_MESSAGE_LENGTH, "        ----- Driver Warnings -----\n%s", buffer);
+  snprintf(message_buffer, MAX_MESSAGE_LENGTH, "          ----- Driver Warnings -----\n%s", buffer);
 	return true;
 }
 


### PR DESCRIPTION
I'm not against having two different core options for this but I'm just trying to keep the number somewhat manageable.

Does this 'four-way' selector make sense to folks?

According to the license we can't remove the copyright warning or distribute compiled versions with the copyright notice disabled by default. Any of our approaches is consistent with that requirement, I just wanted to mention it while we're looking at this part of the code.
