### PR TITLE
WIP ignore only control mappings in the cfg

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -176,6 +176,10 @@ static int input_port_read_ver_8(mame_file *f, struct InputPort *in)
 {
 	UINT32 i;
 	UINT16 w;
+  
+  if(!options.mame_remapping)
+    return 0;
+  
 	if (readint(f,&i) != 0)
 		return -1;
 	in->type = i;
@@ -288,10 +292,7 @@ static unsigned int count_input_ports(const struct InputPort *in)
 
 config_file *config_open(const char *name)
 {
-	if(options.mame_remapping)
-    return config_init(name, 0);
-
-  return NULL;
+  return config_init(name, 0);
 }
 
 
@@ -302,10 +303,7 @@ config_file *config_open(const char *name)
 
 config_file *config_create(const char *name)
 {
-	if(options.mame_remapping)
-    return config_init(name, 1);
-
-  return NULL;
+  return config_init(name, 1);
 }
 
 


### PR DESCRIPTION
@nayslayer pardon me for peeking into your repository, but I am doing a bunch of porting/synchronization between MAME 2003 and MAME 2003-Plus.

Specifically I'm now syncing some of the input code, and I was looking at your lightgun branch when I noticed this patch. Given that you didn't offer it to the core, this seems like an improvement over the current code.

Would you be OK having it added? If so, are there any issues with it other than the merge conflict from the new analog code?