### PR TITLE
Remove nrallyv hack

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -493,7 +493,6 @@ const struct GameDriver *test_drivers[] =
 	DRIVER( rallyx )	/* (c) 1980 Namco */
 	DRIVER( rallyxm )	/* (c) 1980 Midway */
 	DRIVER( nrallyx )	/* (c) 1981 Namco */
-	DRIVER( nrallyv )	/* hack */
 	DRIVER( jungler )	/* GX327 (c) 1981 Konami */
 	DRIVER( junglers )	/* GX327 (c) 1981 Stern */
 	DRIVER( tactcian )	/* GX335 (c) 1982 Sega */

--- a/src/drivers/rallyx.c
+++ b/src/drivers/rallyx.c
@@ -454,6 +454,7 @@ ROM_START( nrallyx )
 	ROM_LOAD( "im5623.2m",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) )  /* timing - not used */
 ROM_END
 
+#if 0
 ROM_START( nrallyv )
 	ROM_REGION( 0x10000, REGION_CPU1, 0 )	/* 64k for code */
 	ROM_LOAD( "nrallyx.1b",   0x0000, 0x1000, CRC(9404c8d6) SHA1(ee7e45c22a2fbf72d3ac5ac26ab1111a22623fc5) )
@@ -475,9 +476,9 @@ ROM_START( nrallyv )
 	ROM_LOAD( "nrallyx.spr",  0x0000, 0x0100, CRC(b75c4e87) SHA1(450f79a5ae09e34f7624d37769815baf93c0028e) )
 	ROM_LOAD( "im5623.2m",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) )  /* timing - not used */
 ROM_END
-
+#endif
 
 GAME( 1980, rallyx,  0,       rallyx, rallyx,  0, ROT0, "Namco", "Rally X" )
 GAME( 1980, rallyxm, rallyx,  rallyx, rallyx,  0, ROT0, "[Namco] (Midway license)", "Rally X (Midway)" )
 GAME( 1981, nrallyx, 0,       rallyx, nrallyx, 0, ROT0, "Namco", "New Rally X" )
-GAME( 1981, nrallyv, nrallyx, rallyx, nrallyv, 0, ROT90, "hack", "New Rally X (Vertical Screen)" )
+/*GAME( 1981, nrallyv, nrallyx, rallyx, nrallyv, 0, ROT90, "hack", "New Rally X (Vertical Screen)" )*/


### PR DESCRIPTION
This is another product of my metadata project. In MAME 0.78u1 `nrallyv` was removed as a simple graphic hack.

> 0.78u1: Stefan Jokisch added proms ($120, 140 - vertical sync). Removed New Rally-X (vertical hack), because the graphic hack (rotated tiles + display) not worth supporting.

I'd propose to do the same in this core by commenting out the `nrallyv`. Maybe if there is an `#ifdef HACKS_MODE` one day we could put this driver in there. Is this OK with you all?