### PR TITLE
add core option for cheat dipswitch/input port enable/disable

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1837,14 +1837,14 @@ InputSeq* input_port_seq(const struct InputPort *in)
 	{
 		type = (in-1)->type & (~IPF_MASK | IPF_PLAYERMASK);
 		/* if port is disabled, or cheat with cheats disabled, return no key */
-		if (((in-1)->type & IPF_UNUSED) || (! 0 && ((in-1)->type & IPF_CHEAT)))
+		if (((in-1)->type & IPF_UNUSED) || (!options.cheat_input_ports && ((in-1)->type & IPF_CHEAT)))
 			return &ip_none;
 	}
 	else
 	{
 		type = in->type & (~IPF_MASK | IPF_PLAYERMASK);
 		/* if port is disabled, or cheat with cheats disabled, return no key */
-		if ((in->type & IPF_UNUSED) || (! 0 && (in->type & IPF_CHEAT)))
+		if ((in->type & IPF_UNUSED) || (!options.cheat_input_ports && (in->type & IPF_CHEAT)))
 			return &ip_none;
 	}
 
@@ -1876,8 +1876,8 @@ void update_analog_port(int port)
 	/* get input definition */
 	in = input_analog[port];
 
-	/* this is a cheat-only port, bail */
-	if (in->type & IPF_CHEAT) return;
+	/* if we're not cheating and this is a cheat-only port, bail */
+	if (!options.cheat_input_ports && (in->type & IPF_CHEAT)) return;
 	type=(in->type & ~IPF_MASK);
 
 	decseq = input_port_seq(in);

--- a/src/mame.c
+++ b/src/mame.c
@@ -836,6 +836,7 @@ static void init_game_options(void)
   /* initialize the samplerate */
   
   Machine->sample_rate = options.samplerate;
+/* move this to a core option if you want it to toggle */
 
 }
 

--- a/src/mame.h
+++ b/src/mame.h
@@ -196,15 +196,15 @@ struct GameOptions
   mame_file *playback;		       /* handle to file to playback input from */
   mame_file *language_file;	     /* handle to file for localization */
 
-  int  content_flags[CONTENT_end];
+  int      content_flags[CONTENT_end];
 
-  char   *romset_filename_noext;
-  char   *libretro_content_path;
-  char   *libretro_system_path;
-  char   *libretro_save_path;
+  char     *romset_filename_noext;
+  char     *libretro_content_path;
+  char     *libretro_system_path;
+  char     *libretro_save_path;
 
-  int		   mame_debug;		       /* 1 to enable debugging */
-  int 	   skip_gameinfo;		     /* 1 to skip the game info screen at startup */
+  int      mame_debug;		       /* 1 to enable debugging */
+  int      skip_gameinfo;		     /* 1 to skip the game info screen at startup */
   bool 	   skip_disclaimer;	     /* 1 to skip the disclaimer screen at startup */
   bool     skip_warnings;        /* 1 to skip the game warning screen at startup */
   bool     display_setup;        /* the MAME setup menu */
@@ -223,30 +223,30 @@ struct GameOptions
   unsigned activate_dcs_speedhack;
   bool     mame_remapping;       /* display MAME input remapping menu */
 
-  int		   samplerate;		       /* sound sample playback rate, in KHz */
-  bool	   use_samples;	         /* 1 to enable external .wav samples */
+  int      samplerate;		       /* sound sample playback rate, in KHz */
+  bool     use_samples;	         /* 1 to enable external .wav samples */
 
   float	   brightness;		       /* brightness of the display */
   float	   pause_bright;		     /* additional brightness when in pause */
   float	   gamma;			           /* gamma correction of the display */
   int      frameskip;
-  int		   color_depth;	         /* valid: 15, 16, or 32. any other value means auto */
-  int		   ui_orientation;	     /* orientation of the UI relative to the video */
+  int      color_depth;	         /* valid: 15, 16, or 32. any other value means auto */
+  int      ui_orientation;	     /* orientation of the UI relative to the video */
       
-  int		   vector_width;	       /* requested width for vector games; 0 means default (640) */
-  int		   vector_height;	       /* requested height for vector games; 0 means default (480) */
+  int      vector_width;	       /* requested width for vector games; 0 means default (640) */
+  int      vector_height;	       /* requested height for vector games; 0 means default (480) */
   float    beam;                 /* vector beam width */
-  int	     vector_flicker;	     /* vector beam flicker effect control */
+  int      vector_flicker;	     /* vector beam flicker effect control */
   float	   vector_intensity_correction;   
-  int		   translucency;	       /* 1 to enable translucency on vectors */
-  int 	   antialias;		         /* 1 to enable antialiasing on vectors */
+  int      translucency;	       /* 1 to enable translucency on vectors */
+  int      antialias;		         /* 1 to enable antialiasing on vectors */
   unsigned vector_resolution_multiplier;
 
-  int		   use_artwork;	         /* bitfield indicating which artwork pieces to use */
-  int		   artwork_res;	         /* 1 for 1x game scaling, 2 for 2x */
-  int		   artwork_crop;	       /* 1 to crop artwork to the game screen */
+  int      use_artwork;	         /* bitfield indicating which artwork pieces to use */
+  int      artwork_res;	         /* 1 for 1x game scaling, 2 for 2x */
+  int      artwork_crop;	       /* 1 to crop artwork to the game screen */
 
-  char	   savegame;		         /* character representing a savegame to load */
+  char     savegame;		         /* character representing a savegame to load */
   int      crc_only;             /* specify if only CRC should be used as checksum */
   bool     nvram_bootstrap;
   
@@ -255,10 +255,11 @@ struct GameOptions
   bool     system_subfolder;     /* save all system files within a subfolder of the libretro system folder rather than directly in the system folder */
   bool     save_subfolder;       /* save all save files within a subfolder of the libretro system folder rather than directly in the system folder */  
   
-  int		   debug_width;	         /* requested width of debugger bitmap */
-  int		   debug_height;	       /* requested height of debugger bitmap */
-  int		   debug_depth;	         /* requested depth of debugger bitmap */
-};
+  int      debug_width;	         /* requested width of debugger bitmap */
+  int      debug_height;	       /* requested height of debugger bitmap */
+  int      debug_depth;	         /* requested depth of debugger bitmap */
+  bool     cheat_input_ports;     /*cheat input ports enable/disable */
+  };
 
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -646,8 +646,7 @@ bool retro_load_game(const struct retro_game_info *game)
   int              orientation    = 0;
   unsigned         rotateMode     = 0;
   static const int uiModes[]      = {ROT0, ROT90, ROT180, ROT270};
-  //move this to a more convient place if you want to it a core option mark
-  options.cheat_input_ports = false;
+
   if(string_is_empty(game->path))
   {
     log_cb(RETRO_LOG_ERROR, LOGPRE "Content path is not set. Exiting!\n");

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -152,7 +152,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_FRAMESKIP],           APPNAME"_frameskip",           "Frameskip; 0|1|2|3|4|5");
   init_default(&default_options[OPT_CORE_SYS_SUBFOLDER],  APPNAME"_core_sys_subfolder",  "Locate system files within a subfolder; enabled|disabled"); /* This should be probably handled by the frontend and not by cores per discussions in Fall 2018 but RetroArch for example doesn't provide this as an option. */
   init_default(&default_options[OPT_CORE_SAVE_SUBFOLDER], APPNAME"_core_save_subfolder", "Locate save files within a subfolder; enabled|disabled"); /* This is already available as an option in RetroArch although it is left enabled by default as of November 2018 for consistency with past practice. At least for now.*/
-
+  init_default(&default_options[OPT_Cheat_Input_Ports],   APPNAME"_cheat_input ports",   "Dip switch/Cheat input ports; disabled|enabled");
   init_default(&default_options[OPT_end], NULL, NULL);
   set_variables(true);
 }
@@ -547,8 +547,16 @@ static void update_variables(bool first_time)
             options.save_subfolder = true;
           else
             options.save_subfolder = false;
-          break;             
-      }
+          break;
+
+	    case OPT_Cheat_Input_Ports:
+          if(strcmp(var.value, "enabled") == 0)
+            options.cheat_input_ports = true;
+          else
+            options.cheat_input_ports = false;
+          break;		  
+
+	  }
     }
   }
  

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -646,7 +646,8 @@ bool retro_load_game(const struct retro_game_info *game)
   int              orientation    = 0;
   unsigned         rotateMode     = 0;
   static const int uiModes[]      = {ROT0, ROT90, ROT180, ROT270};
-
+  //move this to a more convient place if you want to it a core option mark
+  options.cheat_input_ports = false;
   if(string_is_empty(game->path))
   {
     log_cb(RETRO_LOG_ERROR, LOGPRE "Content path is not set. Exiting!\n");

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -81,7 +81,8 @@ enum /* controls the order in which core options appear. common, important, and 
   OPT_SAMPLE_RATE,  
   OPT_MAME_REMAPPING,
   OPT_BACKDROP,
-  OPT_NVRAM_BOOTSTRAP,  
+  OPT_NVRAM_BOOTSTRAP, 
+  OPT_Cheat_Input_Ports,
   OPT_end /* dummy last entry */
 };
 

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -1781,7 +1781,8 @@ static int setcodesettings(struct mame_bitmap *bitmap,int selected)
 	total = 0;
 	while (in->type != IPT_END)
 	{
-		if (input_port_name(in) != 0 && seq_get_1(&in->seq) != CODE_NONE && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION && !(!options.cheat_input_ports && (in->type & IPF_CHEAT))) 
+		if (input_port_name(in) != 0 && seq_get_1(&in->seq) != CODE_NONE && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION 
+		 && !( !options.cheat_input_ports && (in->type & IPF_CHEAT) ) ) 	
 		{
 			entry[total] = in;
 			menu_item[total] = input_port_name(in);

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -1470,7 +1470,7 @@ static int switchmenu(struct mame_bitmap *bitmap, int selected, UINT32 switch_na
 	{
 		if ((in->type & ~IPF_MASK) == switch_name && input_port_name(in) != 0 &&
 				(in->type & IPF_UNUSED) == 0 &&
-				!(in->type & IPF_CHEAT))
+				!(!options.cheat_input_ports && (in->type & IPF_CHEAT)))
 		{
 			entry[total] = in;
 			menu_item[total] = input_port_name(in);
@@ -1519,7 +1519,7 @@ static int switchmenu(struct mame_bitmap *bitmap, int selected, UINT32 switch_na
 		else
 		{
 			if (((in-1)->type & ~IPF_MASK) == switch_setting &&
-					!((in-1)->type & IPF_CHEAT))
+					!(!options.cheat_input_ports && ((in-1)->type & IPF_CHEAT)))
 				arrowize |= 1;
 		}
 	}
@@ -1536,7 +1536,7 @@ static int switchmenu(struct mame_bitmap *bitmap, int selected, UINT32 switch_na
 		else
 		{
 			if (((in+1)->type & ~IPF_MASK) == switch_setting &&
-					!((in+1)->type & IPF_CHEAT))
+					!(!options.cheat_input_ports && ((in+1)->type & IPF_CHEAT)))
 				arrowize |= 2;
 		}
 	}
@@ -1564,7 +1564,7 @@ static int switchmenu(struct mame_bitmap *bitmap, int selected, UINT32 switch_na
 			else
 			{
 				if (((in+1)->type & ~IPF_MASK) == switch_setting &&
-						!((in+1)->type & IPF_CHEAT))
+						!(!options.cheat_input_ports && ((in+1)->type & IPF_CHEAT)))
 					entry[sel]->default_value = (in+1)->default_value & entry[sel]->mask;
 			}
 
@@ -1588,7 +1588,7 @@ static int switchmenu(struct mame_bitmap *bitmap, int selected, UINT32 switch_na
 			else
 			{
 				if (((in-1)->type & ~IPF_MASK) == switch_setting &&
-						!((in-1)->type & IPF_CHEAT))
+						!(!options.cheat_input_ports && ((in-1)->type & IPF_CHEAT)))
 					entry[sel]->default_value = (in-1)->default_value & entry[sel]->mask;
 			}
 
@@ -1653,7 +1653,7 @@ static int setdefcodesettings(struct mame_bitmap *bitmap,int selected)
 	while (in->type != IPT_END)
 	{
 		if (in->name != 0  && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION && (in->type & IPF_UNUSED) == 0
-			&& !(in->type & IPF_CHEAT))
+			&& !(!options.cheat_input_ports && (in->type & IPF_CHEAT)))
 		{
 			entry[total] = in;
 			menu_item[total] = in->name;
@@ -1781,7 +1781,7 @@ static int setcodesettings(struct mame_bitmap *bitmap,int selected)
 	total = 0;
 	while (in->type != IPT_END)
 	{
-		if (input_port_name(in) != 0 && seq_get_1(&in->seq) != CODE_NONE && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION)
+		if (input_port_name(in) != 0 && seq_get_1(&in->seq) != CODE_NONE && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION && !(!options.cheat_input_ports && (in->type & IPF_CHEAT))) 
 		{
 			entry[total] = in;
 			menu_item[total] = input_port_name(in);
@@ -1976,7 +1976,7 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 	while (in->type != IPT_END)
 	{
 		if (((in->type & 0xff) > IPT_ANALOG_START) && ((in->type & 0xff) < IPT_ANALOG_END)
-				&& !(in->type & IPF_CHEAT))
+				&& !(!options.cheat_input_ports && (in->type & IPF_CHEAT)))
 		{
 			entry[total] = in;
 			total++;


### PR DESCRIPTION
Im not sure if you want this as a core option or just off if its just off ill just remove the core option part of the code just let me know. ill add screen shots of the differences with the assault thisgame menu. 

Ive also added some parts of the input code that needed fixed up where it was removed before when the cheat flag is active,

I also added the code for the dipswitches as well to show/hide the cheat input code back and added the code that was missing from input this game to do the same as the dip-switches this was missing in mame078.


![assault-181114-064024](https://user-images.githubusercontent.com/6128601/48471529-fe9f8c80-e7eb-11e8-9900-b1121444e784.png)
![assault-181114-085047](https://user-images.githubusercontent.com/6128601/48471530-fe9f8c80-e7eb-11e8-83a7-c37d6d297649.png)





