### PR TITLE
stop rewind crashing for incompatible save state games

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1116,18 +1116,18 @@ void retro_deinit(void)
 #endif
 }
 
+   extern size_t state_get_dump_size(void);
 
 size_t retro_serialize_size(void)
 {
-    extern size_t state_get_dump_size(void);
-    
+     
     return state_get_dump_size();
 }
 
 bool retro_serialize(void *data, size_t size)
 {
    int cpunum;
-	if( ( retro_serialize_size() ) && (data)  && (size) )
+	if(  retro_serialize_size() == size  && size   )
 	{
 		/* write the save state */
 		state_save_save_begin(data);


### PR DESCRIPTION
I know asterix save states arent working on mame078 either. I have changed the code not crash when the size changes. It seems common on the games that crash the first loop is a different size. The states still need work done but some will work some wont. The interrupts really need handled properly in some games for this to work properly.  If you rewind too far on a game that doesnt work just reset. 