### PR TITLE
tweak how timing is dealt with

### DIFF
--- a/src/mame.c
+++ b/src/mame.c
@@ -834,23 +834,10 @@ static void init_game_options(void)
 
 // set sample rate here as osd_start_audio_stream the logic must be the same in both some soundcores require setting here as well
 // ie ymf271 will segfault without this.
- if (options.machine_timing)
-  {
-    if ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) ) 
-      Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-    
-    else Machine->sample_rate = options.samplerate;
-  }
-
+  if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
+    Machine->sample_rate=22050;
   else
-  {
-    if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
-      Machine->sample_rate=22050;
-
-    else
-      Machine->sample_rate = options.samplerate;
-  }
-
+    Machine->sample_rate = options.samplerate;
 }
 
 


### PR DESCRIPTION
It seems i have go to the bottom of what RA is doing to the timing there is no need to change the sample rate just make these games run at 60fps like RA wants mame just wont render the extra frames.

RA believes a framerate form 57 to 59 should be 60 by design. This option will be disabled by default if users preference is not playing a game to fast and high pitched audio they can just put this option on. 

https://github.com/libretro/RetroArch/issues/8555
 

 
