### PR TITLE
avoid using "round" function (not in MSVC 2010)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -565,9 +565,6 @@ endif
 # for example, audio on rtype leo is wrong on ARM without this flag
 CFLAGS += -fsigned-char
 
-# include the math library
-CFLAGS += -lm
-
 # Use position-independent code for all platforms
 CFLAGS += $(fpic)
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1925,7 +1925,7 @@ int convert_analog_scale(int input)
 		// Re-scale analog range
 		float scaled = (input - trigger_deadzone)*scale;
 
-		input = (int)round(scaled);
+		input = roundf(scaled);
 		if (input > +32767) 
 		{
 			input = +32767;


### PR DESCRIPTION
Howdy @grant2258 ! It seems MSVC's `math.h` simply doesn't have a `round` function. Our options as I know them include defining `round` behind an MSVC `ifdef` or avoiding using the round function.

This PR takes the latter approach -- and this should be right, right? But it's all up to you how to proceed.