### PR TITLE
Mr Do color palette correction and clock frequencies adjustment

### DIFF
--- a/src/drivers/mrdo.c
+++ b/src/drivers/mrdo.c
@@ -5,10 +5,10 @@ Mr Do!
 driver by Nicola Salmoria
 
 
-Video clock: XTAL = 20 MHz
-Horizontal video frequency: HSYNC = XTAL/4/312 = 16.02564103 kHz
-Video frequency: VSYNC = HSYNC/262 = 61.1665688 Hz
-VBlank duration: 1/VSYNC * (70/262) = 4368 us
+Video clock: XTAL = 19.6 MHz
+Horizontal video frequency: HSYNC = XTAL/4/312 = 15.7051282051 kHz
+Video frequency: VSYNC = HSYNC/262 = 59.94323742 Hz
+VBlank duration: 1/VSYNC * (70/262) = 4457 us
 
 ***************************************************************************/
 
@@ -16,7 +16,8 @@ VBlank duration: 1/VSYNC * (70/262) = 4368 us
 #include "vidhrdw/generic.h"
 #include "cpu/z80/z80.h"
 
-
+#define MAIN_CLOCK   8200000	/* XTAL_8_2MHz */
+#define VIDEO_CLOCK 19600000.0	/* XTAL_19_6_MHz */
 
 extern unsigned char *mrdo_bgvideoram,*mrdo_fgvideoram;
 WRITE_HANDLER( mrdo_bgvideoram_w );
@@ -179,7 +180,7 @@ static struct GfxDecodeInfo gfxdecodeinfo[] =
 static struct SN76496interface sn76496_interface =
 {
 	2,	/* 2 chips */
-	{ 4000000, 4000000 },	/* 4 MHz */
+	{ MAIN_CLOCK/2, MAIN_CLOCK/2 },	/* 4.1 MHz */
 	{ 50, 50 }
 };
 
@@ -188,12 +189,12 @@ static struct SN76496interface sn76496_interface =
 static MACHINE_DRIVER_START( mrdo )
 
 	/* basic machine hardware */
-	MDRV_CPU_ADD(Z80,8000000/2)	/* 4 MHz */
+	MDRV_CPU_ADD(Z80,MAIN_CLOCK/2)	/* 4.1 MHz */
 	MDRV_CPU_MEMORY(readmem,writemem)
 	MDRV_CPU_VBLANK_INT(irq0_line_hold,1)
 
-	MDRV_FRAMES_PER_SECOND(5000000.0/312/262)
-	MDRV_VBLANK_DURATION(4368)
+	MDRV_FRAMES_PER_SECOND((VIDEO_CLOCK/4)/312/262)
+	MDRV_VBLANK_DURATION(4457)
 
 	/* video hardware */
 	MDRV_VIDEO_ATTRIBUTES(VIDEO_TYPE_RASTER)

--- a/src/vidhrdw/mrdo_vidhrdw.c
+++ b/src/vidhrdw/mrdo_vidhrdw.c
@@ -57,19 +57,19 @@ PALETTE_INIT( mrdo )
 	const int R2 = 120;
 	const int R3 = 100;
 	const int R4 = 75;
-	const int pull = 200;
+	const int pull = 220;
 	float pot[16];
 	int weight[16];
-	const float potadjust = 0.2;	/* diode voltage drop */
+	const float potadjust = 0.7f;	/* diode voltage drop */
 
-	for (i = 15;i >= 0;i--)
+	for (i = 0x0f;i >= 0;i--)
 	{
 		float par = 0;
 
-		if (i & 1) par += 1.0/R1;
-		if (i & 2) par += 1.0/R2;
-		if (i & 4) par += 1.0/R3;
-		if (i & 8) par += 1.0/R4;
+		if (i & 1) par += 1.0f/(float)R1;
+		if (i & 2) par += 1.0f/(float)R2;
+		if (i & 4) par += 1.0f/(float)R3;
+		if (i & 8) par += 1.0f/(float)R4;
 		if (par)
 		{
 			par = 1/par;
@@ -77,10 +77,11 @@ PALETTE_INIT( mrdo )
 		}
 		else pot[i] = 0;
 
-		weight[i] = 255 * pot[i] / pot[15];
+		weight[i] = 0xff * pot[i] / pot[0x0f];
+		if (weight[i] < 0) weight[i] = 0;
 	}
 
-	for (i = 0;i < 256;i++)
+	for (i = 0;i < 0x100;i++)
 	{
 		int a1,a2;
 		int bits0,bits2,r,g,b;
@@ -100,19 +101,22 @@ PALETTE_INIT( mrdo )
 		palette_set_color(i,r,g,b);
 	}
 
-	color_prom += 64;
+	color_prom += 0x40;
+
+        /* characters */
+        for (i = 0; i < 0x100; i++)
+               COLOR(0,i) = i;
 
 	/* sprites */
-	for (i = 0;i < TOTAL_COLORS(2);i++)
+	for (i = 0x100; i < 0x140 ; i++)
 	{
-		int bits;
-
-		if (i < 32)
-			bits = color_prom[i] & 0x0f;		/* low 4 bits are for sprite color n */
+		unsigned char ctabentry = color_prom[(i - 0x100) & 0x1f];
+		if ((i - 0x100) & 0x20)
+			ctabentry >>= 4;	/* high 4 bits are for sprite color n + 8 */
 		else
-			bits = color_prom[i & 0x1f] >> 4;	/* high 4 bits are for sprite color n + 8 */
+			ctabentry &= 0x0f;	/* low 4 bits are for sprite color n */
 
-		COLOR(2,i) = bits + ((bits & 0x0c) << 3);
+		COLOR(1,i) = (ctabentry + ((ctabentry & 0x0c) << 3));
 	}
 }
 


### PR DESCRIPTION
Ported color palette and clock frequencies changes from MAME 0.205 code base. Tested changes on Retropie with the 7 known versions as supported in src/drivers/mrdo.c. Sprite colors and background colors now match MAME 0.205.

-cataylox 
