### PR TITLE
Update Stonebal for D-Pad button names

### DIFF
--- a/src/controls.c
+++ b/src/controls.c
@@ -24360,6 +24360,10 @@ const char *stonebal_get_ctrl_name(int type)
     case IPT_BUTTON1: return BTN1 "Shoot/Fight";
     case IPT_BUTTON2: return BTN2 "Pass/Tackle";
     case IPT_BUTTON3: return BTN3 "Push";
+    case IPT_JOYSTICK_UP: return "Up";
+    case IPT_JOYSTICK_DOWN: return "Down";
+    case IPT_JOYSTICK_LEFT: return "Left";
+    case IPT_JOYSTICK_RIGHT: return "Right";
   } /* end of switch */
 
   return "";


### PR DESCRIPTION
never ending story here... if there is no entry for joystick directions it is displayed in RA as "---"
can this be easily globally automated? or do we need a respective entry here for all games... then maybe a hint in the wiki would be nice