### PR TITLE
fix vectror gfx setting up

### DIFF
--- a/src/mame.c
+++ b/src/mame.c
@@ -822,6 +822,8 @@ static void init_game_options(void)
   }
 
   /* update the vector width/height with defaults */
+  options.vector_width=640;
+  options.vector_width=480;
   if (options.vector_width  == 0) options.vector_width  = Machine->drv->screen_width;
   if (options.vector_height == 0) options.vector_height = Machine->drv->screen_height;
   

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -205,9 +205,9 @@ static void init_core_options(void)
   init_default(&default_options[OPT_SCALE],               APPNAME"_analogscale",         "Analog scale type; rsn8887|grant2258");
   init_default(&default_options[OPT_TATE_MODE],           APPNAME"_tate_mode",           "TATE Mode; disabled|enabled");
   init_default(&default_options[OPT_VECTOR_RESOLUTION],   APPNAME"_vector_resolution_multiplier",
-                                                                                         "Vector resolution multiplier (Restart core); 3|1|2|4|5|6|7|8|9|10");
+                                                                                         "Vector resolution multiplier (Restart core); 2|1|3|4|5|6|7|8|9|10");
   init_default(&default_options[OPT_VECTOR_ANTIALIAS],    APPNAME"_vector_antialias",    "Vector antialiasing; enabled|disabled");
-  init_default(&default_options[OPT_VECTOR_BEAM],         APPNAME"_vector_beam_width",   "Vector beam width (only with antialiasing); 1.2|1|1.4|1.6|1.8|2|2.5|3|4|5|6|7|8|9|10|11|12");
+  init_default(&default_options[OPT_VECTOR_BEAM],         APPNAME"_vector_beam_width",   "Vector beam width (only with antialiasing); 1|1.2|1.4|1.6|1.8|2|2.5|3|4|5|6|7|8|9|10|11|12");
   init_default(&default_options[OPT_VECTOR_TRANSLUCENCY], APPNAME"_vector_translucency", "Vector translucency; enabled|disabled");
   init_default(&default_options[OPT_VECTOR_FLICKER],      APPNAME"_vector_flicker",      "Vector flicker; 20|0|10|30|40|50|60|70|80|90|100");
   init_default(&default_options[OPT_VECTOR_INTENSITY],    APPNAME"_vector_intensity",    "Vector intensity; 1.5|0.5|1|2|2.5|3");

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -205,7 +205,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_SCALE],               APPNAME"_analogscale",         "Analog scale type; rsn8887|grant2258");
   init_default(&default_options[OPT_TATE_MODE],           APPNAME"_tate_mode",           "TATE Mode; disabled|enabled");
   init_default(&default_options[OPT_VECTOR_RESOLUTION],   APPNAME"_vector_resolution_multiplier",
-                                                                                         "Vector resolution multiplier (Restart core); 2|1|3|4|5|6|7|8|9|10");
+                                                                                         "Vector resolution multiplier (Restart core); 2|1|3");
   init_default(&default_options[OPT_VECTOR_ANTIALIAS],    APPNAME"_vector_antialias",    "Vector antialiasing; enabled|disabled");
   init_default(&default_options[OPT_VECTOR_BEAM],         APPNAME"_vector_beam_width",   "Vector beam width (only with antialiasing); 1|1.2|1.4|1.6|1.8|2|2.5|3|4|5|6|7|8|9|10|11|12");
   init_default(&default_options[OPT_VECTOR_TRANSLUCENCY], APPNAME"_vector_translucency", "Vector translucency; enabled|disabled");


### PR DESCRIPTION
due to the change in aspect ratios that where requested to be change it had a knock on effect on vector games as the code was set to use mames aspect ratio .

they run 800x600 by default * whatever res you choose. since we clamped the aspect ratio for overlays this doesn't fair well it all been fix up and the resoultions are as follows 

x1 is 640 x 480
x2 is 1280 x 960
x3 is 1920 x 1140

@UDb23 this means you can do hd for vector games at x3 it will scale perfect.

the default settings are x2 with a beam width of 1 this can change by default if the pi coupes well with x3 