### PR TITLE
sync info->library_name with RetroArch .info file

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -554,11 +554,11 @@ unsigned retro_api_version(void)
 
 void retro_get_system_info(struct retro_system_info *info)
 {
-  info->library_name = "MAME 2003-plus";
+  info->library_name = "MAME 2003-Plus";
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
-  info->library_version = "0.78" GIT_VERSION;
+  info->library_version = GIT_VERSION;
   info->valid_extensions = "zip";
   info->need_fullpath = true;
   info->block_extract = true;


### PR DESCRIPTION
@gblues thanks for working to improve netplay and for educating me on how the matchmatking works.

I'm just tagging you here so you will know that mame2003-plus also now has a `library_name` that is sync'd with the .info file. No action needed. :+1: 

If you have any other findings about netplay or other issues, particularly about mame2003-plus, please let me/us know. 