### PR TITLE
fix segfault when gamename does not exist in mame

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -681,20 +681,19 @@ bool retro_load_game(const struct retro_game_info *game)
     if ((strcasecmp(driver_lookup, needle->description) == 0) 
       || (strcasecmp(driver_lookup, needle->name) == 0) )
     {
-      log_cb(RETRO_LOG_INFO, LOGPRE "Total game drivers: %i. Matched game driver: %s.\n", (int) total_drivers, needle->name);
+      log_cb(RETRO_LOG_INFO, LOGPRE "Driver index counter: %d. Matched game driver: %s.\n",  driverIndex, needle->name);
       game_driver = needle;
       options.romset_filename_noext = driver_lookup;
       break;
     }
-  }
-
-  if(driverIndex == total_drivers)
-  {
-      log_cb(RETRO_LOG_ERROR, LOGPRE "Total game drivers: %i. Game driver not found for selected game!", (int) total_drivers);
+	if(driverIndex == total_drivers -2) // we could fix the total drives in drivers c but the it pointless its taken into account here
+	{
+      log_cb(RETRO_LOG_ERROR, LOGPRE "Driver index counter: %d. Game driver not found for %s!\n", driverIndex, needle->name);
       return false;
-  }
+	}
+ }
 
-  if(!init_game(driverIndex))
+   if(!init_game(driverIndex))
     return false;  
   set_content_flags();
 


### PR DESCRIPTION
This was a particularly bad bug ive known about but seemed to always forget about never got round to fixing it. 

The problem is if the game name did not match out driver list we would segfault. This shouldn't happen ever.

sets change names if fba and different mame versions this will give us the failed to load contents message. Now this is fixed we know if we get a bug report of a crash its really a crash.

please see 
https://github.com/libretro/mame2003-plus-libretro/issues/440#issuecomment-445488380

about the boom.zip