### PR TITLE
DO NOT MERGE ignore only control mappings in the cfg

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -176,6 +176,10 @@ static int input_port_read_ver_8(mame_file *f, struct InputPort *in)
 {
 	UINT32 i;
 	UINT16 w;
+  
+  if(!options.mame_remapping)
+    return 0;
+  
 	if (readint(f,&i) != 0)
 		return -1;
 	in->type = i;
@@ -288,10 +292,7 @@ static unsigned int count_input_ports(const struct InputPort *in)
 
 config_file *config_open(const char *name)
 {
-	if(options.mame_remapping)
-    return config_init(name, 0);
-
-  return NULL;
+  return config_init(name, 0);
 }
 
 
@@ -302,10 +303,7 @@ config_file *config_open(const char *name)
 
 config_file *config_create(const char *name)
 {
-	if(options.mame_remapping)
-    return config_init(name, 1);
-
-  return NULL;
+  return config_init(name, 1);
 }
 
 


### PR DESCRIPTION
My current implementation of the "Activate MAME Remapping" option is very simple -- when active, this option tells the MAME mode that there is no CFG file regardless of whether that is true.

However in addition to control mappings, the MAME CFG files also include information regarding coin and ticket counters as well as metadata regarding the internal audio mixer. I'm not honestly sure that this core uses any of that information but it seems better to be a little more sophisticated in my approach.

@grant2258 I feel I must turn to you as someone who is experienced with CFG files. Does this change make sense to you?