### PR TITLE
some fixes

### DIFF
--- a/src/mame.c
+++ b/src/mame.c
@@ -831,10 +831,7 @@ static void init_game_options(void)
   Machine->orientation    = ROT0;
   Machine->ui_orientation = options.ui_orientation;
 
-  /* initialize the samplerate */
-  
-  Machine->sample_rate = options.samplerate;
-/* move this to a core option if you want it to toggle */
+
 
 }
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -673,30 +673,38 @@ static void update_variables(bool first_time)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-	mame2003_video_get_geometry(&info->geometry);  
-	if(options.machine_timing)
-	{
-		if (Machine->drv->frames_per_second < 60.0 )
-			info->timing.fps = 60.0; 
-		else 
-			info->timing.fps = Machine->drv->frames_per_second; /* qbert is 61 fps */
+  mame2003_video_get_geometry(&info->geometry);  
+  if(options.machine_timing)
+  {
+    if (Machine->drv->frames_per_second < 60.0 )
+      info->timing.fps = 60.0; 
+    else 
+      info->timing.fps = Machine->drv->frames_per_second; /* qbert is 61 fps */
 
-		if  ( (Machine->drv->frames_per_second * 1000 < options.samplerate) || ( Machine->drv->frames_per_second < 60) ) 
-		{
-			info->timing.sample_rate = Machine->drv->frames_per_second * 1000;
-			log_cb(RETRO_LOG_INFO, LOGPRE "Sample timing rate too high for framerate required dropping to %f",  Machine->drv->frames_per_second * 1000);
-		}       
-		else
-		{
-			info->timing.sample_rate = options.samplerate;
-			log_cb(RETRO_LOG_INFO, LOGPRE "Sample rate set to %d\n",options.samplerate); 
-		}
-	}
-	else
-	{
-		info->timing.fps = Machine->drv->frames_per_second;
-		info->timing.sample_rate = options.samplerate;
-	}
+    if ( (Machine->drv->frames_per_second * 1000 < options.samplerate) || ( Machine->drv->frames_per_second < 60) ) 
+    {
+      info->timing.sample_rate = Machine->drv->frames_per_second * 1000;
+      log_cb(RETRO_LOG_INFO, LOGPRE "Sample timing rate too high for framerate required dropping to %f",  Machine->drv->frames_per_second * 1000);
+    }       
+
+    else
+    {
+      info->timing.sample_rate = options.samplerate;
+      log_cb(RETRO_LOG_INFO, LOGPRE "Sample rate set to %d\n",options.samplerate); 
+    }
+  }
+
+  else
+  {
+    info->timing.fps = Machine->drv->frames_per_second;
+
+    if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
+     info->timing.sample_rate = 22050;
+
+    else 
+     info->timing.sample_rate = options.samplerate;
+  }
+
 }
 
 unsigned retro_api_version(void)
@@ -1323,26 +1331,36 @@ bool retro_unserialize(const void * data, size_t size)
 
 int osd_start_audio_stream(int stereo)
 {
-	if (options.machine_timing)
-	{
-		if  ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) )   Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-		else Machine->sample_rate = options.samplerate;
-	}
-	else
-	Machine->sample_rate = options.samplerate;
-	delta_samples = 0.0f;
-	usestereo = stereo ? 1 : 0;
+  if (options.machine_timing)
+  {
+    if ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) ) 
+      Machine->sample_rate = Machine->drv->frames_per_second * 1000;
+    
+    else Machine->sample_rate = options.samplerate;
+  }
 
-	/* determine the number of samples per frame */
-	samples_per_frame = Machine->sample_rate / Machine->drv->frames_per_second;
-	orig_samples_per_frame = samples_per_frame;
+  else
+  {
+    if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
+      Machine->sample_rate=22050;
 
-	if (Machine->sample_rate == 0) return 0;
+    else
+      Machine->sample_rate = options.samplerate;
+  }
+  
+  delta_samples = 0.0f;
+  usestereo = stereo ? 1 : 0;
 
-	samples_buffer = (short *) calloc(samples_per_frame+16, 2 + usestereo * 2);
-	if (!usestereo) conversion_buffer = (short *) calloc(samples_per_frame+16, 4);
-	
-	return samples_per_frame;
+  /* determine the number of samples per frame */
+  samples_per_frame = Machine->sample_rate / Machine->drv->frames_per_second;
+  orig_samples_per_frame = samples_per_frame;
+
+  if (Machine->sample_rate == 0) return 0;
+
+  samples_buffer = (short *) calloc(samples_per_frame+16, 2 + usestereo * 2);
+  if (!usestereo) conversion_buffer = (short *) calloc(samples_per_frame+16, 4);
+  
+  return samples_per_frame;
 }
 
 

--- a/src/vidhrdw/blktiger_vidhrdw.c
+++ b/src/vidhrdw/blktiger_vidhrdw.c
@@ -38,8 +38,8 @@ static void get_bg_tile_info(int tile_index)
 	   was not derived from a PROM so it could be wrong. */
 	static int split_table[16] =
 	{
-		3,0,2,2,	/* the fourth could be 1 instead of 2 */
-		0,1,0,0,
+		3,3,0,0,
+		0,0,0,0,
 		0,0,0,0,
 		0,0,0,0
 	};


### PR DESCRIPTION
first fix is for bypass audio skew off any games with low frame rate with sample rate too high would just run wrong. @markwkidd I put this in a separate commit in case you want to update mame2003 so its easier for you to see whats going on.

second fix is for black tiger see the introduction screen when you start the game the dragon should be behind the statue.

