### PR TITLE
restore default sound volume in vsnesc driver

### DIFF
--- a/src/drivers/vsnes.c
+++ b/src/drivers/vsnes.c
@@ -2087,13 +2087,13 @@ static struct NESinterface nes_interface =
 {
 	1,
 	{ REGION_CPU1 },
-	{ 25 },
+	{ 50 },
 };
 
 static struct DACinterface nes_dac_interface =
 {
 	1,
-	{ 18 },
+	{ 50 },
 };
 
 static struct NESinterface nes_dual_interface =
@@ -2106,7 +2106,7 @@ static struct NESinterface nes_dual_interface =
 static struct DACinterface nes_dual_dac_interface =
 {
 	2,
-	{ 18, 18 },
+	{ 25, 25 },
 };
 
 static MACHINE_DRIVER_START( vsnes )


### PR DESCRIPTION
This reverses changes to the DAC initialization which @grant2258 and I made before we realized that the audio problem that Nintendo Switch users were having was a signed/unsigned char issue rather than audio clipping.

The commits are:
* https://github.com/libretro/mame2003-plus-libretro/commit/4dec18288453621c4d1387fc667b0d418d8a81d4
* https://github.com/libretro/mame2003-plus-libretro/commit/f4735eb1bd8e97c7de2a94d5d89794fcfc40c177