### PR TITLE
fix segfault when loggin is on

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -791,7 +791,7 @@ bool retro_load_game(const struct retro_game_info *game)
   
   for(port_index = DISP_PLAYER6 - 1; port_index > (options.content_flags[CONTENT_CTRL_COUNT] - 1); port_index--)
   {
-    retropad_subdevice_ports[port_index].types       = &unsupported_controllers[port_index];
+    retropad_subdevice_ports[port_index].types       = &unsupported_controllers[0];
     retropad_subdevice_ports[port_index].num_types   = 4;
   }
 


### PR DESCRIPTION
Made a little mistake by guessing what the code does. I found the issue when I put logging on and  then debugging the code. The pointer is fixed properly and the controls still save on exit sorry about that.