### PR TITLE
no-op: compartmentalize mame zlib implementation

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -8,8 +8,7 @@ INCFLAGS := \
 	-I$(CORE_DIR)/mame2003 \
 	-I$(LIBRETRO_COMM_DIR)/include \
  	-I$(CORE_DIR)/libretro-deps/libFLAC/include \
- 	-I$(CORE_DIR)/lib/mame-chd \
-	-I$(CORE_DIR)/lib/zlib
+ 	-I$(CORE_DIR)/lib/mame-chd
 
 ifneq (,$(findstring msvc200,$(platform)))
 INCFLAGS += -I$(LIBRETRO_COMM_DIR)/include/compat/msvc

--- a/src/lib/zlib/compress.c
+++ b/src/lib/zlib/compress.c
@@ -6,7 +6,7 @@
 /* @(#) $Id$ */
 
 #define ZLIB_INTERNAL
-#include <zlib.h>
+#include "mame_zlib.h"
 
 /* ===========================================================================
    Compresses the source buffer into the destination buffer. The level

--- a/src/lib/zlib/gzguts.h
+++ b/src/lib/zlib/gzguts.h
@@ -22,7 +22,7 @@
 #endif
 
 #include <stdio.h>
-#include <zlib.h>
+#include "mame_zlib.h"
 #ifdef STDC
 #  include <string.h>
 #  include <stdlib.h>

--- a/src/lib/zlib/mame_zlib.h
+++ b/src/lib/zlib/mame_zlib.h
@@ -28,8 +28,8 @@
   (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
 */
 
-#ifndef ZLIB_H
-#define ZLIB_H
+#ifndef MAME_ZLIB_H
+#define MAME_ZLIB_H
 
 #include "zconf.h"
 

--- a/src/lib/zlib/zconf.h
+++ b/src/lib/zlib/zconf.h
@@ -5,8 +5,8 @@
 
 /* @(#) $Id$ */
 
-#ifndef ZCONF_H
-#define ZCONF_H
+#ifndef MAME_ZCONF_H
+#define MAME_ZCONF_H
 
 /*
  * If you *really* need a unique prefix for all types and library functions,

--- a/src/lib/zlib/zutil.h
+++ b/src/lib/zlib/zutil.h
@@ -10,8 +10,8 @@
 
 /* @(#) $Id$ */
 
-#ifndef ZUTIL_H
-#define ZUTIL_H
+#ifndef MAME_ZUTIL_H
+#define MAME_ZUTIL_H
 
 #ifdef HAVE_HIDDEN
 #  define ZLIB_INTERNAL __attribute__((visibility ("hidden")))
@@ -19,7 +19,7 @@
 #  define ZLIB_INTERNAL
 #endif
 
-#include <zlib.h>
+#include "mame_zlib.h"
 
 #if defined(STDC) && !defined(Z_SOLO)
 #  if !(defined(_WIN32_WCE) && defined(_MSC_VER))


### PR DESCRIPTION
I'm getting things ready to ask for some help on discord migrating to the libretro-deps zlib implementation, an accomplishment which has somehow eluded me. At any rate, no-op here.