### PR TITLE
align neo geo bios sets with current mame

### DIFF
--- a/src/drivers/neogeo.c
+++ b/src/drivers/neogeo.c
@@ -1453,19 +1453,19 @@ aof3
  ****/
 
 SYSTEM_BIOS_START( neogeo )
-	SYSTEM_BIOS_ADD( 0, "europe",       "Europe MVS (Ver. 2)" )
-	SYSTEM_BIOS_ADD( 1, "europe_a",    "Europe MVS (Ver. 1)" )
+	SYSTEM_BIOS_ADD( 0, "euro",       "Europe MVS (Ver. 2)" )
+	SYSTEM_BIOS_ADD( 1, "euro-s1",    "Europe MVS (Ver. 1)" )
 	SYSTEM_BIOS_ADD( 2, "us",         "US MVS (Ver. 2?)" )
-	SYSTEM_BIOS_ADD( 3, "us-a",       "US MVS (Ver. 1)" )
+	SYSTEM_BIOS_ADD( 3, "us-e",       "US MVS (Ver. 1)" )
 	SYSTEM_BIOS_ADD( 4, "asia",       "Asia MVS (Ver. 3)" )
 	SYSTEM_BIOS_ADD( 5, "japan",      "Japan MVS (Ver. 3)" )
-	SYSTEM_BIOS_ADD( 6, "japan-a",   "Japan MVS (Ver. 2)" )
-	SYSTEM_BIOS_ADD( 7, "uni-bios.10","Unibios MVS (Hack, Ver. 1.0)" )
-	SYSTEM_BIOS_ADD( 8, "uni-bios.11","Unibios MVS (Hack, Ver. 1.1)" )
-	SYSTEM_BIOS_ADD( 9, "debug",      "Debug MVS (Hack?)" )
-	SYSTEM_BIOS_ADD(10, "asia-aes",   "Asia AES" )
-	SYSTEM_BIOS_ADD(11, "uni-bios.13","Unibios MVS (Hack, Ver. 1.3)" )
-	SYSTEM_BIOS_ADD(12, "uni-bios.20","Unibios MVS (Hack, Ver. 2.0)" )
+	SYSTEM_BIOS_ADD( 6, "japan-s2",   "Japan MVS (Ver. 2)" )
+	SYSTEM_BIOS_ADD( 7, "unibios20",  "Unibios MVS (Hack, Ver. 2.0)" )
+	SYSTEM_BIOS_ADD( 8, "unibios13",  "Unibios MVS (Hack, Ver. 1.3)" )  
+	SYSTEM_BIOS_ADD( 9, "unibios11",  "Unibios MVS (Hack, Ver. 1.1)" )  
+	SYSTEM_BIOS_ADD(10, "unibios10",  "Unibios MVS (Hack, Ver. 1.0)" )
+	SYSTEM_BIOS_ADD(10, "debug",      "Debug MVS (Hack?)" )
+	SYSTEM_BIOS_ADD(11, "asia-aes",   "Asia AES" )
 SYSTEM_BIOS_END
 
 
@@ -1479,17 +1479,18 @@ SYSTEM_BIOS_END
 	ROM_LOAD16_WORD_SWAP_BIOS( 3, "sp-e.sp1",     0x00000, 0x020000, CRC(2723a5b5) SHA1(5dbff7531cf04886cde3ef022fb5ca687573dcb8) ) /* US, 6 Slot (V5?) */ \
 	ROM_LOAD16_WORD_SWAP_BIOS( 4, "asia-s3.rom",  0x00000, 0x020000, CRC(91b64be3) SHA1(720a3e20d26818632aedf2c2fd16c54f213543e1) ) /* Asia */ \
 	ROM_LOAD16_WORD_SWAP_BIOS( 5, "vs-bios.rom",  0x00000, 0x020000, CRC(f0e8f27d) SHA1(ecf01eda815909f1facec62abf3594eaa8d11075) ) /* Japan, Ver 6 VS Bios */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 6, "sp-j2.rom",    0x00000, 0x020000, CRC(acede59c) SHA1(b6f97acd282fd7e94d9426078a90f059b5e9dd91) ) /* Japan, Older */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 7, "uni-bios.10",  0x00000, 0x020000, CRC(0ce453a0) SHA1(3b4c0cd26c176fc6b26c3a2f95143dd478f6abf9) ) /* Universe Bios v1.0 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 8, "uni-bios.11",  0x00000, 0x020000, CRC(5dda0d84) SHA1(4153d533c02926a2577e49c32657214781ff29b7) ) /* Universe Bios v1.1 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 9, "neodebug.rom", 0x00000, 0x020000, CRC(698ebb7d) SHA1(081c49aa8cc7dad5939833dc1b18338321ea0a07) ) /* Debug (Development) Bios */ \
-	ROM_LOAD16_WORD_SWAP_BIOS(10, "aes-bios.bin", 0x00000, 0x020000, CRC(d27a71f1) SHA1(1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07) ) /* AES Console (Asia?) Bios */ \
-	ROM_LOAD16_WORD_SWAP_BIOS(11, "uni-bios.13",  0x00000, 0x020000, CRC(b24b44a0) ) /* Universe Bios v1.3 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS(12, "uni-bios.20",  0x00000, 0x020000, CRC(0c12c2ad) ) /* Universe Bios v2.0 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 6, "sp-j2.sp1",    0x00000, 0x020000, CRC(acede59c) SHA1(b6f97acd282fd7e94d9426078a90f059b5e9dd91) ) /* Japan, Older */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 7, "uni-bios_2_0.rom",  0x00000, 0x020000, CRC(0c12c2ad) ) /* Universe Bios v2.0 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 8, "uni-bios_1_3.rom",  0x00000, 0x020000, CRC(b24b44a0) ) /* Universe Bios v1.3 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 9, "uni-bios_1_1.rom",  0x00000, 0x020000, CRC(5dda0d84) SHA1(4153d533c02926a2577e49c32657214781ff29b7) ) /* Universe Bios v1.1 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(10, "uni-bios_1_0.rom",  0x00000, 0x020000, CRC(0ce453a0) SHA1(3b4c0cd26c176fc6b26c3a2f95143dd478f6abf9) ) /* Universe Bios v1.0 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(11, "neodebug.rom", 0x00000, 0x020000, CRC(698ebb7d) SHA1(081c49aa8cc7dad5939833dc1b18338321ea0a07) ) /* Debug (Development) Bios */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(12, "neo-epo.bin", 0x00000, 0x020000, CRC(d27a71f1) SHA1(1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07) ) /* AES Console (Asia?) Bios */ \
 
 /* note you'll have to modify the last for lines of each block to use the extra bios roms,
    they're hacks / homebrew / console bios roms so Mame doesn't list them by default */
-
+   
+/* may 2018: what does the above comment mean? is it just talking about listing the bioses in a UI? that doesn't matter to mame2003-plus*/
 
 
 /* we only have one irritating maze bios and thats asia */

--- a/src/drivers/stv.c
+++ b/src/drivers/stv.c
@@ -3759,9 +3759,9 @@ ROM_END
 
 SYSTEM_BIOS_START( stvbios )
 	SYSTEM_BIOS_ADD( 0, "japan",       "Japan (bios epr19730)" )
-	SYSTEM_BIOS_ADD( 1, "japan_a",      "Japan (bios mp17951a)" )
+	SYSTEM_BIOS_ADD( 1, "japana",      "Japan (bios mp17951a)" )
 	SYSTEM_BIOS_ADD( 2, "us",          "USA (bios mp17952a)" )
-	SYSTEM_BIOS_ADD( 3, "japan_b",      "Japan (bios 20091)" )
+	SYSTEM_BIOS_ADD( 3, "japanb",      "Japan (bios 20091)" )
 	SYSTEM_BIOS_ADD( 4, "taiwan",      "Taiwan (bios mp17953a)" )
 	SYSTEM_BIOS_ADD( 5, "europe",      "Europe (bios mp17954a)" )
 /*	SYSTEM_BIOS_ADD( 7, "saturn",      "Saturn bios :)" )*/

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -91,6 +91,7 @@ static void check_system_specs(void)
    environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, &level);
 }
 
+
 void retro_set_environment(retro_environment_t cb)
 {
   static const struct retro_variable vars[] = {
@@ -107,7 +108,8 @@ void retro_set_environment(retro_environment_t cb)
     { APPNAME"_brightness", "Brightness; 1.0|0.2|0.3|0.4|0.5|0.6|0.7|0.8|0.9|1.1|1.2|1.3|1.4|1.5|1.6|1.7|1.8|1.9|2.0" },
     { APPNAME"_gamma", "Gamma correction; 1.2|0.5|0.6|0.7|0.8|0.9|1.1|1.2|1.3|1.4|1.5|1.6|1.7|1.8|1.9|2.0" },
     { APPNAME"_enable_backdrop", "EXPERIMENTAL: Use Backdrop artwork (Restart); disabled|enabled" },
-    { APPNAME"_bios_region", "Specify alternate BIOS region (Restart); default|asia|asia-aes|debug|europe|europe_a|japan|japan_a|japan_b|taiwan|us|us_a|uni-bios.10|uni-bios.11|uni-bios.13|uni-bios.20" },
+    { APPNAME"_neogeo_bios", "Specify Neo Geo BIOS (Restart); default|euro|euro-s1|us|us-e|asia|japan|japan-s2|unibios20|unibios13|unibios11|unibios10|debug|asia-aes" },
+    { APPNAME"_stv_bios", "Specify Sega ST-V BIOS (Restart); default|japan|japana|us|japan_b|taiwan|europe" },    
     { APPNAME"_dialsharexy", "Share 2 player dial controls across one X/Y device; disabled|enabled" },
     { APPNAME"_dual_joysticks", "Dual Joystick Mode (Players 1 & 2); disabled|enabled" },
     { APPNAME"_rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
@@ -279,16 +281,30 @@ static void update_variables(bool first_time)
       options.use_artwork = ARTWORK_USE_NONE;
   }
 
+  options.bios = NULL;
+
   var.value = NULL;
 
-  var.key = APPNAME"_bios_region";
-  options.bios = NULL;
+  var.key = APPNAME"_neogeo_bios";
   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
   {
-    if(strcmp(var.value, "default") == 0)
-      options.bios = NULL;
-    else
+    if(strcmp(var.value, "default") != 0) /* leave as null if set to default */
       options.bios = strdup(var.value);
+  }
+  
+  var.value = NULL;
+
+  var.key = APPNAME"_stv_bios";
+  if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+  {
+    if(strcmp(var.value, "default") != 0) /* do nothing if set to default */
+    {
+      if(!string_is_empty(options.bios)) /* there is something other than default in both BIOS core options. not good! */
+      {
+        log_cb(RETRO_LOG_ERROR, LOGPRE "Conflicting BIOS options have been set!\n");
+      }
+      options.bios = strdup(var.value);
+    }
   }
 
   var.value = NULL;
@@ -841,6 +857,7 @@ void retro_unload_game(void)
     mame_done();
     
     free(options.romset_filename_noext);
+    free(options.bios);
     
     /*free(fallbackDir);
     systemDir = 0;*/


### PR DESCRIPTION
## Summary

With this PR the mame2003-plus `neogeo` BIOS set is 100% compatible with the current MAME 0.197 `neogeo` BIOS set. The current MAME set has more BIOS ROMs than ours but

1. Every Neo Geo BIOS ROM CRC in our `neogeo.c` driver is also in MAME 0.197
2. Every Neo Geo BIOS ROM file in our `neogeo.c` is named the same as in MAME 0.197

This is accomplished in a way that keeps the original mame2003 Neo Geo BIOS in place with the same filename and CRC so as to preserve backwards compatibility in that regard.

### Previous Discussion

Ihere has been a fair amount of discussion on Neo Geo BIOSes to date. I want to recognize the importance of that discussion. Over the last day or two I have looked again at the FBA BIOS CRCs and spent some time in the MAME 0.197 code. This code change and writeup is my response to the discussion so as to build on it and move forward.

I would like to ask that folks trust that this change is being made in good faith after as thorough a process as I know how to do. Grant and I agreed that it would be best for me to try to make additional changes to this code (since Grant been working with the code up till now). If there are regressions or apparent regressions, I am generally available for the next few days so I can implement fixes.

In terms of the code, this is a relatively simple set of changes so I don't think we are risking much to put them in place.

## Baseline in mame2003

mame2003 can only use the default Neo Geo BIOS from MAME 0.78, described as `Europe MVS (Ver. 2)` with a CRC of `e09e253c`. This file can be named anything the user wants as long as it is present with the correct CRC in either the game romset zip or in a BIOS set named `neogeo.zip`.

**In other words, the Neo Geo BIOS ROMs other than `Europe MVS (Ver. 2)` with `e09e253c` have always been effectively useless in mame2003.** I believe it's important to keep this in mind.

## Baseline in mame2003-plus

When SapphireTactician reported a Neo Geo game that defaults to the Spanish language with the default of `Europe MVS (Ver. 2)`, Grant and I had already been looking at the BIOS loading core regarding Die Hard: Arcade. At that point I added a new core option for selectable BIOS. One misjudgement on my part at that time was to unify the ST-V BIOS and Neo Geo BIOS selection in one option.

As part of this change are now two different options for BIOS selection on the two different systems -- one day if someone refactors the core option code sufficiently we could set things to only display the BIOS selection option for games that support it. FBA does this I believe.

## Functional and UX Priorities for Neo Geo BIOS

**Loosely ordered from highest priority to lowest, from my perspective.**

1. Users should be able to select their Neo Geo BIOS on a game-by-game basis
2. There should be as broad a range of Neo Geo BIOSes available as can function in mame2003-plus, and those BIOSes should be drawn from commonly available romsets
3. `neogeo` BIOS sets from MAME 0.78 should still work -- in other words `Europe MVS (Ver. 2)` / `e09e253c` should always be available
4. The files in the mame2003-plus `neogeo` BIOS set should be intercompatible with the FBA `neogeo` set, which follows current MAME

# Implementation

As far as I can tell, current MAME incorporates all of the current mame2003-plus Neo Geo BIOS ROMs including the MAME 0.78 default of `Europe MVS (Ver. 2)` / `e09e253c`. The first and most important part of this change is to rename the ROMs in our BIOS romset that conflict with current MAME filenames and to split the Neo Geo + STV BIOS selection core option into one option for each system.

### Possible Phase 2 

Maybe there is a phase two where we try to add new BIOS ROMs from current MAME, if anyone feels like trying that.

I wonder if there is value in trying to add more current Unibioses, for example.