### PR TITLE
[no functional change] demonstrate game-specific input labels

### DIFF
--- a/src/mame.h
+++ b/src/mame.h
@@ -160,9 +160,6 @@ struct RunningMachine
 #define ARTWORK_USE_BACKDROPS	0x01
 #define ARTWORK_USE_OVERLAYS	0x02
 #define ARTWORK_USE_BEZELS		0x04
-#define RETROPAD_MAME			0
-#define RETROPAD_MODERN			1
-#define RETROPAD_SNES			2
 
 /* The host platform should fill these fields with the preferences specified in the GUI */
 /* or on the commandline. */

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -584,6 +584,19 @@ void retro_get_system_info(struct retro_system_info *info)
   info->block_extract = true;
 }
 
+#define BTN1 "BTN1: "
+#define BTN2 "BTN2: "
+#define BTN3 "BTN3: "
+#define BTN4 "BTN4: "
+#define BTN5 "BTN5: "
+#define BTN6 "BTN6: "
+#define BTN7 "BTN7: "
+#define BTN8 "BTN8: "
+
+static const char* control_labels[RETRO_DEVICE_ID_JOYPAD_R3 + 1]; /* RETRO_DEVICE_ID_JOYPAD_R3 is the retropad input with the highest index # */
+static const char* sf2_button_labels[6];
+static const char* neogeo_button_labels[4];
+
 void retro_describe_buttons(void)
 {
   /* Assuming the standard RetroPad layout:
@@ -657,23 +670,133 @@ void retro_describe_buttons(void)
    *     [v]                               [1/LP]      |
    *                                                   |
    */
+
+  sf2_button_labels[COUNT_BUTTON1] = BTN1 "Weak Kick";
+  sf2_button_labels[COUNT_BUTTON2] = BTN2 "Medium Kick";
+  sf2_button_labels[COUNT_BUTTON3] = BTN3 "Strong Punch";
+  sf2_button_labels[COUNT_BUTTON4] = BTN4 "Weak Punch";
+  sf2_button_labels[COUNT_BUTTON5] = BTN5 "Medium Punch";
+  sf2_button_labels[COUNT_BUTTON6] = BTN6 "Strong Kick";
+  
+  neogeo_button_labels[COUNT_BUTTON1] = BTN1 "Neo Geo A";
+  neogeo_button_labels[COUNT_BUTTON2] = BTN2 "Neo Geo B";
+  neogeo_button_labels[COUNT_BUTTON3] = BTN3 "Neo Geo C";
+  neogeo_button_labels[COUNT_BUTTON4] = BTN4 "Neo Geo D";
+
+  /************  BASELINE "CLASSIC" MAPPING  ************/   
+  control_labels[RETRO_DEVICE_ID_JOYPAD_LEFT]    =  "Joystick Left";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_RIGHT]   =  "Joystick Right";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_UP]      =  "Joystick Up";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_DOWN]    =  "Joystick Down";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_B]       =  "Button 1";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_Y]       =  "Button 3";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_X]       =  "Button 4";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_A]       =  "Button 2";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_L]       =  "Button 5";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_R]       =  "Button 6";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_L2]      =  "Button 7";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_R2]      =  "Button 8";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_L3]      =  "Button 9";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_R3]      =  "Button 10";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_SELECT]  =  "Insert Coin";
+  control_labels[RETRO_DEVICE_ID_JOYPAD_START]   =  "Start";
+  
+  /************  CONTENT-SPECIFIC OVERLAYS FOR CLASSIC ************/ 
+  if(options.retropad_layout == RETROPAD_MAME)
+  {
+    if(is_sf2_layout)  /* overlay sf2-specific names */
+    {
+      control_labels[RETRO_DEVICE_ID_JOYPAD_B]     =  sf2_button_labels[COUNT_BUTTON1];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]     =  sf2_button_labels[COUNT_BUTTON3];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_X]     =  sf2_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_A]     =  sf2_button_labels[COUNT_BUTTON2];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_L]     =  sf2_button_labels[COUNT_BUTTON5];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_R]     =  sf2_button_labels[COUNT_BUTTON6];
+    }
+    else if(is_neogeo)
+    {
+      control_labels[RETRO_DEVICE_ID_JOYPAD_B]     =  neogeo_button_labels[COUNT_BUTTON1];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]     =  neogeo_button_labels[COUNT_BUTTON3];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_X]     =  neogeo_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_A]     =  neogeo_button_labels[COUNT_BUTTON2];
+    }
+  }
+
+  /************  "MODERN" MAPPING OVERLAY  ************/ 
+  if(options.retropad_layout == RETROPAD_MODERN)
+  {
+    control_labels[RETRO_DEVICE_ID_JOYPAD_B]     = "Button 4";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_Y]     = "Button 1";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_X]     = "Button 2";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_A]     = "Button 5";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_L]     = "Button 7";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_R]     = "Button 3";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_L2]    = "Button 8";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_R2]    = "Button 6";
+    
+    if(is_sf2_layout) /* overlay sf2-specific names */
+    {
+      control_labels[RETRO_DEVICE_ID_JOYPAD_B]   = sf2_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]   = sf2_button_labels[COUNT_BUTTON1];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_X]   = sf2_button_labels[COUNT_BUTTON2];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_A]   = sf2_button_labels[COUNT_BUTTON5];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_L]   = sf2_button_labels[COUNT_BUTTON6];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_R]   = sf2_button_labels[COUNT_BUTTON3];
+    }
+    else if(is_neogeo)
+    {
+      control_labels[RETRO_DEVICE_ID_JOYPAD_B]   = neogeo_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]   = neogeo_button_labels[COUNT_BUTTON1];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_X]   = neogeo_button_labels[COUNT_BUTTON2];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_R]   = neogeo_button_labels[COUNT_BUTTON3];
+    }
+  }
+  
+  /************  "MODERN" MAPPING OVERLAY  ************/
+  if(options.retropad_layout == RETROPAD_SNES)
+  {
+    control_labels[RETRO_DEVICE_ID_JOYPAD_B]    = "Button 4";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_Y]    = "Button 1";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_X]    = "Button 2";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_A]    = "Button 5";
+    control_labels[RETRO_DEVICE_ID_JOYPAD_L]    = "Button 3";
+
+    if(is_sf2_layout) /* overlay sf2-specific names */
+    {
+      control_labels[RETRO_DEVICE_ID_JOYPAD_B]  = sf2_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]  = sf2_button_labels[COUNT_BUTTON1];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_X]  = sf2_button_labels[COUNT_BUTTON2];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_A]  = sf2_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_L]  = sf2_button_labels[COUNT_BUTTON3];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_R]  = sf2_button_labels[COUNT_BUTTON6];
+    }
+    else if(is_neogeo)
+    {
+      control_labels[RETRO_DEVICE_ID_JOYPAD_B]  = neogeo_button_labels[COUNT_BUTTON4];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]  = neogeo_button_labels[COUNT_BUTTON1];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_X]  = neogeo_button_labels[COUNT_BUTTON2];
+      control_labels[RETRO_DEVICE_ID_JOYPAD_L]  = neogeo_button_labels[COUNT_BUTTON3];
+    }
+  }
+  
+
 #define describe_buttons(INDEX) \
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "Joystick Left" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "Joystick Right" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "Joystick Up" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "Joystick Down" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      (options.retropad_layout == RETROPAD_MAME ? "Button 1" : "Button 4") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      (options.retropad_layout == RETROPAD_MAME ? "Button 3" : "Button 1") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      (options.retropad_layout == RETROPAD_MAME ? "Button 4" : "Button 2") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      (options.retropad_layout == RETROPAD_MAME ? "Button 2" : "Button 5") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      (options.retropad_layout == RETROPAD_MAME ? "Button 5" : (options.retropad_layout == RETROPAD_MODERN ? "Button 7" : "Button 3")) },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      (options.retropad_layout == RETROPAD_MODERN ? "Button 3" : "Button 6") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     (options.retropad_layout == RETROPAD_MODERN ? "Button 8" : "Button 7") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     (options.retropad_layout == RETROPAD_MODERN ? "Button 6" : "Button 8") },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,     "Button 9" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     "Button 10" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Insert Coin" },\
-{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" },
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   control_labels[RETRO_DEVICE_ID_JOYPAD_LEFT]   },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  control_labels[RETRO_DEVICE_ID_JOYPAD_RIGHT]  },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     control_labels[RETRO_DEVICE_ID_JOYPAD_UP]     },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   control_labels[RETRO_DEVICE_ID_JOYPAD_DOWN]   },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      control_labels[RETRO_DEVICE_ID_JOYPAD_B]      },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      control_labels[RETRO_DEVICE_ID_JOYPAD_Y]      },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      control_labels[RETRO_DEVICE_ID_JOYPAD_X]      },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      control_labels[RETRO_DEVICE_ID_JOYPAD_A]      },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      control_labels[RETRO_DEVICE_ID_JOYPAD_L]      },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      control_labels[RETRO_DEVICE_ID_JOYPAD_R]      },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     control_labels[RETRO_DEVICE_ID_JOYPAD_L2]     },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     control_labels[RETRO_DEVICE_ID_JOYPAD_R2]     },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,     control_labels[RETRO_DEVICE_ID_JOYPAD_L3]     },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     control_labels[RETRO_DEVICE_ID_JOYPAD_R3]     },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, control_labels[RETRO_DEVICE_ID_JOYPAD_SELECT] },\
+{ INDEX, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  control_labels[RETRO_DEVICE_ID_JOYPAD_START]  },
   
   struct retro_input_descriptor desc[] = {
     describe_buttons(0)
@@ -685,6 +808,7 @@ void retro_describe_buttons(void)
   
   environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 }
+
 
 bool retro_load_game(const struct retro_game_info *game)
 {

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -81,6 +81,28 @@ enum
   OPT_end /* dummy last entry */
 };
 
+enum
+{
+  RETROPAD_MAME = 0,
+  RETROPAD_MODERN,
+  RETROPAD_SNES,
+  RETROPAD_end
+};
+
+enum
+{
+  COUNT_BUTTON1 = 0,
+  COUNT_BUTTON2,
+  COUNT_BUTTON3,
+  COUNT_BUTTON4,
+  COUNT_BUTTON5,
+  COUNT_BUTTON6,
+  COUNT_BUTTON7,
+  COUNT_BUTTON8,
+  COUNT_BUTTON_end
+};
+  
+
 /******************************************************************************
 
 	Display


### PR DESCRIPTION
I am trying to get to where I am ready to test use the code that @fr500 provided for joypad device subtypes. That's not what you're looking at here though.

Along the way it has now become much more straightforward to add game-specific input labels, starting with the Street Fighter 2 labels that fr500 incorporated into the diff patch.

**With this PR, Neo Geo games and SF2 clones will display game-apporpriate names along with the MAME button numbers. Instead of just `Button 1` in a Neo Geo game, you will see `BTN1: Neo Geo A`. For Street Fighter 2, you will see the button number and then things like `Weak Kick`, `Strong Punch`, etc.**

## This is not meant to make any functional change to way inputs work now

I've taken care to only refactor and enhance the labels. I am submitting this is as a PR because the input system is important, and even though I have been careful I wouldn't mind another pair of eyes (@dankcushions ?)

Once this piece is finalized it does also serve as a building block towards the input subtypes!