### PR TITLE
fixed typo in Makefile (fpic = -fPICb)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ endif
 
 ifeq ($(platform), unix)
    TARGET = $(TARGET_NAME)_libretro.so
-   fpic = -fPICb
+   fpic = -fPIC
    CFLAGS += $(fpic)
    LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
 


### PR DESCRIPTION
Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
