### PR TITLE
stub function to restore game input to default

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -413,6 +413,8 @@ static void update_variables(bool first_time)
               usrintf_showmessage_secs(4, "%s Reloading input maps.", buffer);
               
               load_input_port_settings(); /* this may just read the active mappings from memory (ie the same ones we're trying to delete) rather than resetting them to default */
+              /* should use reset_driver_inputs() if that function is ever completed */
+
               old_dual_joystick_state = options.dual_joysticks;
             }
             break;
@@ -1924,4 +1926,3 @@ const struct KeyboardInfo retroKeys[] =
 
     {0, 0, 0}
 };
-

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3070,7 +3070,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
         else
           snprintf(msg_buffer, MAX_MESSAGE_LENGTH, "%s", "CFG flushed!"); 
         usrintf_showmessage_secs(2, "%s", msg_buffer);
- 
+        reset_driver_inputs(); /* just a stub for now */
         break;
       }
       case UI_FLUSH_ALL_CFG:
@@ -3108,7 +3108,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
             remove(path_buffer); /* try to remove full/alternative filename version -- although not in use as of November 2018 */   
           }
         }
-        load_input_port_settings(); /* this may just read the active mappings from memory (ie the same ones we're trying to delete) rather than resetting them to default */
+        reset_driver_inputs(); /* just a stub for now */
 
         break;          
       }        


### PR DESCRIPTION
Not implemented yet, although now I do have a stub that is 70% there. I'm just putting these placeholders in to make it easier for me to pick back up on the Legacy Remapper/Delete CFG command feature later on.