### PR TITLE
only stop samples for ost

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -238,8 +238,9 @@ struct GameSamples *readsamples(const char **samplenames,const char *basename)
 	int i;
 	struct GameSamples *samples;
 	int skipfirst = 0;
-  
-  if(!options.use_samples || samplenames == 0 || samplenames[0] == 0)
+   if( (!options.use_samples)  &&  (options.content_flags[CONTENT_ALT_SOUND]) ) return 0;
+
+  if( samplenames == 0 || samplenames[0] == 0)
     return 0;
 
 	if (samplenames[0][0] == '*')


### PR DESCRIPTION
this only stops samples if these two conditions are met makes more sens and less can go wrong. 

mame2003-plus_use_alt_sound = "enabled"

will only save to the core config if  a ost game is selected now. 

Too many things can go wrong on a setting thats only saved sometimes just use the flags you have set as a conditions this takes care of not setting the uknown the sample disable is only for ost anyway