### PR TITLE
add core option do disable the audio bypass 

### DIFF
--- a/src/mame.h
+++ b/src/mame.h
@@ -259,6 +259,7 @@ struct GameOptions
   int      debug_height;	       /* requested height of debugger bitmap */
   int      debug_depth;	         /* requested depth of debugger bitmap */
   bool     cheat_input_ports;     /*cheat input ports enable/disable */
+  bool     machine_timing;         
   };
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -602,7 +602,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
   else
   {
     info->timing.fps = Machine->drv->frames_per_second; /* sets the core timing does any game go above 60fps? */
-    info->timing.sample_rate = 30000;
+    info->timing.sample_rate = options.samplerate;
   }
 }
 
@@ -1235,12 +1235,12 @@ if (options.machine_timing)
  }
  else 
  {
-	 Machine->sample_rate = 30000; 
+	 Machine->sample_rate = options.samplerate; 
 	 delta_samples = 0.0f;
 	usestereo = stereo ? 1 : 0;
 
 	/* determine the number of samples per frame */
-	samples_per_frame = Machine->sample_rate / Machine->drv->frames_per_second;
+	samples_per_frame = ( Machine->sample_rate / Machine->drv->frames_per_second ) / Machine->drv->frames_per_second * (Machine->drv->frames_per_second) ; 
 	orig_samples_per_frame = samples_per_frame;
 
 	if (Machine->sample_rate == 0) return 0;
@@ -1278,7 +1278,7 @@ int osd_update_audio_stream(INT16 *buffer)
 		if ( samples_per_frame  != orig_samples_per_frame ) samples_per_frame = orig_samples_per_frame;
 		
 		// dont drop any sample frames some games like mk will drift with time
-   		delta_samples += (Machine->sample_rate / Machine->drv->frames_per_second) - orig_samples_per_frame;
+   		delta_samples += ( Machine->sample_rate / Machine->drv->frames_per_second ) / Machine->drv->frames_per_second * (Machine->drv->frames_per_second) - orig_samples_per_frame;
 		if ( delta_samples >= 1.0f )
 		{
 		
@@ -1296,6 +1296,7 @@ int osd_update_audio_stream(INT16 *buffer)
 	}
         return samples_per_frame;
 }
+
 
 void osd_stop_audio_stream(void)
 {

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -143,7 +143,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_VECTOR_FLICKER],      APPNAME"_vector_flicker",      "Vector flicker; 20|0|10|30|40|50|60|70|80|90|100");
   init_default(&default_options[OPT_VECTOR_INTENSITY],    APPNAME"_vector_intensity",    "Vector intensity; 1.5|0.5|1|2|2.5|3");
   init_default(&default_options[OPT_NVRAM_BOOTSTRAP],     APPNAME"_nvram_bootstraps",    "NVRAM Bootstraps; enabled|disabled");
-  init_default(&default_options[OPT_SAMPLE_RATE],         APPNAME"_sample_rate",         "Sample Rate (KHz); 48000|8000|11025|22050|44100");
+  init_default(&default_options[OPT_SAMPLE_RATE],         APPNAME"_sample_rate",         "Sample Rate (KHz); 30000|8000|11025|22050|44100|48000");
   init_default(&default_options[OPT_DCS_SPEEDHACK],       APPNAME"_dcs_speedhack",       "DCS Speedhack; enabled|disabled");
   init_default(&default_options[OPT_INPUT_INTERFACE],     APPNAME"_input_interface",     "Input interface; retroarch|keyboard|mame");  
   init_default(&default_options[OPT_MAME_REMAPPING],      APPNAME"_mame_remapping",      "Legacy Remapping (!NETPLAY); disabled|enabled");  
@@ -1278,7 +1278,8 @@ int osd_update_audio_stream(INT16 *buffer)
 		if ( samples_per_frame  != orig_samples_per_frame ) samples_per_frame = orig_samples_per_frame;
 		
 		// dont drop any sample frames some games like mk will drift with time
-   		delta_samples += ( Machine->sample_rate / Machine->drv->frames_per_second ) / Machine->drv->frames_per_second * (Machine->drv->frames_per_second) - orig_samples_per_frame;
+		if (!options.machine_timing)  		delta_samples += ( Machine->sample_rate / Machine->drv->frames_per_second ) / Machine->drv->frames_per_second * (Machine->drv->frames_per_second) - orig_samples_per_frame;
+		else delta_samples += (Machine->sample_rate / Machine->drv->frames_per_second) - orig_samples_per_frame;
 		if ( delta_samples >= 1.0f )
 		{
 		

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -83,6 +83,7 @@ enum /* controls the order in which core options appear. common, important, and 
   OPT_BACKDROP,
   OPT_NVRAM_BOOTSTRAP, 
   OPT_Cheat_Input_Ports,
+  OPT_Machine_Timing,
   OPT_end /* dummy last entry */
 };
 


### PR DESCRIPTION
This is to keep the RA compatibility more. If you turn this off please set you you audio scew to 0.03 and restart the core else some games will run too fast. 

The reason the bypass is here is so users do not need to do this thanks 