### PR TITLE
NOT READY YET improve legacy remapper core option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -288,10 +288,10 @@ static unsigned int count_input_ports(const struct InputPort *in)
 
 config_file *config_open(const char *name)
 {
-	if(options.mame_remapping)
+/*	if(options.mame_remapping)*/ 
     return config_init(name, 0);
 
-  return NULL;
+/*  return NULL;*/
 }
 
 
@@ -302,10 +302,10 @@ config_file *config_open(const char *name)
 
 config_file *config_create(const char *name)
 {
-	if(options.mame_remapping)
+/*	if(options.mame_remapping) */
     return config_init(name, 1);
 
-  return NULL;
+/*  return NULL;*/
 }
 
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -61,7 +61,6 @@ struct _mame_file
 ***************************************************************************/
 
 static mame_file *generic_fopen(int pathtype, const char *gamename, const char *filename, const char* hash, UINT32 flags);
-static const char *get_extension_for_filetype(int filetype);
 static int checksum_file(int pathtype, int pathindex, const char *file, UINT8 **p, UINT64 *size, char* hash);
 
 
@@ -780,7 +779,7 @@ static INLINE void compose_path(char *output, const char *gamename, const char *
 	get_extension_for_filetype
 ***************************************************************************/
 
-static const char *get_extension_for_filetype(int filetype)
+const char *get_extension_for_filetype(int filetype)
 {
 	const char *extension;
 

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -81,6 +81,8 @@ FILE* osd_fopen(int pathtype, int pathindex, const char *filename, const char *m
 
 int osd_create_directory(const char *dir);
 
+
+
 int mame_faccess(const char *filename, int filetype);
 mame_file *mame_fopen(const char *gamename, const char *filename, int filetype, int openforwrite);
 mame_file *mame_fopen_rom(const char *gamename, const char *filename, const char* exphash);
@@ -113,6 +115,14 @@ UINT64 mame_ftell(mame_file *file);
 
 int mame_fputs(mame_file *f, const char *s);
 int mame_vfprintf(mame_file *f, const char *fmt, va_list va);
+
+
+/***************************************************************************
+	get_extension_for_filetype
+***************************************************************************/
+
+const char *get_extension_for_filetype(int filetype);
+
 
 /***************************************************************************
 	spawn_bootstrap_nvram

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1691,6 +1691,15 @@ static void save_default_keys(void)
 	memcpy(inputport_defaults,inputport_defaults_backup,sizeof(inputport_defaults_backup));
 }
 
+/* 
+ * void reset_default_keys(void)
+ * repopulate mappings from the defaults specified in the inptport source 
+ */
+void reset_default_keys(void)
+{
+	memcpy(inputport_defaults,inputport_defaults_backup,sizeof(inputport_defaults_backup));
+  save_default_keys();
+}
 
 int load_input_port_settings(void)
 {

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1692,13 +1692,29 @@ static void save_default_keys(void)
 }
 
 /* 
- * void reset_default_keys(void)
+ * void reset_default_inputs(void)
  * repopulate mappings from the defaults specified in the inptport source 
  */
-void reset_default_keys(void)
+void reset_default_inputs(void)
 {
 	memcpy(inputport_defaults,inputport_defaults_backup,sizeof(inputport_defaults_backup));
   save_default_keys();
+}
+
+/* 
+ * void reset_default_inputs(void)
+ * repopulate mappings from the defaults specified in the driver source 
+ */
+void reset_driver_inputs(void)
+{
+  struct InputPort *in;
+
+	in = (struct InputPort *) inputport_defaults;
+	while (in->type != IPT_END)
+	{
+    /* still needs to be implemented */
+		in++;
+	}
 }
 
 int load_input_port_settings(void)

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -412,11 +412,16 @@ void seq_set_string(InputSeq* a, const char *buf);
 const char *generic_ctrl_label(int input);
 
 /* 
- * void reset_default_keys(void)
+ * void reset_default_inputs(void)
  * repopulate mappings from the defaults specified in the inptport source 
  */
-void reset_default_keys(void);
+void reset_default_inputs(void);
 
+/* 
+ * void reset_default_keys(void)
+ * repopulate mappings from the defaults specified in the driver source 
+ */
+void reset_driver_inputs(void);
 
 #ifdef __cplusplus
 }

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -411,6 +411,12 @@ extern int num_ik;
 void seq_set_string(InputSeq* a, const char *buf);
 const char *generic_ctrl_label(int input);
 
+/* 
+ * void reset_default_keys(void)
+ * repopulate mappings from the defaults specified in the inptport source 
+ */
+void reset_default_keys(void);
+
 
 #ifdef __cplusplus
 }

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -412,7 +412,7 @@ static void update_variables(bool first_time)
               log_cb(RETRO_LOG_INFO, LOGPRE "%s Reloading input maps.\n", buffer);
               usrintf_showmessage_secs(4, "%s Reloading input maps.", buffer);
               
-              load_input_port_settings();
+              load_input_port_settings(); /* this may just read the active mappings from memory (ie the same ones we're trying to delete) rather than resetting them to default */
               old_dual_joystick_state = options.dual_joysticks;
             }
             break;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -144,7 +144,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_SAMPLE_RATE],         APPNAME"_sample_rate",         "Sample Rate (KHz); 48000|8000|11025|22050|44100");
   init_default(&default_options[OPT_DCS_SPEEDHACK],       APPNAME"_dcs_speedhack",       "DCS Speedhack; enabled|disabled");
   init_default(&default_options[OPT_INPUT_INTERFACE],     APPNAME"_input_interface",     "Input interface; retroarch|keyboard|mame");  
-  init_default(&default_options[OPT_MAME_REMAPPING],      APPNAME"_mame_remapping",      "Legacy Remapping and Dipswitch Saving (!NETPLAY); disabled|enabled");  
+  init_default(&default_options[OPT_MAME_REMAPPING],      APPNAME"_mame_remapping",      "Legacy Remapping (!NETPLAY); disabled|enabled");  
   init_default(&default_options[OPT_4WAY],                APPNAME"_four_way_emulation",  "4way emulation on 8 way; original|new|rotated_4way");
   
   init_default(&default_options[OPT_end], NULL, NULL);

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -25,7 +25,7 @@
 static const struct GameDriver  *game_driver;
 static float              delta_samples;
 int                       samples_per_frame = 0;
-int 			  orig_samples_per_frame =0;
+int                       orig_samples_per_frame =0;
 short*                    samples_buffer;
 short*                    conversion_buffer;
 int                       usestereo = 1;
@@ -37,7 +37,7 @@ int16_t                   XsoundBuffer[2048];
 
 extern const struct KeyboardInfo retroKeys[];
 extern int          retroKeyState[512];
- int          retroJsState[109]= {0}; // initialise to zero we are only reaing 4 players atm
+int                 retroJsState[109]= {0}; // initialise to zero - we are only reading 4 players atm
 extern int16_t      mouse_x[4];
 extern int16_t      mouse_y[4];
 extern struct       osd_create_params videoConfig;

--- a/src/ui_text.c
+++ b/src/ui_text.c
@@ -80,6 +80,8 @@ static const char *mame_default_text[] =
 	"Calibrate Joysticks",
 	"Bookkeeping Info",
 	"Input (this game)",
+  "Flush Current CFG",
+  "Flush All CFGs",  
 	"Game Information",
 	"Game History",
 	"Reset Game",

--- a/src/ui_text.h
+++ b/src/ui_text.h
@@ -79,6 +79,8 @@ enum
 	UI_calibrate,
 	UI_bookkeeping,
 	UI_inputspecific,
+  UI_flush_current_cfg,
+  UI_flush_all_cfg,  
 	UI_gameinfo,
 	UI_history,
   UI_resetgame,

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3063,12 +3063,13 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
         msg_buffer[0]='\0';  
 
         osd_get_path(FILETYPE_CONFIG, current_path);       
-        snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), Machine->gamedrv->name, get_extension_for_filetype(FILETYPE_CONFIG));
-        
+        snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), Machine->gamedrv->name, '.', get_extension_for_filetype(FILETYPE_CONFIG));
+        printf("%s%s", path_buffer, "\n");
         if(remove(path_buffer))
           snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s%s%s", "Error flushing CFG from ", path_buffer, "!");
         else
           snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s", "CFG flushed!"); 
+        usrintf_showmessage_secs(2, "%s", msg_buffer);
  
         break;
       }
@@ -3077,18 +3078,17 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
         char msg_buffer[MAX_MESSAGE_LENGTH];
         char path_buffer[PATH_MAX_LENGTH];
         char current_path[PATH_MAX_LENGTH];
-        int driverIndex = 0;
-        
+        int driverIndex = 0;       
         msg_buffer[0]='\0';
+
         osd_get_path(FILETYPE_CONFIG, current_path);        
 
         snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s", "Executing flush all CFG command!"); 
         usrintf_showmessage_secs(2, "%s", msg_buffer);
 
         /* be sure to delete "default.cfg" as well */
-        snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), "default", get_extension_for_filetype(FILETYPE_CONFIG));
+        snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), "default", '.', get_extension_for_filetype(FILETYPE_CONFIG));
         remove(path_buffer);
-
         /* loop through all driver names and attempt to delete the corresponding cfg file.
            it would be good to have a cleaner implementation but this does work and can reuse
            code from mame2003.c */
@@ -3096,20 +3096,26 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
         for (driverIndex = 0; driverIndex < total_drivers; driverIndex++)
         {
           const struct GameDriver *needle = drivers[driverIndex];
-
-          snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), needle->name, get_extension_for_filetype(FILETYPE_CONFIG));
-          remove(path_buffer); /* remove DOS filename version */          
-
-          snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), needle->description, get_extension_for_filetype(FILETYPE_CONFIG));
-          remove(path_buffer); /* remove full/alternative filename version -- although not in use as of November 2018 */
+          if(needle && needle->name) 
+          {
+            snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), needle->name, '.', get_extension_for_filetype(FILETYPE_CONFIG));
+            remove(path_buffer); /* try to remove DOS filename version */
+          }            
+          if(needle && needle->description)
+          {            
+            snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), needle->description, '.', get_extension_for_filetype(FILETYPE_CONFIG));
+            remove(path_buffer); /* try to remove full/alternative filename version -- although not in use as of November 2018 */   
+          }
         }
-      }        
         break;          
-      case UI_GENERATE_NEW_XML_DAT:
+      }        
+      case UI_GENERATE_NEW_XML_DAT: /* full/alternative filename version -- not in use as of November 2018 */
+          usrintf_showmessage_secs(4, "%s", "Generating Alternative XML DAT!");
           print_mame_xml(0);
           break;
 
       case UI_GENERATE_OLD_XML_DAT:
+          usrintf_showmessage_secs(4, "%s", "Generating XML DAT!");      
           print_mame_xml(1);
           break;
 

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3108,6 +3108,8 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
             remove(path_buffer); /* try to remove full/alternative filename version -- although not in use as of November 2018 */   
           }
         }
+        load_input_port_settings(); /* this may just read the active mappings from memory (ie the same ones we're trying to delete) rather than resetting them to default */
+
         break;          
       }        
       case UI_GENERATE_NEW_XML_DAT: /* full/alternative filename version -- not in use as of November 2018 */

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -2891,8 +2891,8 @@ void setup_menu_init(void)
   {
 	  menu_item[menu_total] = ui_getstring (UI_inputgeneral);      menu_action[menu_total++] = UI_DEFCODE;
     menu_item[menu_total] = ui_getstring (UI_inputspecific);     menu_action[menu_total++] = UI_CODE;
-    menu_item[menu_total] = ui_getstring (UI_flush_current_cfg); menu_action[menu_total++] = UI_FLUSH_CURRENT_CFG;    
-    menu_item[menu_total] = ui_getstring (UI_flush_all_cfg); menu_action[menu_total++] = UI_FLUSH_ALL_CFG;    
+    //menu_item[menu_total] = ui_getstring (UI_flush_current_cfg); menu_action[menu_total++] = UI_FLUSH_CURRENT_CFG;    
+    //menu_item[menu_total] = ui_getstring (UI_flush_all_cfg);     menu_action[menu_total++] = UI_FLUSH_ALL_CFG;    
   }
 
 	/* Determine if there are any dip switches */
@@ -3064,7 +3064,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
 
         osd_get_path(FILETYPE_CONFIG, current_path);       
         snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), Machine->gamedrv->name, '.', get_extension_for_filetype(FILETYPE_CONFIG));
-        printf("%s%s", path_buffer, "\n");
+
         if(remove(path_buffer))
           snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s%s%s", "Error flushing CFG from ", path_buffer, "!");
         else
@@ -3089,7 +3089,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
         /* delete "default.cfg" and repopulate from the defaults specified by inptport source */
         snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), "default", '.', get_extension_for_filetype(FILETYPE_CONFIG));
         remove(path_buffer);
-        reset_default_keys();
+        reset_default_inputs();
               
         /* loop through all driver names and attempt to delete the corresponding cfg file.
            it would be good to have a cleaner implementation but this does work and can reuse

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -2871,9 +2871,9 @@ int memcard_menu(struct mame_bitmap *bitmap, int selection)
 }
 
 
-enum { UI_SWITCH = 0,UI_DEFCODE,UI_CODE,UI_ANALOG,UI_CALIBRATE,
+enum { UI_SWITCH = 0,UI_DEFCODE,UI_CODE,UI_FLUSH_CURRENT_CFG, UI_FLUSH_ALL_CFG, UI_ANALOG,UI_CALIBRATE,
 		UI_STATS,UI_GAMEINFO, UI_HISTORY,
-		UI_CHEAT,UI_RESET,UI_GENERATE_NEW_XML_DAT, UI_GENERATE_OLD_XML_DAT, UI_MEMCARD,UI_RAPIDFIRE,UI_EXIT };
+		UI_CHEAT,UI_RESET, UI_GENERATE_NEW_XML_DAT, UI_GENERATE_OLD_XML_DAT, UI_MEMCARD,UI_RAPIDFIRE,UI_EXIT };
 
 
 
@@ -2889,8 +2889,10 @@ void setup_menu_init(void)
 
   if(options.mame_remapping)
   {
-	  menu_item[menu_total] = ui_getstring (UI_inputgeneral); menu_action[menu_total++] = UI_DEFCODE;
-    menu_item[menu_total] = ui_getstring (UI_inputspecific); menu_action[menu_total++] = UI_CODE;
+	  menu_item[menu_total] = ui_getstring (UI_inputgeneral);      menu_action[menu_total++] = UI_DEFCODE;
+    menu_item[menu_total] = ui_getstring (UI_inputspecific);     menu_action[menu_total++] = UI_CODE;
+    menu_item[menu_total] = ui_getstring (UI_flush_current_cfg); menu_action[menu_total++] = UI_FLUSH_CURRENT_CFG;    
+    menu_item[menu_total] = ui_getstring (UI_flush_all_cfg); menu_action[menu_total++] = UI_FLUSH_ALL_CFG;    
   }
 
 	/* Determine if there are any dip switches */
@@ -2956,7 +2958,9 @@ void setup_menu_init(void)
 
 #if !defined(WIIU) && !defined(GEKKO) && !defined(__CELLOS_LV2__) && !defined(__SWITCH__) && !defined(PSP) && !defined(VITA) && !defined(__GCW0__) && !defined(__EMSCRIPTEN__) && !defined(_XBOX)
     /* don't offer to generate_xml_dat on consoles where it can't be used */
-    menu_item[menu_total] = ui_getstring (UI_generate_old_xml_dat); menu_action[menu_total++] = UI_GENERATE_OLD_XML_DAT;
+    menu_item[menu_total] = ui_getstring (UI_generate_old_xml_dat);   menu_action[menu_total++] = UI_GENERATE_OLD_XML_DAT;
+
+    /* the "alternative XML DAT project" with proper game names for the files instead of DOS names is on hold as of November 2018 */
     /*menu_item[menu_total] = ui_getstring (UI_generate_new_xml_dat); menu_action[menu_total++] = UI_GENERATE_NEW_XML_DAT;*/  
 #endif
   if(!options.display_setup) 
@@ -3051,7 +3055,56 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
 				sel |= 1 << SEL_BITS;
 				schedule_full_refresh();
 				break;
-           
+      case UI_FLUSH_CURRENT_CFG:
+      {
+        char msg_buffer[MAX_MESSAGE_LENGTH];
+        char path_buffer[PATH_MAX_LENGTH];
+        char current_path[PATH_MAX_LENGTH];
+        msg_buffer[0]='\0';  
+
+        osd_get_path(FILETYPE_CONFIG, current_path);       
+        snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), Machine->gamedrv->name, get_extension_for_filetype(FILETYPE_CONFIG));
+        
+        if(remove(path_buffer))
+          snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s%s%s", "Error flushing CFG from ", path_buffer, "!");
+        else
+          snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s", "CFG flushed!"); 
+ 
+        break;
+      }
+      case UI_FLUSH_ALL_CFG:
+      {
+        char msg_buffer[MAX_MESSAGE_LENGTH];
+        char path_buffer[PATH_MAX_LENGTH];
+        char current_path[PATH_MAX_LENGTH];
+        int driverIndex = 0;
+        
+        msg_buffer[0]='\0';
+        osd_get_path(FILETYPE_CONFIG, current_path);        
+
+        snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s", "Executing flush all CFG command!"); 
+        usrintf_showmessage_secs(2, "%s", msg_buffer);
+
+        /* be sure to delete "default.cfg" as well */
+        snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), "default", get_extension_for_filetype(FILETYPE_CONFIG));
+        remove(path_buffer);
+
+        /* loop through all driver names and attempt to delete the corresponding cfg file.
+           it would be good to have a cleaner implementation but this does work and can reuse
+           code from mame2003.c */
+
+        for (driverIndex = 0; driverIndex < total_drivers; driverIndex++)
+        {
+          const struct GameDriver *needle = drivers[driverIndex];
+
+          snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), needle->name, get_extension_for_filetype(FILETYPE_CONFIG));
+          remove(path_buffer); /* remove DOS filename version */          
+
+          snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%s", current_path, path_default_slash(), needle->description, get_extension_for_filetype(FILETYPE_CONFIG));
+          remove(path_buffer); /* remove full/alternative filename version -- although not in use as of November 2018 */
+        }
+      }        
+        break;          
       case UI_GENERATE_NEW_XML_DAT:
           print_mame_xml(0);
           break;

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3086,13 +3086,14 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
         snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s", "Executing flush all CFG command!"); 
         usrintf_showmessage_secs(2, "%s", msg_buffer);
 
-        /* be sure to delete "default.cfg" as well */
+        /* delete "default.cfg" and repopulate from the defaults specified by inptport source */
         snprintf(path_buffer, PATH_MAX_LENGTH, "%s%s%s%c%s", current_path, path_default_slash(), "default", '.', get_extension_for_filetype(FILETYPE_CONFIG));
         remove(path_buffer);
+        reset_default_keys();
+              
         /* loop through all driver names and attempt to delete the corresponding cfg file.
            it would be good to have a cleaner implementation but this does work and can reuse
            code from mame2003.c */
-
         for (driverIndex = 0; driverIndex < total_drivers; driverIndex++)
         {
           const struct GameDriver *needle = drivers[driverIndex];


### PR DESCRIPTION
This new approach to the MAME/Legacy control remapper core option is almost ready. @grant2258 this is my attempt to implement the concept I was describing over the weekend.

The purpose is to allow the CFG files to be saved so that dipswitch settings are maintained, but to do so in a way that still helps new users avoid making changes via the MAME remapper that they don't want or understand.

Because this new approach does make it, in my estimation, a little easier than before to accidentally create an unwanted CFG, I believe the answer is to make it as easy as possible for the user to get back to a clean slate. With this PR, the core option only controls what submenus are accessible from the MAME UI. Turning on the `Legacy Remapper` will give access to the mapping submenus as well as two new entries I've created:

* Flush current CFG
* Flush all CFGs

### Remaining issue
At the moment, things are close to working. However when the current game's CFG is deleted, the current modified mappings are still in active memory. Then when the core exits, these modified values are written back to disk, defeating the purpose of deleting the CFG file.

I've already worked out how to avoid this problem for the `default.cfg` file so I probably just need fresh eyes to get things completely working.

I decided to go ahead and open this PR because even as things are now it should be possible for grant or anyone else who is interested to load this version of the code, see the UI, and hopefully understand how this is supposed to work.