### PR TITLE
repair for insufficient checking against null

### DIFF
--- a/src/cheat.c
+++ b/src/cheat.c
@@ -9507,11 +9507,10 @@ static void WatchCheatEntry(CheatEntry * entry, UINT8 associate)
 	UINT32		i;
 	CheatEntry	* associateEntry = NULL;
 
-	if(associate)
-		associateEntry = entry;
-
-	if(!entry || !associateEntry)
-		return;
+	if(!entry || !associate)
+    return;
+  
+  associateEntry = entry;
 
 	for(i = 0; i < entry->actionListLength; i++)
 	{

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -9510,7 +9510,7 @@ static void WatchCheatEntry(CheatEntry * entry, UINT8 associate)
 	if(associate)
 		associateEntry = entry;
 
-	if(!entry)
+	if(!entry || !associateEntry)
 		return;
 
 	for(i = 0; i < entry->actionListLength; i++)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -401,6 +401,10 @@ UINT32 mame_fread(mame_file *file, void *buffer, UINT32 length)
 
 UINT32 mame_fwrite(mame_file *file, const void *buffer, UINT32 length)
 {
+	/* check against null pointer */
+	if (!file)
+		return 0;
+	
 	/* switch off the file type */
 	switch (file->type)
 	{


### PR DESCRIPTION
Hi all,

There is a possible null pointer dereference found by Qihoo360 CodeSafe Team, see
If only 'entry' is checked, 'associateEntry' could sitll be a null pointer (if 'associate' is 0).
It is better to check both 'entry' and 'associateEntry' against null pointer.
Then there will be OK if 'associateEntry' is passed as argument to function 'AddActionWatch()' in which  the 2nd argument is dereferenced in line 9558.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
