### PR TITLE
restore Nebulous Bee bootleg

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -512,7 +512,7 @@ const struct GameDriver *test_drivers[] =
 	DRIVER( galagao )	
 	DRIVER( gallag )	/* bootleg */
 	DRIVER( galagamk ) 	
-//	DRIVER( nebulbee )	/* hack */
+	DRIVER( nebulbee )	/* hack */
 	DRIVER( gatsbee )	/* (c) 1984 Uchida / hack */
 	DRIVER( digdug )	/* (c) 1982 */
 	DRIVER( digdugb )	/* (c) 1982 */

--- a/src/drivers/galaga.c
+++ b/src/drivers/galaga.c
@@ -2511,6 +2511,36 @@ ROM_START( gatsbee )
 ROM_END
 
 
+ROM_START( nebulbee )
+	ROM_REGION( 0x10000, REGION_CPU1, 0 )     /* 64k for code for the first CPU  */
+	ROM_LOAD( "nebulbee.01",  0x0000, 0x1000, CRC(f405f2c4) SHA1(9249afeffd8df0f24539ea9b4f88c23a6ad58d8c) )
+	ROM_LOAD( "nebulbee.02",  0x1000, 0x1000, CRC(31022b60) SHA1(90e64afb4128c6dfeeee89635ea9f97a34f70f5f) )
+	ROM_LOAD( "04j_g03.bin",  0x2000, 0x1000, CRC(753ce503) SHA1(481f443aea3ed3504ec2f3a6bfcf3cd47e2f8f81) )
+	ROM_LOAD( "nebulbee.04",  0x3000, 0x1000, CRC(d76788a5) SHA1(adcb83cf64951d86c701a99b410e9230912f8a48) )
+
+	ROM_REGION( 0x10000, REGION_CPU2, 0 )     /* 64k for the second CPU */
+	ROM_LOAD( "04e_g05.bin",  0x0000, 0x1000, CRC(3102fccd) SHA1(d29b68d6aab3217fa2106b3507b9273ff3f927bf) )
+
+	ROM_REGION( 0x10000, REGION_CPU3, 0 )     /* 64k for the third CPU  */
+	ROM_LOAD( "04d_g06.bin",  0x0000, 0x1000, CRC(8995088d) SHA1(d6cb439de0718826d1a0363c9d77de8740b18ecf) )
+
+	ROM_REGION( 0x1000, REGION_GFX1, ROMREGION_DISPOSE )
+	ROM_LOAD( "07m_g08.bin",  0x0000, 0x1000, CRC(58b2f47c) SHA1(62f1279a784ab2f8218c4137c7accda00e6a3490) )
+
+	ROM_REGION( 0x2000, REGION_GFX2, ROMREGION_DISPOSE )
+	ROM_LOAD( "07e_g10.bin",  0x0000, 0x1000, CRC(ad447c80) SHA1(e697c180178cabd1d32483c5d8889a40633f7857) )
+	ROM_LOAD( "07h_g09.bin",  0x1000, 0x1000, CRC(dd6f1afc) SHA1(c340ed8c25e0979629a9a1730edc762bd72d0cff) )
+
+	ROM_REGION( 0x0320, REGION_PROMS, 0 )
+	ROM_LOAD( "5n.bin",       0x0000, 0x0020, CRC(54603c6b) SHA1(1a6dea13b4af155d9cb5b999a75d4f1eb9c71346) )	/* palette */
+	ROM_LOAD( "2n.bin",       0x0020, 0x0100, CRC(a547d33b) SHA1(7323084320bb61ae1530d916f5edd8835d4d2461) )	/* char lookup table */
+	ROM_LOAD( "1c.bin",       0x0120, 0x0100, CRC(b6f585fb) SHA1(dd10147c4f05fede7ae6e7a760681700a660e87e) )	/* sprite lookup table */
+	ROM_LOAD( "5c.bin",       0x0220, 0x0100, CRC(8bd565f6) SHA1(bedba65816abfc2ebeacac6ee335ca6f136e3e3d) )	/* unknown */
+
+	ROM_REGION( 0x0100, REGION_SOUND1, 0 )	/* sound prom */
+	ROM_LOAD( "1d.bin",       0x0000, 0x0100, CRC(86d92b24) SHA1(6bef9102b97c83025a2cf84e89d95f2d44c3d2ed) )
+ROM_END
+
 
 ROM_START( xevious )
 	ROM_REGION( 0x10000, REGION_CPU1, 0 )	/* 64k for the first CPU */
@@ -3131,10 +3161,12 @@ GAMEX(1981, boscomdo, bosco,   bosco,   boscomd,  0,       ROT0,  "[Namco] (Midw
 
 GAMEX(1981, galaga,   0,       galaga,  galaga,   galaga,  ROT90, "Namco", "Galaga (Namco rev. B)", GAME_IMPERFECT_GRAPHICS )
 GAMEX(1981, galagao,  galaga,  galaga,  galaga,   galaga,  ROT90, "Namco", "Galaga (Namco)", GAME_IMPERFECT_GRAPHICS )
-GAMEX(1981, galagamw, galaga,  galaga,  galagamw, galaga,  ROT90, "[Namco] (Midway license)", "Galaga (Midway set 1)", GAME_IMPERFECT_GRAPHICS )
-GAMEX(1981, galagamk, galaga,  galaga,  galaga,   galaga,  ROT90, "[Namco] (Midway license)", "Galaga (Midway set 2)", GAME_IMPERFECT_GRAPHICS )
-GAMEX(1981, gallag,   galaga,  galagab, galaga,   galaga,  ROT90, "bootleg", "Gallag", GAME_IMPERFECT_GRAPHICS )
-GAMEX(1984, gatsbee,  galaga,  galagab, galaga,   gatsbee, ROT90, "hack", "Gatsbee", GAME_IMPERFECT_GRAPHICS )
+GAMEX(1981, galagamw, galaga,  galaga,  galagamw, galaga,  ROT90, "Namco (Midway license)", "Galaga (Midway set 1)", GAME_IMPERFECT_GRAPHICS )
+GAMEX(1981, galagamk, galaga,  galaga,  galaga,   galaga,  ROT90, "Namco (Midway license)", "Galaga (Midway set 2)", GAME_IMPERFECT_GRAPHICS )
+
+GAMEX(1981, gallag,   galaga,  galagab, galaga,   galaga,  ROT90, "bootleg",       "Gallag",        GAME_IMPERFECT_GRAPHICS )
+GAMEX(1984, gatsbee,  galaga,  galagab, galaga,   gatsbee, ROT90, "hack (Uchida)", "Gatsbee",       GAME_IMPERFECT_GRAPHICS )
+GAMEX(1984, nebulbee, galaga,  galaga,  galaga,   galaga,  ROT90, "bootleg",       "Nebulous Bee",  GAME_IMPERFECT_GRAPHICS )
 
 GAME( 1982, xevious,  0,       xevious, xevious,  xevious, ROT90, "Namco", "Xevious (Namco)" )
 GAME( 1982, xeviousa, xevious, xevious, xeviousa, xevious, ROT90, "Namco (Atari license)", "Xevious (Atari set 1)" )


### PR DESCRIPTION
Nebulous Bee was removed in 0.79u1 as being a hack, but it is in fact a real bootleg PCB that is found in the wild.

It's been added back to MAME and so I thought I'd try adding it back here. I think this was a straightforward "re-add the ROMs and tweak the Nebulous Bee driver declaration so that it uses the new `galaga` init" ... right?

@arcadez and @grant2258 -- does this look about right? the game seems to run ... just want to make sure I've not just added code that will explode the core :)