### PR TITLE
no functional change - optional for core option to create mame2003 subfolders

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -181,6 +181,21 @@ int osd_get_path_count(int pathtype)
  *****************************************************************************/
 void osd_get_path(int pathtype, char* path)
 {
+  char save_path_buffer[PATH_MAX_LENGTH];
+  char sys_path_buffer[PATH_MAX_LENGTH];
+
+  save_path_buffer[0] = '\0';
+  if(options.save_subfolder)
+    snprintf(save_path_buffer, PATH_MAX_LENGTH, "%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME);
+  else
+    snprintf(save_path_buffer, PATH_MAX_LENGTH, "%s", options.libretro_save_path);
+
+  sys_path_buffer[0] = '\0';
+  if(options.system_subfolder)
+    snprintf(sys_path_buffer, PATH_MAX_LENGTH, "%s%s%s", options.libretro_system_path, path_default_slash(), APPNAME);
+  else
+    snprintf(sys_path_buffer, PATH_MAX_LENGTH, "%s", options.libretro_system_path);
+    
    switch (pathtype)
    {       
        case FILETYPE_ROM:
@@ -190,40 +205,41 @@ void osd_get_path(int pathtype, char* path)
 
       /* user-initiated content goes in mame2003 save directory subfolders */      
       case FILETYPE_IMAGE_DIFF:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME, path_default_slash(), "diff");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", save_path_buffer, path_default_slash(), "diff");
          break;     
       case FILETYPE_NVRAM:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME, path_default_slash(), "nvram");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", save_path_buffer, path_default_slash(), "nvram");
          break;
       case FILETYPE_HIGHSCORE:
-          snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME, path_default_slash(), "hi");
+          snprintf(path, PATH_MAX_LENGTH, "%s%s%s", save_path_buffer, path_default_slash(), "hi");
          break;
       case FILETYPE_CONFIG:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME, path_default_slash(), "cfg");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", save_path_buffer, path_default_slash(), "cfg");
          break;
       case FILETYPE_MEMCARD:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME, path_default_slash(), "memcard");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", save_path_buffer, path_default_slash(), "memcard");
          break;
       case FILETYPE_CTRLR:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME, path_default_slash(), "ctrlr");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", save_path_buffer, path_default_slash(), "ctrlr");
          break;
       case FILETYPE_XML_DAT:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", options.libretro_save_path, path_default_slash(), APPNAME);
+         snprintf(path, PATH_MAX_LENGTH, "%s", save_path_buffer);
          break;
-      /* pre-generated content goes in mam2003 system directory subfolders */
+
+         /* static, pregenerated content goes in mam2003 system directory subfolders */
       case FILETYPE_ARTWORK:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_system_path, path_default_slash(), APPNAME, path_default_slash(), "artwork");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", sys_path_buffer, path_default_slash(), "artwork");
          break;
       case FILETYPE_SAMPLE:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_system_path, path_default_slash(), APPNAME, path_default_slash(), "samples");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", sys_path_buffer, path_default_slash(), "samples");
          break;
       case FILETYPE_SAMPLE_FLAC:
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s%s%s", options.libretro_system_path, path_default_slash(), APPNAME, path_default_slash(), "samples");
+         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", sys_path_buffer, path_default_slash(), "samples");
          break;
 
       default:
          /* .dat files and additional core content goes in mame2003 system directory */
-         snprintf(path, PATH_MAX_LENGTH, "%s%s%s", options.libretro_system_path, path_default_slash(), APPNAME);
+         snprintf(path, PATH_MAX_LENGTH, "%s", sys_path_buffer);
    }    
 }
 
@@ -1165,4 +1181,3 @@ int CLIB_DECL mame_fprintf(mame_file *f, const char *fmt, ...)
 	va_end(va);
 	return rc;
 }
-

--- a/src/mame.h
+++ b/src/mame.h
@@ -213,6 +213,7 @@ struct GameOptions
   unsigned input_interface;                /* can be set to RETRO_DEVICE_JOYPAD, RETRO_DEVICE_KEYBOARD, or 0 (both simultaneously) */
   unsigned retropad_layout[DISP_PLAYER6];  /* flags to indicate the default layout for each player */
   bool     dual_joysticks;                 /* Player 1 uses Joystick 1 & 2, Player 2 uses Joystick 3 and 4 */
+  int 	   four_way_emulation;             /* use new 4 way emulation */
   unsigned rstick_to_btns;
   unsigned tate_mode;
 
@@ -248,11 +249,13 @@ struct GameOptions
   bool     nvram_bootstrap;
   
   const char *bios;			         /* specify system bios (if used), 0 is default */
-
+  
+  bool     system_subfolder;     /* save all system files within a subfolder of the libretro system folder rather than directly in the system folder */
+  bool     save_subfolder;       /* save all save files within a subfolder of the libretro system folder rather than directly in the system folder */  
+  
   int		   debug_width;	         /* requested width of debugger bitmap */
   int		   debug_height;	       /* requested height of debugger bitmap */
   int		   debug_depth;	         /* requested depth of debugger bitmap */
-  int 	 four_way_emulation; /* use new 4 way emulation */
 };
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -100,9 +100,8 @@ void retro_init (void)
 
 static void check_system_specs(void)
 {
-   /* TODO - set variably */
-   /* Midway DCS - Mortal Kombat/NBA Jam etc. require level 9 */
-   unsigned level = 10;
+   /* Should we set level variably like the API asks? Are there any frontends that implement this? */
+   unsigned level = 10; /* For stub purposes, set to the highest level */
    environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, &level);
 }
 
@@ -113,7 +112,7 @@ void retro_set_environment(retro_environment_t cb)
 
 static void init_core_options(void)
 {
-  init_default(&default_options[OPT_FRAMESKIP],           APPNAME"_frameskip",           "Frameskip; 0|1|2|3|4|5");
+  init_default(&default_options[OPT_4WAY],                APPNAME"_four_way_emulation",  "4-way joystick emulation on 8-way joysticks; original|new|rotated_4way");
 #if defined(__IOS__)
   init_default(&default_options[OPT_MOUSE_DEVICE],        APPNAME"_mouse_device",        "Mouse Device; pointer|mouse|disabled");
 #else
@@ -145,8 +144,10 @@ static void init_core_options(void)
   init_default(&default_options[OPT_DCS_SPEEDHACK],       APPNAME"_dcs_speedhack",       "DCS Speedhack; enabled|disabled");
   init_default(&default_options[OPT_INPUT_INTERFACE],     APPNAME"_input_interface",     "Input interface; retroarch|keyboard|mame");  
   init_default(&default_options[OPT_MAME_REMAPPING],      APPNAME"_mame_remapping",      "Legacy Remapping (!NETPLAY); disabled|enabled");  
-  init_default(&default_options[OPT_4WAY],                APPNAME"_four_way_emulation",  "4way emulation on 8 way; original|new|rotated_4way");
-  
+  init_default(&default_options[OPT_FRAMESKIP],           APPNAME"_frameskip",           "Frameskip; 0|1|2|3|4|5");
+  init_default(&default_options[OPT_CORE_SYS_SUBFOLDER],  APPNAME"_core_sys_subfolder",  "Locate system files within a subfolder; enabled|disabled"); /* This should be probably handled by the frontend and not by cores per discussions in Fall 2018 but RetroArch for example doesn't provide this as an option. */
+  init_default(&default_options[OPT_CORE_SAVE_SUBFOLDER], APPNAME"_core_save_subfolder", "Locate save files within a subfolder; enabled|disabled"); /* This is already available as an option in RetroArch although it is left enabled by default as of November 2018 for consistency with past practice. At least for now.*/
+
   init_default(&default_options[OPT_end], NULL, NULL);
   set_variables(true);
 }
@@ -244,20 +245,25 @@ static void update_variables(bool first_time)
             
       switch(index)
       {
-        case OPT_FRAMESKIP:
-          options.frameskip = atoi(var.value);
-          break;
-
         case OPT_INPUT_INTERFACE:
           if(strcmp(var.value, "retroarch") == 0)
             options.input_interface = RETRO_DEVICE_JOYPAD;
           else if(strcmp(var.value, "keyboard") == 0)
             options.input_interface = RETRO_DEVICE_KEYBOARD;
-		  else 
-			  options.input_interface = RETRO_DEVICE_KEYBOARD + RETRO_DEVICE_JOYPAD;
+		    else 
+			    options.input_interface = RETRO_DEVICE_KEYBOARD + RETRO_DEVICE_JOYPAD;
+        break;
+
+        case OPT_4WAY:
+          if(strcmp(var.value, "original") == 0)		
+           options.four_way_emulation = 0;
+          else if (strcmp(var.value, "new") == 0)		
+           options.four_way_emulation = 1;
+          else 
+           options.four_way_emulation = 2;
           break;
 
-	    case OPT_MOUSE_DEVICE:
+        case OPT_MOUSE_DEVICE:
           if(strcmp(var.value, "pointer") == 0)
             options.mouse_device = RETRO_DEVICE_POINTER;
           else if(strcmp(var.value, "mouse") == 0)
@@ -495,14 +501,24 @@ static void update_variables(bool first_time)
           if(!first_time)
             setup_menu_init();
           break;
-		case OPT_4WAY:
-         if(strcmp(var.value, "original") == 0)		
-		  options.four_way_emulation = 0;
-         else if (strcmp(var.value, "new") == 0)		
-	      options.four_way_emulation = 1;
-		 else 
-		  options.four_way_emulation = 2;
-		break;
+
+        case OPT_FRAMESKIP:
+          options.frameskip = atoi(var.value);
+          break;
+
+        case OPT_CORE_SYS_SUBFOLDER:
+          if(strcmp(var.value, "enabled") == 0)
+            options.system_subfolder = true;
+          else
+            options.system_subfolder = false;
+          break;       
+
+          case OPT_CORE_SAVE_SUBFOLDER:
+          if(strcmp(var.value, "enabled") == 0)
+            options.save_subfolder = true;
+          else
+            options.save_subfolder = false;
+          break;             
       }
     }
   }

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -80,6 +80,8 @@ enum
   OPT_INPUT_INTERFACE,  
   OPT_MAME_REMAPPING,
   OPT_4WAY,
+  OPT_CORE_SYS_SUBFOLDER,
+  OPT_CORE_SAVE_SUBFOLDER,
   OPT_end /* dummy last entry */
 };
 


### PR DESCRIPTION
One way in which MAME 2003 had to be ahead of the curve for most other libretro cores is in creating a primary subfolder in the SYSTEM and SAVE folders where all of its files can tidily exist separate from the SYSTEM and SAVE content from other cores that are installed alongside it.

Now in 2018, it is more clear that this is a scenario -- lots of core-generated files, some with filenames that can conflict with the filenames used by other installed cores -- needs a more standard solution and in fact there is one. RetroArch has already added an option to sort save files within a subfolder named after the core.

Without this PR, if a user has RetroArch configured to sort their save files, the result is a nested pair of mame2003-plus folders... not so nice.
![screenshot 2018-11-05 18 03 21](https://user-images.githubusercontent.com/19554678/48038375-2aa07b00-e125-11e8-8d01-771db0a8cc39.png)

I think one day there will also be an option within the RetroArch frontend (and other frontends) to sort their SYSTEM files this way too so I've pre-emptively added an option to disable that within the core as well.

This PR allows people who are already using the RetroArch option to sort their saves within named subfolders to have a sensible experience with this core. It also allows those who have installations built around the "legacy" behavior to continue on as-is with no change. Eventually I'd be interested in changing these to default to `disabled` but I don't feel there's a rush for that.
