### PR TITLE
add support for unibios 3.3

### DIFF
--- a/src/drivers/neogeo.c
+++ b/src/drivers/neogeo.c
@@ -1460,12 +1460,13 @@ SYSTEM_BIOS_START( neogeo )
 	SYSTEM_BIOS_ADD( 4, "asia",       "Asia MVS (Ver. 3)" )
 	SYSTEM_BIOS_ADD( 5, "japan",      "Japan MVS (Ver. 3)" )
 	SYSTEM_BIOS_ADD( 6, "japan-s2",   "Japan MVS (Ver. 2)" )
-	SYSTEM_BIOS_ADD( 7, "unibios20",  "Unibios MVS (Hack, Ver. 2.0)" )
-	SYSTEM_BIOS_ADD( 8, "unibios13",  "Unibios MVS (Hack, Ver. 1.3)" )  
-	SYSTEM_BIOS_ADD( 9, "unibios11",  "Unibios MVS (Hack, Ver. 1.1)" )  
-	SYSTEM_BIOS_ADD(10, "unibios10",  "Unibios MVS (Hack, Ver. 1.0)" )
-	SYSTEM_BIOS_ADD(10, "debug",      "Debug MVS (Hack?)" )
-	SYSTEM_BIOS_ADD(11, "asia-aes",   "Asia AES" )
+	SYSTEM_BIOS_ADD( 7, "unibios33",  "Universe Bios (Hack, Ver. 3.3)" )
+	SYSTEM_BIOS_ADD( 8, "unibios20",  "Unibios MVS (Hack, Ver. 2.0)" )
+	SYSTEM_BIOS_ADD( 9, "unibios13",  "Unibios MVS (Hack, Ver. 1.3)" )  
+	SYSTEM_BIOS_ADD(10, "unibios11",  "Unibios MVS (Hack, Ver. 1.1)" )  
+	SYSTEM_BIOS_ADD(11, "unibios10",  "Unibios MVS (Hack, Ver. 1.0)" )
+	SYSTEM_BIOS_ADD(12, "debug",      "Debug MVS (Hack?)" )
+	SYSTEM_BIOS_ADD(13, "asia-aes",   "Asia AES" )
 SYSTEM_BIOS_END
 
 
@@ -1480,12 +1481,13 @@ SYSTEM_BIOS_END
 	ROM_LOAD16_WORD_SWAP_BIOS( 4, "asia-s3.rom",  0x00000, 0x020000, CRC(91b64be3) SHA1(720a3e20d26818632aedf2c2fd16c54f213543e1) ) /* Asia */ \
 	ROM_LOAD16_WORD_SWAP_BIOS( 5, "vs-bios.rom",  0x00000, 0x020000, CRC(f0e8f27d) SHA1(ecf01eda815909f1facec62abf3594eaa8d11075) ) /* Japan, Ver 6 VS Bios */ \
 	ROM_LOAD16_WORD_SWAP_BIOS( 6, "sp-j2.sp1",    0x00000, 0x020000, CRC(acede59c) SHA1(b6f97acd282fd7e94d9426078a90f059b5e9dd91) ) /* Japan, Older */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 7, "uni-bios_2_0.rom",  0x00000, 0x020000, CRC(0c12c2ad) ) /* Universe Bios v2.0 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 8, "uni-bios_1_3.rom",  0x00000, 0x020000, CRC(b24b44a0) ) /* Universe Bios v1.3 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS( 9, "uni-bios_1_1.rom",  0x00000, 0x020000, CRC(5dda0d84) SHA1(4153d533c02926a2577e49c32657214781ff29b7) ) /* Universe Bios v1.1 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS(10, "uni-bios_1_0.rom",  0x00000, 0x020000, CRC(0ce453a0) SHA1(3b4c0cd26c176fc6b26c3a2f95143dd478f6abf9) ) /* Universe Bios v1.0 (hack) */ \
-	ROM_LOAD16_WORD_SWAP_BIOS(11, "neodebug.rom", 0x00000, 0x020000, CRC(698ebb7d) SHA1(081c49aa8cc7dad5939833dc1b18338321ea0a07) ) /* Debug (Development) Bios */ \
-	ROM_LOAD16_WORD_SWAP_BIOS(12, "neo-epo.bin", 0x00000, 0x020000, CRC(d27a71f1) SHA1(1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07) ) /* AES Console (Asia?) Bios */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 7, "uni-bios_3_3.rom",  0x00000, 0x020000, CRC(24858466) SHA1(0ad92efb0c2338426635e0159d1f60b4473d0785) ) /* Japan, Older */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 8, "uni-bios_2_0.rom",  0x00000, 0x020000, CRC(0c12c2ad) ) /* Universe Bios v2.0 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS( 9, "uni-bios_1_3.rom",  0x00000, 0x020000, CRC(b24b44a0) ) /* Universe Bios v1.3 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(10, "uni-bios_1_1.rom",  0x00000, 0x020000, CRC(5dda0d84) SHA1(4153d533c02926a2577e49c32657214781ff29b7) ) /* Universe Bios v1.1 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(11, "uni-bios_1_0.rom",  0x00000, 0x020000, CRC(0ce453a0) SHA1(3b4c0cd26c176fc6b26c3a2f95143dd478f6abf9) ) /* Universe Bios v1.0 (hack) */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(12, "neodebug.rom", 0x00000, 0x020000, CRC(698ebb7d) SHA1(081c49aa8cc7dad5939833dc1b18338321ea0a07) ) /* Debug (Development) Bios */ \
+	ROM_LOAD16_WORD_SWAP_BIOS(13, "neo-epo.bin", 0x00000, 0x020000, CRC(d27a71f1) SHA1(1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07) ) /* AES Console (Asia?) Bios */ \
 
 /* note you'll have to modify the last for lines of each block to use the extra bios roms,
    they're hacks / homebrew / console bios roms so Mame doesn't list them by default */

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -108,7 +108,7 @@ void retro_set_environment(retro_environment_t cb)
     { APPNAME"_brightness", "Brightness; 1.0|0.2|0.3|0.4|0.5|0.6|0.7|0.8|0.9|1.1|1.2|1.3|1.4|1.5|1.6|1.7|1.8|1.9|2.0" },
     { APPNAME"_gamma", "Gamma correction; 1.2|0.5|0.6|0.7|0.8|0.9|1.1|1.2|1.3|1.4|1.5|1.6|1.7|1.8|1.9|2.0" },
     { APPNAME"_enable_backdrop", "EXPERIMENTAL: Use Backdrop artwork (Restart); disabled|enabled" },
-    { APPNAME"_neogeo_bios", "Specify Neo Geo BIOS (Restart); default|euro|euro-s1|us|us-e|asia|japan|japan-s2|unibios20|unibios13|unibios11|unibios10|debug|asia-aes" },
+    { APPNAME"_neogeo_bios", "Specify Neo Geo BIOS (Restart); default|euro|euro-s1|us|us-e|asia|japan|japan-s2|unibios33|unibios20|unibios13|unibios11|unibios10|debug|asia-aes" },
     { APPNAME"_stv_bios", "Specify Sega ST-V BIOS (Restart); default|japan|japana|us|japan_b|taiwan|europe" },    
     { APPNAME"_dialsharexy", "Share 2 player dial controls across one X/Y device; disabled|enabled" },
     { APPNAME"_dual_joysticks", "Dual Joystick Mode (Players 1 & 2); disabled|enabled" },
@@ -301,7 +301,7 @@ static void update_variables(bool first_time)
     {
       if(!string_is_empty(options.bios)) /* there is something other than default in both BIOS core options. not good! */
       {
-        log_cb(RETRO_LOG_ERROR, LOGPRE "Conflicting BIOS options have been set!\n");
+        log_cb(RETRO_LOG_ERROR, LOGPRE "Conflicting BIOS options have been set - using default BIOS instead! Please check your core options.\n");
       }
       options.bios = strdup(var.value);
     }


### PR DESCRIPTION
After the previous work, adding this BIOS was a snap.

I have only booted into the Neo Bomberman attract mode so far but at first glance Unibios 3.3 is working as expected.

@Wilstorm if we are experimenting with Unibios, I figure we might as well have this latest version supported by MAME.