### PR TITLE
Correct stonebal button numbering

### DIFF
--- a/src/controls.c
+++ b/src/controls.c
@@ -23548,9 +23548,9 @@ const char *stonebal_get_ctrl_name(int type)
 {
   switch(type)
   {
-    case IPT_BUTTON1: return "Shoot/Fight";
-    case IPT_BUTTON2: return "Pass/Tackle";
-    case IPT_BUTTON3: return "Push";
+    case IPT_BUTTON1: return BTN1 "Shoot/Fight";
+    case IPT_BUTTON2: return BTN2 "Pass/Tackle";
+    case IPT_BUTTON3: return BTN3 "Push";
   } /* end of switch */
 
   return generic_ctrl_label(type);

--- a/src/controls.c
+++ b/src/controls.c
@@ -23549,8 +23549,8 @@ const char *stonebal_get_ctrl_name(int type)
   switch(type)
   {
     case IPT_BUTTON1: return "Shoot/Fight";
-    case IPT_BUTTON2: return "Push";
-    case IPT_BUTTON3: return "Pass/Tackle";
+    case IPT_BUTTON2: return "Pass/Tackle";
+    case IPT_BUTTON3: return "Push";
   } /* end of switch */
 
   return generic_ctrl_label(type);


### PR DESCRIPTION
strangely the stonebal ingame help menu displays buttons 1-2-3 but they are represented in a different order as core buttons 1-3-2. Therefore i interchanged button labels 2 and 3.

![1-3-2](https://user-images.githubusercontent.com/36081149/40690217-47a2af04-63a6-11e8-8618-afe5d60ac57e.jpg)


Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
