### PR TITLE
fix up the logic for 4way

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -2181,11 +2181,10 @@ ScanJoysticks( struct InputPort *in )
 		}
 
 		/* Only update mJoy4Way if the joystick has moved. */
-		if( mJoyCurrent[i]!=mJoyPrevious[i] )
+		if( mJoyCurrent[i]!=mJoyPrevious[i] && !options.four_way_emulation)
 		{
 			mJoy4Way[i] = mJoyCurrent[i];
-			if (!options.four_way_emulation) //start use original code
-			{
+
 			  if( (mJoy4Way[i] & 0x3) && (mJoy4Way[i] & 0xc) )
 			  {
 			  	  /* If joystick is pointing at a diagonal, acknowledge that the player moved
@@ -2225,17 +2224,25 @@ ScanJoysticks( struct InputPort *in )
 				 	  mJoy4Way[i] &= 0xc; /* eliminate vertical component */
 				  }
 			  }
-			}// end use original code
-			//new 4 way emluation
-            if (options.four_way_emulation) //start use alternative code 
-			{
-			  if( (!mJoy4Way[i] & 0x3) && !(mJoy4Way[i] & 0xc) ) last_direction = mJoy4Way[i]; 
-			  if( (mJoy4Way[i] & 0x3) && (mJoy4Way[i] & 0xc) )  
-			  mJoy4Way[i] ^= last_direction; //favour last direction assume the diag was a mistake
-	    	}
-			
+
 		}
+        else if (options.four_way_emulation) //start use alternative code 
+		{
+			mJoy4Way[i] = mJoyCurrent[i];
+			if( (mJoy4Way[i] & 0x3) && (mJoy4Way[i] & 0xc) && ( options.four_way_emulation == 1) )   mJoy4Way[i] ^= last_direction ; // xor 
+			if( (mJoy4Way[i] & 0x3) && (mJoy4Way[i] & 0xc) && ( options.four_way_emulation == 2) )  mJoy4Way[i] = last_direction ; // last pressed  
+			if  ( (mJoyCurrent[i]) && (mJoyCurrent[i] !=5) && (mJoyCurrent[i] !=6) && (mJoyCurrent[i] !=9) && (mJoyCurrent[i] !=10)) 
+			{ 
+				last_direction = mJoyCurrent[i]; 
+				
+			}
+			else  mJoy4Way[i] = last_direction; // put any logic on diagonal
+		}
+				
+ 	
+
 	}
+
 } /* ScanJoysticks */
 
 void update_input_ports(void)

--- a/src/mame.h
+++ b/src/mame.h
@@ -252,7 +252,7 @@ struct GameOptions
   int		   debug_width;	         /* requested width of debugger bitmap */
   int		   debug_height;	       /* requested height of debugger bitmap */
   int		   debug_depth;	         /* requested depth of debugger bitmap */
-  bool 	 four_way_emulation; /* use new 4 way emulation */
+  int 	 four_way_emulation; /* use new 4 way emulation */
 };
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -149,7 +149,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_INPUT_INTERFACE],     APPNAME"_input_interface",     "Input interface; retropad|mame_keyboard|simultaneous");  
   init_default(&default_options[OPT_MAME_REMAPPING],      APPNAME"_mame_remapping",      "Activate MAME Remapping (!NETPLAY); disabled|enabled");
   
-  init_default(&default_options[OPT_4WAY],	              APPNAME"_four_way_emulation",  "Alternative 4way emulation ; disabled|enabled");
+  init_default(&default_options[OPT_4WAY],	              APPNAME"_four_way_emulation",  "Alternative 4way emulation ; original|xor|last_pressed");
   
   init_default(&default_options[OPT_end], NULL, NULL);
   set_variables(true);
@@ -499,15 +499,17 @@ static void update_variables(bool first_time)
             setup_menu_init();
           break;
 		case OPT_4WAY:
-         if(strcmp(var.value, "enabled") == 0)		
-		  options.four_way_emulation = true;
-         else
-          options.four_way_emulation = false;
+         if(strcmp(var.value, "original") == 0)		
+		  options.four_way_emulation = 0;
+         else if (strcmp(var.value, "xor") == 0)		
+	      options.four_way_emulation = 1;
+	     else if (strcmp(var.value, "last_pressed") == 0)		
+		  options.four_way_emulation = 2;
 		  break;
       }
     }
   }
-  
+ 
   if(!options.content_flags[CONTENT_ALT_SOUND])
     options.use_samples = true;
 


### PR DESCRIPTION
This has been tested on windows 64 with retroatch with a xbox360 and xbox one and an dragonrise zeroday encoder with a sanwa jlf. The same controllers where tested on retropie. I didnt want to commit this until I was 100% happy with it.

A little note on xbo360 controllers you if your using the analog as digital please put the dead zone up to at least 0.600 if your having wondering problems. These sticks more so when they age are notorious for is as well as ps3 ones.

There are 3 options for 4 way in the options its on original by default original is mames native code. I personally recommend last_pressed. 

@robertvb83  said he was having problems with bomberman. Its set to 8way in the mame source in the drivers and im having no problems with the game that way. (only tested on my sanwa stick to be fair). 
I have the source changes to make it 4way if someone can tell me how to reproduce the problem. I will change it.

hopefully this is the last update on this

 