### PR TITLE
flag Dual Joystick content to selectively apply core option

### DIFF
--- a/src/controls.c
+++ b/src/controls.c
@@ -25,7 +25,7 @@ const struct ControlInfo generic_ctrl =
   false, /* dual joystick controls */
   &generic_ctrl_label /* button labeler function */ 
 };
- 
+
 const struct ControlInfo a88games_ctrl =
 {
   2, /* num_players */
@@ -20673,7 +20673,6 @@ const char *robocop2_get_ctrl_name(int type)
 {
   switch(type)
   {
-/* P1NumButtons=3 */
     case (IPT_OSD_DESCRIPTION | IPF_PLAYER1): return "8-way Joystick+joy8way";
     case IPT_BUTTON1: return "Shoot Left";
     case IPT_BUTTON2: return "Shoot Right";
@@ -20689,14 +20688,14 @@ const char *robocop2_get_ctrl_name(int type)
 
 const struct ControlInfo robotron_ctrl =
 {
-  2, /* num_players */
-  true, /* alternating_controls */
-  true, /* mirrored_controls */
-  true, /* has_tilt */
+  2,     /* num_players */
+  true,  /* alternating_controls */
+  true,  /* mirrored_controls */
+  true,  /* has_tilt */
   false, /* has_cocktail_dipswitch */
   false, /* uses_service */
   "The drivers in mame don't have a cocktail mode, but klov shows a cocktail cab, and the robotron drawing set shows two (cocktail) sets of dual joysticks.", /* control__details */
-  false, /* dual joystick controls */
+  true,  /* dual joystick controls */
   &robotron_get_ctrl_name
 };
 
@@ -20706,13 +20705,13 @@ const char *robotron_get_ctrl_name(int type)
   {
 /* P1NumButtons=0 */
     case (IPT_OSD_DESCRIPTION | IPF_PLAYER1): return "Dual 8-way Joysticks+doublejoy8way";
-    case IPT_JOYSTICKLEFT_UP: return "Move Up";
-    case IPT_JOYSTICKLEFT_DOWN: return "Move Down";
-    case IPT_JOYSTICKLEFT_LEFT: return "Move Left";
-    case IPT_JOYSTICKLEFT_RIGHT: return "Move Right";
-    case IPT_JOYSTICKRIGHT_UP: return "Fire Up";
-    case IPT_JOYSTICKRIGHT_DOWN: return "Fire Down";
-    case IPT_JOYSTICKRIGHT_LEFT: return "Fire Left";
+    case IPT_JOYSTICKLEFT_UP:     return "Move Up";
+    case IPT_JOYSTICKLEFT_DOWN:   return "Move Down";
+    case IPT_JOYSTICKLEFT_LEFT:   return "Move Left";
+    case IPT_JOYSTICKLEFT_RIGHT:  return "Move Right";
+    case IPT_JOYSTICKRIGHT_UP:    return "Fire Up";
+    case IPT_JOYSTICKRIGHT_DOWN:  return "Fire Down";
+    case IPT_JOYSTICKRIGHT_LEFT:  return "Fire Left";
     case IPT_JOYSTICKRIGHT_RIGHT: return "Fire Right";
   } /* end of switch */
 

--- a/src/drivers/williams.c
+++ b/src/drivers/williams.c
@@ -2532,8 +2532,8 @@ GAME( 1981, colony7a, colony7,  defender, colony7,  colony7,  ROT270, "Taito", "
 
 GAME( 1981, stargate, 0,        williams, stargate, stargate, ROT0,   "Williams", "Stargate" )
 
-GAME( 1982, robotron, 0,        williams, robotron, robotron, ROT0,   "Williams", "Robotron (Solid Blue label)" )
-GAME( 1982, robotryo, robotron, williams, robotron, robotron, ROT0,   "Williams", "Robotron (Yellow-Orange label)" )
+GAMEC( 1982, robotron, 0,        williams, robotron, robotron, ROT0,   "Williams", "Robotron (Solid Blue label)",    &robotron_ctrl, NULL )
+GAMEC( 1982, robotryo, robotron, williams, robotron, robotron, ROT0,   "Williams", "Robotron (Yellow-Orange label)", &robotron_ctrl, NULL )
 
 GAME( 1982, joust,    0,        williams, joust,    joust,    ROT0,   "Williams", "Joust (White-Green label)" )
 GAME( 1982, joustr,   joust,    williams, joust,    joust,    ROT0,   "Williams", "Joust (Solid Red label)" )
@@ -2545,9 +2545,9 @@ GAME( 1982, bubblesp, bubbles,  williams, bubbles,  bubbles,  ROT0,   "Williams"
 
 GAME( 1982, splat,    0,        williams, splat,    splat,    ROT0,   "Williams", "Splat!" )
 
-GAMEC( 1982, sinistar, 0,        sinistar, sinistar, sinistar, ROT270, "Williams", "Sinistar (revision 3)", &generic_ctrl, &sinistar_bootstrap)
-GAMEC( 1982, sinista1, sinistar, sinistar, sinistar, sinistar, ROT270, "Williams", "Sinistar (prototype version)", &generic_ctrl, &sinista1_bootstrap )
-GAMEC( 1982, sinista2, sinistar, sinistar, sinistar, sinistar, ROT270, "Williams", "Sinistar (revision 2)", &generic_ctrl, &sinista2_bootstrap )
+GAMEC( 1982, sinistar, 0,        sinistar, sinistar, sinistar, ROT270, "Williams", "Sinistar (revision 3)",          &generic_ctrl, &sinistar_bootstrap)
+GAMEC( 1982, sinista1, sinistar, sinistar, sinistar, sinistar, ROT270, "Williams", "Sinistar (prototype version)",   &generic_ctrl, &sinista1_bootstrap )
+GAMEC( 1982, sinista2, sinistar, sinistar, sinistar, sinistar, ROT270, "Williams", "Sinistar (revision 2)",          &generic_ctrl, &sinista2_bootstrap )
 
 GAME( 1983, playball, 0,        playball, playball, playball, ROT270, "Williams", "PlayBall! (prototype)" )
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -432,35 +432,43 @@ static void update_variables(bool first_time)
           break;
 
         case OPT_DUAL_JOY:
-          if(strcmp(var.value, "enabled") == 0)
-            options.dual_joysticks = true;
-          else
-            options.dual_joysticks = false;
-
-          if(first_time)
-            old_dual_joystick_state = options.dual_joysticks;
-          else if(old_dual_joystick_state != options.dual_joysticks)
+          if(options.content_flags[CONTENT_DUAL_JOYSTICK])
           {
-            char cfg_file_path[PATH_MAX_LENGTH];
-            char buffer[PATH_MAX_LENGTH];
-            osd_get_path(FILETYPE_CONFIG, buffer);
-            snprintf(cfg_file_path, PATH_MAX_LENGTH, "%s%s%s.cfg", buffer, path_default_slash(), options.romset_filename_noext);
-            buffer[0] = '\0';
+            if(strcmp(var.value, "enabled") == 0)
+              options.dual_joysticks = true;
+            else
+              options.dual_joysticks = false;
             
-            if(path_is_valid(cfg_file_path))
-            {            
-              if(!remove(cfg_file_path) == 0)
-                snprintf(buffer, PATH_MAX_LENGTH, "%s.cfg exists but cannot be deleted!\n", options.romset_filename_noext);
-              else
-                snprintf(buffer, PATH_MAX_LENGTH, "%s.cfg exists but cannot be deleted!\n", options.romset_filename_noext);
+            if(first_time)
+              old_dual_joystick_state = options.dual_joysticks;
+            else if(old_dual_joystick_state != options.dual_joysticks)
+            {
+              char cfg_file_path[PATH_MAX_LENGTH];
+              char buffer[PATH_MAX_LENGTH];
+              osd_get_path(FILETYPE_CONFIG, buffer);
+              snprintf(cfg_file_path, PATH_MAX_LENGTH, "%s%s%s.cfg", buffer, path_default_slash(), options.romset_filename_noext);
+              buffer[0] = '\0';
+              
+              if(path_is_valid(cfg_file_path))
+              {            
+                if(!remove(cfg_file_path) == 0)
+                  snprintf(buffer, PATH_MAX_LENGTH, "%s.cfg exists but cannot be deleted!\n", options.romset_filename_noext);
+                else
+                  snprintf(buffer, PATH_MAX_LENGTH, "%s.cfg exists but cannot be deleted!\n", options.romset_filename_noext);
+              }
+              log_cb(RETRO_LOG_INFO, LOGPRE "%s Reloading input maps.\n", buffer);
+              usrintf_showmessage_secs(4, "%s Reloading input maps.", buffer);
+              
+              load_input_port_settings();
+              old_dual_joystick_state = options.dual_joysticks;
             }
-            log_cb(RETRO_LOG_INFO, LOGPRE "%s Reloading input maps.\n", buffer);
-            usrintf_showmessage_secs(4, "%s Reloading input maps.", buffer);
-            
-            load_input_port_settings();
-            old_dual_joystick_state = options.dual_joysticks;
+            break;
           }
-          break;
+          else /* always disabled except when options.content_flags[CONTENT_DUAL_JOYSTICK] has been set to true */
+          {
+            options.dual_joysticks = false; 
+            break;
+          }
 
         case OPT_RSTICK_BTNS:
           if(strcmp(var.value, "enabled") == 0)
@@ -705,7 +713,10 @@ static void set_content_flags(void)
 				"mk", "mkr4", "mkprot9", "mkla1", "mkla2",  "mkla3", "mkla4", \
 				"nbajam", "nbajamr2", "nbajamte", "nbajamt12", "nbajamt2",  "nbajamt3", \
 				"ffight", "ffightu", "ffightj",  "ffightj1", 0
-		 };    
+		 };
+
+  const char* dual_joy_drivers[] = { "angelkds", "aponow", "bandido", "bwidow", "ccboot", "ccboot2", "cclimber", "cclimbr2", "cclimbrj", "cloak", "cloakfr", "cloakgr", "cloaksp", "complexx", "dribling", "driblino", "firetpbl", "firetrap", "frontlin", "idsoccer", "inferno", "joyfulr", "karatedo", "karatevs", "kchamp", "kchampvs", "krull", "liblrabl", "losttmbh", "losttomb", "mars", "minefld", "mnchmobl", "rescraid", "rescrdsa", "rescue", "rockclim", "roishtar", "screwloo", "sdungeon", "sheriff", "smashtv", "smashtv4", "smashtv5", "smashtv6", "spcpostn", "splat", "stargrds", "stompin", "tinstar", "titlef", "totcarn", "totcarnp", "ultratnk", "wmatch", "wwester1", "wwestern", 0,
+  };  
 
   if(true) /* TODO: test for lightgun games */
   {
@@ -732,7 +743,7 @@ static void set_content_flags(void)
     log_cb(RETRO_LOG_INFO, LOGPRE "Content identified as \"Die Hard: Arcade\". BIOS will be set to \"us\".\n");
   }
 
-
+  i = 0;
   while(ost_drivers[i])
   {
     if(strcmp(ost_drivers[i], game_driver->name) == 0)
@@ -748,16 +759,32 @@ static void set_content_flags(void)
     options.content_flags[CONTENT_VECTOR] = true;
     /*log_cb(RETRO_LOG_INFO, LOGPRE "Content identified as using a vector video display.\n");*/
   }
+
   if(true) /* TODO: test for dial games */
   {
     options.content_flags[CONTENT_DIAL] = true;
     /*log_cb(RETRO_LOG_INFO, LOGPRE "Content identified as using a rotary dial input device.\n");*/
   }
-  if(true) /* TODO: test for games which with dual joystick configurations */
+
+  i = 0;
+  if(game_driver->ctrl_dat->dual_joysticks)
   {
     options.content_flags[CONTENT_DUAL_JOYSTICK] = true;
-    /*log_cb(RETRO_LOG_INFO, LOGPRE "Content identified as using \"dual joystick\" controls.\n");*/
+    log_cb(RETRO_LOG_INFO, LOGPRE "Content identified by controls.c as using \"dual joystick\" controls.\n");
   }
+  else
+  {
+    while(dual_joy_drivers[i]) /* fallback: if dual_joystick is not specified by ControlInfo, check our whitelist */
+    {
+      if(strcmp(dual_joy_drivers[i], game_driver->name) == 0)
+      {
+        options.content_flags[CONTENT_DUAL_JOYSTICK] = true;
+        log_cb(RETRO_LOG_INFO, LOGPRE "Content listed in \"dual joystick\" whitelist.\n");
+      }
+      i++;
+    }
+  }
+
 }
 
 void retro_reset (void)


### PR DESCRIPTION
This patch implements two ways to check if the original game used "Dual Joystick" controls.

One approach is to specify dual_joysticks = true in controls.c. I have done this for Robotron and its clone mostly as a demonstration.

The other approach is to add the game driver name to `dual_joy_drivers[]` which is a hardcoded list of all games that we know which use Dual Joysticks. It's implemented the same as @grant2258 's check for the hacked CD audio games

@robertvb83 I removed assault, its clones, and wacko from the hardcoded list pending further investigation into their control types as implemented in these versions of the MAME drivers. With this code in place it will be easy to make further additions or other adjustments though.