### PR TITLE
Potential graphical fix for Rev-X

### DIFF
--- a/src/vidhrdw/midtunit_vidhrdw.c
+++ b/src/vidhrdw/midtunit_vidhrdw.c
@@ -751,8 +751,8 @@ WRITE16_HANDLER( midtunit_dma_w )
 	/* clip the clippers */
 	dma_state.topclip = dma_register[DMA_TOPCLIP] & 0x1ff;
 	dma_state.botclip = dma_register[DMA_BOTCLIP] & 0x1ff;
-	dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x1ff;
-	dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x1ff;
+	dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x3ff;
+	dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x3ff;
 
 	/* determine the offset */
 	gfxoffset = dma_register[DMA_OFFSETLO] | (dma_register[DMA_OFFSETHI] << 16);


### PR DESCRIPTION
- 9th May 2007: Aaron Giles - Having recently touched all of the TMS34010-based games led me to start looking into some long-standing issues with some of the Williams/Midway Z/Y/X/Wolf-unit games. The first thing to do was to add save state support to them, because playing Revolution X more than once to get to the place where the video craps out is not for the faint of heart. This was relatively straightforward, and also had the side benefit of making some useful data available in the debugger (such as the local_videoram array and the dma_registers array). Side note: any array or pointer you register with state_save_register_global_array/_pointer automatically becomes a viewable option in a memory window in the debugger. This is very handy if you need to expose any internal state. Anyway, it turned out that the Revolution X bug was caused by over-aggressive masking in the blitter code. It was masking out one too many bits in the clipping window and this led to the right edge of the clip window being less than the left edge, effectively clipping out everything during the blit. Hence the black screen.

- 0.114u2: Aaron Giles fixed Revolution X gameplay/finish a level.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
