### PR TITLE
Vector resolution changes

### DIFF
--- a/src/mame.c
+++ b/src/mame.c
@@ -821,15 +821,11 @@ static void init_game_options(void)
     alpha_init();
   }
 
-  /* update the vector width/height with defaults */
-  options.vector_width=640;
-  options.vector_height=480;
+  /* update the vector width/height with libretro settings or use the default */
   if (options.vector_width  == 0) options.vector_width  = Machine->drv->screen_width;
   if (options.vector_height == 0) options.vector_height = Machine->drv->screen_height;
   
-  /* apply the vector resolution multiplier */
-	options.vector_width  *= options.vector_resolution_multiplier;
-	options.vector_height *= options.vector_resolution_multiplier;
+
 
   /* get orientation right */
   Machine->orientation    = ROT0;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -204,8 +204,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_DEADZONE],            APPNAME"_deadzone",            "Analog deadzone; 20|0|5|10|15|25|30|35|40|45|50|55|60|65|70|75|80|85|90|95");
   init_default(&default_options[OPT_SCALE],               APPNAME"_analogscale",         "Analog scale type; rsn8887|grant2258");
   init_default(&default_options[OPT_TATE_MODE],           APPNAME"_tate_mode",           "TATE Mode; disabled|enabled");
-  init_default(&default_options[OPT_VECTOR_RESOLUTION],   APPNAME"_vector_resolution_multiplier",
-                                                                                         "Vector resolution multiplier (Restart core); 2|1|3");
+  init_default(&default_options[OPT_VECTOR_RESOLUTION],   APPNAME"_vector_resolution",   "Vector resolution (Restart core); 1024x768|640x480|1280x960|1440x1080|original");
   init_default(&default_options[OPT_VECTOR_ANTIALIAS],    APPNAME"_vector_antialias",    "Vector antialiasing; enabled|disabled");
   init_default(&default_options[OPT_VECTOR_BEAM],         APPNAME"_vector_beam_width",   "Vector beam width (only with antialiasing); 2|1|1.2|1.4|1.6|1.8|2.5|3|4|5|6|7|8|9|10|11|12");
   init_default(&default_options[OPT_VECTOR_TRANSLUCENCY], APPNAME"_vector_translucency", "Vector translucency; enabled|disabled");
@@ -532,7 +531,31 @@ static void update_variables(bool first_time)
           break;
 
         case OPT_VECTOR_RESOLUTION:
-          options.vector_resolution_multiplier = atoi(var.value);
+          if(strcmp(var.value, "640x480") == 0)
+          {
+            options.vector_width=640;
+            options.vector_height=480; 
+          }
+          else if(strcmp(var.value, "1024x768") == 0)
+          {
+            options.vector_width=1024;
+            options.vector_height=768; 
+          }
+          else if(strcmp(var.value, "1280x960") == 0)
+          {
+            options.vector_width=1280;
+            options.vector_height=960; 
+          }
+          else if(strcmp(var.value, "1440x1080") == 0)
+          {
+            options.vector_width=1440;
+            options.vector_height=1080; 
+          }
+          else 
+          {
+            options.vector_width=0; // mame will set this from the driver resolution set
+            options.vector_height=0; 
+          }
           break;
 
         case OPT_VECTOR_ANTIALIAS:


### PR DESCRIPTION
monitor resolutions added
640x480
1024x768

720/1080p
1280x960
1440x1080

original is the original resolution set in the driver. 

@markwkidd @UDb23  if you want any more resolutions added let me know if your both ok with whats there just pull it.

 It simple to add resolutions if we come across devices that dont scale well to the resolutions we have. I think what we have here will cover whats needed the resolutions can be 4:3 format
