### PR TITLE
 Revert "dont optimize draw_screen breaks on a few builds"

### DIFF
--- a/src/vidhrdw/namcos1_vidhrdw.c
+++ b/src/vidhrdw/namcos1_vidhrdw.c
@@ -490,10 +490,6 @@ static void draw_sprites(struct mame_bitmap *bitmap,const struct rectangle *clip
 }
 #endif
 
-
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-
 static void namcos1_draw_screen(struct mame_bitmap *bitmap, const struct rectangle *cliprect)
 {
 	int i, j, scrollx, scrolly, priority;
@@ -567,7 +563,6 @@ static void namcos1_draw_screen(struct mame_bitmap *bitmap, const struct rectang
 		draw_sprites(bitmap, cliprect, sp_updatebuffer);
 #endif
 }
-#pragma GCC pop_options
 
 
 VIDEO_START( namcos1 )


### PR DESCRIPTION
This reverts commit 149b5464d43794af2d84b9d7bde8b3ac59523e0d.

this is not needed anymore the problem was fixed properly with e40f75ed4293d106bc63e625d0fcd72cd5778c6c

@markwkidd this needs done on mame2003 the revert sha is aa31059233287bf9781098836cd61d4b86264c53 for mame2003