### PR TITLE
WIP: add core option to toggle use of mame remapper

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -216,20 +216,6 @@ static config_file *config_init(const char *name, int save)
 	{
 		/* mame 0.74 with 8 coin counters */
 		{ "MAMECFG\x9",	"MAMEDEF\x7",	input_port_read_ver_8, seq_read_ver_8, 8 },
-
-#ifndef NOLEGACY
-		/* mame 0.36b16 with key/joy merge */
-		{ "MAMECFG\x8",	"MAMEDEF\x7",	input_port_read_ver_8, seq_read_ver_8, 4 },
-
-		/* mame 0.36b13 with and/or/not combination */
-		{ "MAMECFG\x7",	"MAMEDEF\x6",	input_port_read_ver_7, seq_read_ver_7, 4 },
-
-		/* mame 0.36b12 with multi key/joy extension */
-		{ "MAMECFG\x6",	"MAMEDEF\x5",	input_port_read_ver_6, seq_read_ver_6, 4 },
-
-		/* mame 0.36b11 */
-		{ "MAMECFG\x5",	"MAMEDEF\x4",	input_port_read_ver_5, seq_read_ver_5, 4 }
-#endif
 	};
 
 	config_file *cfg;
@@ -312,7 +298,10 @@ static unsigned int count_input_ports(const struct InputPort *in)
 
 config_file *config_open(const char *name)
 {
-	return config_init(name, 0);
+	if(options.mame_remapper)
+    return config_init(name, 0);
+
+  return NULL;
 }
 
 
@@ -323,7 +312,10 @@ config_file *config_open(const char *name)
 
 config_file *config_create(const char *name)
 {
-	return config_init(name, 1);
+	if(options.mame_remapper)
+    return config_init(name, 1);
+
+  return NULL;
 }
 
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -94,19 +94,19 @@
 
 
 /* start/end tags for the machine driver */
-#define MACHINE_DRIVER_START(game)                                \
-  void construct_##game(struct InternalMachineDriver *machine)    \
-  {                                                               \
-   struct MachineCPU *cpu = NULL;									                \
-   (void)cpu;														                          \
+#define MACHINE_DRIVER_START(game) 										\
+	void construct_##game(struct InternalMachineDriver *machine)		\
+	{																	\
+		struct MachineCPU *cpu = NULL;									\
+		(void)cpu;														\
 
-#define MACHINE_DRIVER_END \
-  }                        \
+#define MACHINE_DRIVER_END 												\
+	}																	\
 
 
 /* importing data from other machine drivers */
-#define MDRV_IMPORT_FROM(game) \
-	construct_##game(machine);   \
+#define MDRV_IMPORT_FROM(game) 											\
+	construct_##game(machine); 											\
 
 
 /* add/modify/remove/replace CPUs */
@@ -287,7 +287,6 @@ void machine_remove_sound(struct InternalMachineDriver *machine, const char *tag
 
 struct InternalMachineDriver
 {
-  const char *name;
 	struct MachineCPU cpu[MAX_CPU];
 	float frames_per_second;
 	int vblank_duration;

--- a/src/driver.h
+++ b/src/driver.h
@@ -94,19 +94,19 @@
 
 
 /* start/end tags for the machine driver */
-#define MACHINE_DRIVER_START(game) 										\
-	void construct_##game(struct InternalMachineDriver *machine)		\
-	{																	\
-		struct MachineCPU *cpu = NULL;									\
-		(void)cpu;														\
+#define MACHINE_DRIVER_START(game)                                \
+  void construct_##game(struct InternalMachineDriver *machine)    \
+  {                                                               \
+   struct MachineCPU *cpu = NULL;									                \
+   (void)cpu;														                          \
 
-#define MACHINE_DRIVER_END 												\
-	}																	\
+#define MACHINE_DRIVER_END \
+  }                        \
 
 
 /* importing data from other machine drivers */
-#define MDRV_IMPORT_FROM(game) 											\
-	construct_##game(machine); 											\
+#define MDRV_IMPORT_FROM(game) \
+	construct_##game(machine);   \
 
 
 /* add/modify/remove/replace CPUs */
@@ -287,6 +287,7 @@ void machine_remove_sound(struct InternalMachineDriver *machine, const char *tag
 
 struct InternalMachineDriver
 {
+  const char *name;
 	struct MachineCPU cpu[MAX_CPU];
 	float frames_per_second;
 	int vblank_duration;

--- a/src/mame.h
+++ b/src/mame.h
@@ -165,6 +165,7 @@ enum /* used to index content-specific flags */
 {
   CONTENT_NEOGEO = 0,
   CONTENT_STV,
+  CONTENT_ALTERNATE_SOUND,
   CONTENT_end,
 };
 
@@ -228,6 +229,7 @@ struct GameOptions
   char	   savegame;		         /* character representing a savegame to load */
   int      crc_only;             /* specify if only CRC should be used as checksum */
   bool     nvram_bootstrap;
+  bool     mame_remapper;
   
   const char *bios;			         /* specify system bios (if used), 0 is default */
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -142,7 +142,8 @@ static void init_core_options(void)
   init_default(&default_options[OPT_NVRAM_BOOTSTRAP],     APPNAME"_nvram_bootstraps",    "NVRAM Bootstraps; enabled|disabled");
   init_default(&default_options[OPT_SAMPLE_RATE],         APPNAME"_sample_rate",         "Sample Rate (KHz); 48000|8000|11025|22050|44100");
   init_default(&default_options[OPT_DCS_SPEEDHACK],       APPNAME"_dcs_speedhack",       "DCS Speedhack; enabled|disabled");
-  
+  init_default(&default_options[OPT_MAME_REMAPPING],      APPNAME"_mame_remapping",      "Activate MAME Remapping (!NETPLAY); disabled|enabled");
+ 
   init_default(&default_options[OPT_end], NULL, NULL);
   set_variables(true);
 }
@@ -438,6 +439,13 @@ static void update_variables(bool first_time)
           else
             options.activate_dcs_speedhack = 0;
           break;
+
+        case OPT_MAME_REMAPPING:
+          if(strcmp(var.value, "enabled") == 0)
+            options.mame_remapping = true;
+          else
+            options.mame_remapping = false;
+          break;           
       }
     }
   }

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -79,6 +79,7 @@ enum
   OPT_NVRAM_BOOTSTRAP,
   OPT_SAMPLE_RATE,
   OPT_DCS_SPEEDHACK,
+  OPT_MAME_REMAPPING,
   OPT_end /* dummy last entry */
 };
 

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -73,7 +73,7 @@ int uirotcharwidth, uirotcharheight;
 
 static int setup_selected;
 static int setup_via_menu = 0;
-static int retropad_menu_flag = 0;
+static int mame_remap_flag = false;
 
 UINT8 ui_dirty;
 
@@ -2889,12 +2889,6 @@ static void setup_menu_init(void)
 {
 	menu_total = 0;
 
-  if(1/*options.input_interface == RETRO_DEVICE_KEYBOARD*/)
-  {
-	  menu_item[menu_total] = ui_getstring (UI_inputgeneral); menu_action[menu_total++] = UI_DEFCODE;
-    menu_item[menu_total] = ui_getstring (UI_inputspecific); menu_action[menu_total++] = UI_CODE;
-  }
-
 	/* Determine if there are any dip switches */
 	{
 		struct InputPort *in;
@@ -2917,6 +2911,12 @@ static void setup_menu_init(void)
 		}
 	}
 
+  if(options.mame_remapper)
+  {
+	  menu_item[menu_total] = ui_getstring (UI_inputgeneral); menu_action[menu_total++] = UI_DEFCODE;
+    menu_item[menu_total] = ui_getstring (UI_inputspecific); menu_action[menu_total++] = UI_CODE;
+  }
+  
 	/* Determine if there are any analog controls */
 	{
 		struct InputPort *in;
@@ -2933,7 +2933,7 @@ static void setup_menu_init(void)
 			in++;
 		}
 
-		if (num != 0)
+		if (num != 0 && options.mame_remapper)
 		{
 			menu_item[menu_total] = ui_getstring (UI_analogcontrols); menu_action[menu_total++] = UI_ANALOG;
 		}
@@ -3168,15 +3168,17 @@ int handle_user_interface(struct mame_bitmap *bitmap)
   }   
   else if(setup_selected)
   {  
-    if (retropad_menu_flag == 0 && options.input_interface == RETRO_DEVICE_JOYPAD)
+    if (!mame_remap_flag && options.mame_remapper)
     {
-        /*retropad_menu_flag = 1;*/
-        /*setup_menu_init();*/
+      mame_remap_flag = true;
+      setup_menu_init();
+      schedule_full_refresh();
     }
-    else if (retropad_menu_flag == 1 && options.input_interface != RETRO_DEVICE_JOYPAD)
+    else if (mame_remap_flag && !options.mame_remapper)
     {
-      /*retropad_menu_flag = 0;*/
-      /*setup_menu_init();*/
+      mame_remap_flag = false;
+      setup_menu_init();
+      schedule_full_refresh();
     }
     setup_selected = setup_menu(bitmap, setup_selected);
   }


### PR DESCRIPTION
This for some reason isn't working yet but I wanted to put up a PR in case someone else is also working to make a core option to to toggle the availability of the MAME remapper. The default would be to have the MAME remapper disabled.

The thing I'm most interested in is using this core option to not only show or hide the remapper in the MAME menu but also to toggle the loading and saving of .cfg files.

This allows the user to keep some cfg files in place / not delete them but still avoid having them applied by MAME. That seemed like a good way to approach things.

I'll fix this soon...