### PR TITLE
Remove needless option and ensure we dont return a double

### DIFF
--- a/src/mame.h
+++ b/src/mame.h
@@ -216,7 +216,6 @@ struct GameOptions
   bool 	   restrict_4_way;                 /* simulate 4-way joystick restrictor */
   unsigned analog;                         /* analog enable/disable */
   unsigned deadzone;                       /* analog deadzone in percent. 20 corresponds to 20% */
-  unsigned analog_scale;           /* analog scale type */
   unsigned tate_mode;
 
   int      crosshair_enable;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1953,7 +1953,7 @@ int convert_analog_scale(int input)
 
 	
 	if (neg_test) input =-abs(input);
-	return input * 1.28;
+	return (int) input * 1.28;
 }
 
 void osd_analogjoy_read(int player,int analog_axis[MAX_ANALOG_AXES], InputCode analogjoy_input[MAX_ANALOG_AXES])

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -83,7 +83,6 @@ enum CORE_OPTIONS/* controls the order in which core options appear. common, imp
   OPT_SHARE_DIAL,
   OPT_DPAD_ANALOG,
   OPT_DEADZONE,
-  OPT_SCALE,
   OPT_VECTOR_RESOLUTION,
   OPT_VECTOR_ANTIALIAS,
   OPT_VECTOR_BEAM,
@@ -202,7 +201,6 @@ static void init_core_options(void)
   init_default(&default_options[OPT_SHARE_DIAL],          APPNAME"_dialsharexy",         "Share 2 player dial controls across one X/Y device; disabled|enabled");
   init_default(&default_options[OPT_DPAD_ANALOG],         APPNAME"_analog",              "Control mapping ; analog|digital");
   init_default(&default_options[OPT_DEADZONE],            APPNAME"_deadzone",            "Analog deadzone; 20|0|5|10|15|25|30|35|40|45|50|55|60|65|70|75|80|85|90|95");
-  init_default(&default_options[OPT_SCALE],               APPNAME"_analogscale",         "Analog scale type; rsn8887|grant2258");
   init_default(&default_options[OPT_TATE_MODE],           APPNAME"_tate_mode",           "TATE Mode; disabled|enabled");
   init_default(&default_options[OPT_VECTOR_RESOLUTION],   APPNAME"_vector_resolution",   "Vector resolution (Restart core); 1024x768|640x480|1280x960|1440x1080|1600x1200|original");
   init_default(&default_options[OPT_VECTOR_ANTIALIAS],    APPNAME"_vector_antialias",    "Vector antialiasing; enabled|disabled");
@@ -518,13 +516,6 @@ static void update_variables(bool first_time)
 
         case OPT_DEADZONE:
             options.deadzone = atoi(var.value);
-          break;
-
-        case OPT_SCALE:
-          if(strcmp(var.value, "grant2258") == 0)
-            options.analog_scale = 1;
-          else
-            options.analog_scale = 0;
           break;
 
         case OPT_TATE_MODE:
@@ -1937,8 +1928,7 @@ int convert_analog_scale(int input)
 	float scale;
 	int trigger_deadzone;
 	
-	if( options.analog_scale)   trigger_deadzone = (32678 /100) * 20;
-	if( !options.analog_scale)  trigger_deadzone = (32678 * options.deadzone) / 100;
+	trigger_deadzone = (32678 * options.deadzone) / 100;
 	
 	if (input < 0) { input =abs(input); neg_test=1; }
 	scale = ((float)TRIGGER_MAX/(float)(TRIGGER_MAX - trigger_deadzone));


### PR DESCRIPTION
The multiply and divide function the exact same way o need for both one less option to confuse users.