### PR TITLE
grant2258 A fix for Midway MCR3 game saving

### DIFF
--- a/src/drivers/mcr3.c
+++ b/src/drivers/mcr3.c
@@ -427,12 +427,12 @@ static READ_HANDLER( turbotag_kludge_r )
 
 static NVRAM_HANDLER( mcr3 )
 {
+  unsigned char *ram = memory_region(REGION_CPU1);
+
 	if (read_or_write)
-		mame_fwrite(file, videoram, videoram_size);
+		mame_fwrite(file, &ram[0xe000], 0x800);
 	else if (file)
-		mame_fread(file, videoram, videoram_size);
-	else
-		memset(videoram, 0, videoram_size);
+		mame_fread(file, &ram[0xe000], 0x800);
 }
 
 


### PR DESCRIPTION
As per a request.........

https://retropie.org.uk/forum/topic/25446/having-an-issue-with-high-score-saving-lr-mame-2003-plus

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
