### PR TITLE
Digital centering correction when using digital joystick in analog games and spacing fixes

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -2466,7 +2466,7 @@ void update_analog_port(int port)
 		if (delta == 0 && options.digital_analog )
 			current = default_value;
 
-		else if ((delta == 0) && (in->type & IPF_CENTER) )
+		else if ((delta == 0) && (in->type & IPF_CENTER))
 		{
 			if (current > default_value)
 			delta = -100 / sensitivity;

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -7,17 +7,17 @@
 TODO:	remove the 1 analog device per port limitation
 		support for inputports producing interrupts
 		support for extra "real" hardware (PC throttle's, spinners etc)
-		
+
                  Controller-Specific Input Port Mappings
                  ---------------------------------------
 
-The main purpose of the controller-specific configuration is to remap 
-inputs.  This is handled via two mechanisms: key re-mapping and 
+The main purpose of the controller-specific configuration is to remap
+inputs.  This is handled via two mechanisms: key re-mapping and
 sequence re-mapping.
 
 Key re-mapping occurs at the most basic level.  The specified keycode is
-replaced where ever it occurs (in all sequences) with the specified 
-replacement.  Only single keycodes can be used as a replacement (that is, a 
+replaced where ever it occurs (in all sequences) with the specified
+replacement.  Only single keycodes can be used as a replacement (that is, a
 single key cannot be replaced with a key sequence).
 
 Sequence mapping occurs at a higher level.  In this case, the entire
@@ -27,15 +27,15 @@ sequence.
 Keycodes are specified as a single keyword.  Key sequences are specified
 as a series of keycodes separated by spaces (the full sequence must be
 enclosed in quotes if spaces exist).  Two special keywords are available
-for defining key sequences, CODE_OR and CODE_NOT (which can abbreviated | 
+for defining key sequences, CODE_OR and CODE_NOT (which can abbreviated |
 and ! respectively).
 
 When two keycodes are specified together (separated by only whitespace),
 the default action is a logical AND, such that both keys must be pressed
 at the same time for the action to occur.  Often it desired that either
-key can be pressed for the action to occur (for example LEFT CTRL and 
+key can be pressed for the action to occur (for example LEFT CTRL and
 Joystick Button 0), in which case the two keycodes need to be separated
-by a CODE_OR (|) keyword.  Finally, certain combinations may be 
+by a CODE_OR (|) keyword.  Finally, certain combinations may be
 undesirable and warrant no action by MAME.  For these, the keywords should
 be specified by a CODE_NOT (!) (for example, ALT-TAB on a windows machine).
 
@@ -57,9 +57,9 @@ Specifies the directory that contains the controller customization .ini files.
 
 -ctrlr "name"
 
-Specifies a controller name for customization.  The .ini files for the 
+Specifies a controller name for customization.  The .ini files for the
 controller are stored in either a directory or a .zip file with the same
-name as the specified controller.  
+name as the specified controller.
 
 The first file in the directory/zip to be scanned is the file default.ini.
 From there, game-specific files are scanned starting with the top-most
@@ -85,12 +85,12 @@ enabled on those games that require it.  If all games for this controller
 require joystick and/or mouse support, those keywords can be placed in
 the main default.ini file.
 
-All of the options that can be specified on the command-line or in the 
-main mame.ini file can be specified in the controller-specific ini files, 
-though because of when these files are parsed, the specified options may 
+All of the options that can be specified on the command-line or in the
+main mame.ini file can be specified in the controller-specific ini files,
+though because of when these files are parsed, the specified options may
 have no effect.  The only two general options guaranteed to be supported
 are mouse and joystick.  Note that command-line specification of these
-options takes precedence.  Since most front-ends, including MAME32, 
+options takes precedence.  Since most front-ends, including MAME32,
 specify these options through the command-line, the mouse and/or joystick
 options specified in the .ini files will be ignored.
 
@@ -98,7 +98,7 @@ Another custom keyword is:
 
 ctrlrname               "name"
 
-This keyword defines a detailed name for the selected controller.  Names 
+This keyword defines a detailed name for the selected controller.  Names
 that include spaces must be enclosed in quotes.
 
 
@@ -107,8 +107,8 @@ Keywords:
 
 Keywords are separated into two categories, keycodes and input port
 definitions.  To specify a key re-mapping, specify the keycode as the
-keyword to re-define (that is, on the left-hand side) followed by the 
-replacement code.  To specify a sequence re-map, specify the input port 
+keyword to re-define (that is, on the left-hand side) followed by the
+replacement code.  To specify a sequence re-map, specify the input port
 code to be re-defined on the left followed by the sequence.
 
 In addition to the standard codes, additional OSD specific codes may be
@@ -131,8 +131,8 @@ connected.  In the codes listed above, the Wingman Warrior was connected as
 the first joystick (J1).  If it had been configured as a different input,
 the generated codes would have a different Jx number.
 
-All keyword matching including the standard keywords is case sensitive.  
-Also, some of the automatically generated OSD codes may be redundant. 
+All keyword matching including the standard keywords is case sensitive.
+Also, some of the automatically generated OSD codes may be redundant.
 For example, J1_Button_0 is the same as JOYCODE_1_BUTTON1.  Standard codes
 are preferred over OSD codes.
 
@@ -240,15 +240,15 @@ P2_JOYSTICKLEFT_RIGHT
 
 P3_JOYSTICK_UP           P3_JOYSTICK_DOWN         P3_JOYSTICK_LEFT
 P3_JOYSTICK_RIGHT        P3_BUTTON1               P3_BUTTON2
-P3_BUTTON3               P3_BUTTON4               
+P3_BUTTON3               P3_BUTTON4
 
 P4_JOYSTICK_UP           P4_JOYSTICK_DOWN         P4_JOYSTICK_LEFT
 P4_JOYSTICK_RIGHT        P4_BUTTON1               P4_BUTTON2
-P4_BUTTON3               P4_BUTTON4               
+P4_BUTTON3               P4_BUTTON4
 
 P1_PEDAL                 P1_PEDAL_EXT             P2_PEDAL
 P2_PEDAL_EXT             P3_PEDAL                 P3_PEDAL_EXT
-P4_PEDAL                 P4_PEDAL_EXT             
+P4_PEDAL                 P4_PEDAL_EXT
 
 P1_PADDLE                P1_PADDLE_EXT            P2_PADDLE
 P2_PADDLE_EXT            P3_PADDLE                P3_PADDLE_EXT
@@ -266,19 +266,19 @@ P4_DIAL_V_EXT
 
 P1_TRACKBALL_X           P1_TRACKBALL_X_EXT       P2_TRACKBALL_X
 P2_TRACKBALL_X_EXT       P3_TRACKBALL_X           P3_TRACKBALL_X_EXT
-P4_TRACKBALL_X           P4_TRACKBALL_X_EXT       
+P4_TRACKBALL_X           P4_TRACKBALL_X_EXT
 
 P1_TRACKBALL_Y           P1_TRACKBALL_Y_EXT       P2_TRACKBALL_Y
 P2_TRACKBALL_Y_EXT       P3_TRACKBALL_Y           P3_TRACKBALL_Y_EXT
-P4_TRACKBALL_Y           P4_TRACKBALL_Y_EXT       
+P4_TRACKBALL_Y           P4_TRACKBALL_Y_EXT
 
 P1_AD_STICK_X            P1_AD_STICK_X_EXT        P2_AD_STICK_X
 P2_AD_STICK_X_EXT        P3_AD_STICK_X            P3_AD_STICK_X_EXT
-P4_AD_STICK_X            P4_AD_STICK_X_EXT        
+P4_AD_STICK_X            P4_AD_STICK_X_EXT
 
 P1_AD_STICK_Y            P1_AD_STICK_Y_EXT        P2_AD_STICK_Y
 P2_AD_STICK_Y_EXT        P3_AD_STICK_Y            P3_AD_STICK_Y_EXT
-P4_AD_STICK_Y            P4_AD_STICK_Y_EXT        
+P4_AD_STICK_Y            P4_AD_STICK_Y_EXT
 
 OSD_1                    OSD_2                    OSD_3
 OSD_4
@@ -2124,7 +2124,7 @@ void change_control_type(void)
     memcpy(inputport_defaults,inputport_defaults_digital,sizeof(inputport_defaults));
     memcpy(inputport_defaults_backup,inputport_defaults,sizeof(inputport_defaults));
   }
-  else 
+  else
   {
     memcpy(inputport_defaults,inputport_defaults_analog,sizeof(inputport_defaults));
     memcpy(inputport_defaults_backup,inputport_defaults_analog,sizeof(inputport_defaults));
@@ -2167,7 +2167,7 @@ int load_input_port_settings(void)
 	struct mixer_config mixercfg;
 	char buf[20];
 
-	if(options.mame_remapping) 
+	if(options.mame_remapping)
 		sprintf(buf,"%s",Machine->gamedrv->name);
 	else
 		sprintf(buf,"ra_%s",Machine->gamedrv->name);
@@ -2221,7 +2221,7 @@ void save_input_port_settings(void)
 		config_file *cfg;
 		struct mixer_config mixercfg;
 		char buf[20];
-		if(options.mame_remapping) 
+		if(options.mame_remapping)
 			sprintf(buf,"%s",Machine->gamedrv->name);
 		else
 			sprintf(buf,"ra_%s",Machine->gamedrv->name);
@@ -2282,7 +2282,7 @@ InputSeq* input_port_type_seq(int type)
 
 InputSeq* input_port_seq(const struct InputPort *in)
 {
-// mark change the (! 0 && ((in-1)->type & IPF_CHEAT))) to a variable name if you want to make it a core option just disable for now until you make a choice 
+// mark change the (! 0 && ((in-1)->type & IPF_CHEAT))) to a variable name if you want to make it a core option just disable for now until you make a choice
 	int i,type;
 
 	static InputSeq ip_none = SEQ_DEF_1(CODE_NONE);
@@ -2399,7 +2399,7 @@ void update_analog_port(int port)
 	delta = 0;
 
 	player = IP_GET_PLAYER(in);
-    
+
     /* if second player on a dial, and dial sharing turned on, use Y axis from player 1 */
     if (options.dial_share_xy && type == IPT_DIAL && player == 1)
     {
@@ -2463,7 +2463,10 @@ void update_analog_port(int port)
 		int new, prev;
 
 		/* center stick */
-		if ((delta == 0) && (in->type & IPF_CENTER))
+		if (delta == 0 && options.digital_analog )
+			current = default_value;
+
+		else if ((delta == 0) && (in->type & IPF_CENTER) )
 		{
 			if (current > default_value)
 			delta = -100 / sensitivity;
@@ -2708,19 +2711,19 @@ ScanJoysticks( struct InputPort *in )
 			  }
 
 		}
-    else if (options.restrict_4_way) //start use alternative code 
+    else if (options.restrict_4_way) //start use alternative code
     {
       if(options.content_flags[CONTENT_ROTATE_JOY_45])
       {
         if  ( (mJoyCurrent[i]) && (mJoyCurrent[i] !=1) &&
               (mJoyCurrent[i] !=2) && (mJoyCurrent[i] !=4) &&
-              (mJoyCurrent[i] !=8) )  	
-        {    
+              (mJoyCurrent[i] !=8) )
+        {
           if      (mJoyCurrent[i] == 9)  mJoy4Way[i]=1;
           else if (mJoyCurrent[i] == 6)  mJoy4Way[i]=2;
           else if (mJoyCurrent[i] == 5)  mJoy4Way[i]=4;
           else if (mJoyCurrent[i] == 10) mJoy4Way[i]=8;
-        }     
+        }
         else if (mJoy4Way[i])
           mJoy4Way[i]=0;
       }

--- a/src/mame.h
+++ b/src/mame.h
@@ -174,7 +174,7 @@ enum /* used to index content-specific flags */
   CONTENT_PADDLE,
   CONTENT_AD_STICK,
   CONTENT_HAS_SERVICE,
-  CONTENT_HAS_TILT,  
+  CONTENT_HAS_TILT,
   CONTENT_ALTERNATING_CTRLS,
   CONTENT_MIRRORED_CTRLS,
   CONTENT_ROTATE_JOY_45,
@@ -231,12 +231,12 @@ struct GameOptions
   int      frameskip;
   int      color_depth;	         /* valid: 15, 16, or 32. any other value means auto */
   int      ui_orientation;	     /* orientation of the UI relative to the video */
-      
+
   int      vector_width;	       /* requested width for vector games; 0 means default (640) */
   int      vector_height;	       /* requested height for vector games; 0 means default (480) */
   float    beam;                 /* vector beam width */
   int      vector_flicker;	     /* vector beam flicker effect control */
-  float	   vector_intensity_correction;   
+  float	   vector_intensity_correction;
   int      translucency;	       /* 1 to enable translucency on vectors */
   int      antialias;		         /* 1 to enable antialiasing on vectors */
   unsigned vector_resolution_multiplier;
@@ -248,17 +248,18 @@ struct GameOptions
   char     savegame;		         /* character representing a savegame to load */
   int      crc_only;             /* specify if only CRC should be used as checksum */
   bool     nvram_bootstrap;
-  
+
   const char *bios;			         /* specify system bios (if used), 0 is default */
-  
+
   bool     system_subfolder;     /* save all system files within a subfolder of the libretro system folder rather than directly in the system folder */
-  bool     save_subfolder;       /* save all save files within a subfolder of the libretro system folder rather than directly in the system folder */  
-  
+  bool     save_subfolder;       /* save all save files within a subfolder of the libretro system folder rather than directly in the system folder */
+
   int      debug_width;	         /* requested width of debugger bitmap */
   int      debug_height;	       /* requested height of debugger bitmap */
   int      debug_depth;	         /* requested depth of debugger bitmap */
   bool     cheat_input_ports;     /*cheat input ports enable/disable */
-  bool     machine_timing;         
+  bool     machine_timing;
+  bool     digital_analog;
   };
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -51,7 +51,7 @@ int16_t             analogjoy[4][4]= {0};
 struct ipd          *default_inputs; /* pointer the array of structs with default MAME input mappings and labels */
 int                 running = 0;
 int                 control_flag=-1;
-int                 legacy_flag=-1;    
+int                 legacy_flag=-1;
 static struct retro_input_descriptor empty[] = { { 0 } };
 
 retro_log_printf_t                 log_cb;
@@ -107,6 +107,7 @@ enum CORE_OPTIONS/* controls the order in which core options appear. common, imp
   OPT_NVRAM_BOOTSTRAP,
   OPT_Cheat_Input_Ports,
   OPT_Machine_Timing,
+  OPT_Digital_Analog,
   OPT_end /* dummy last entry */
 };
 
@@ -221,6 +222,7 @@ static void init_core_options(void)
   init_default(&default_options[OPT_CORE_SAVE_SUBFOLDER], APPNAME"_core_save_subfolder", "Locate save files within a subfolder; enabled|disabled"); /* This is already available as an option in RetroArch although it is left enabled by default as of November 2018 for consistency with past practice. At least for now.*/
   init_default(&default_options[OPT_Cheat_Input_Ports],   APPNAME"_cheat_input_ports",   "Dip switch/Cheat input ports; disabled|enabled");
   init_default(&default_options[OPT_Machine_Timing],      APPNAME"_machine_timing",      "Bypass audio skew (Restart core); enabled|disabled");
+  init_default(&default_options[OPT_Digital_Analog],      APPNAME"_digital_analog",      "Center joystick axis for digital controls; enabled|disabled");
   init_default(&default_options[OPT_end], NULL, NULL);
   set_variables(true);
 }
@@ -496,9 +498,9 @@ static void update_variables(bool first_time)
           {
             if( options.analog !=1 && control_flag !=-1) control_flag =1;
             options.analog = 1;
-            if (running && control_flag == 1) 
+            if (running && control_flag == 1)
             {
-              change_control_type(); 
+              change_control_type();
               control_flag =0;
             }
           }
@@ -506,9 +508,9 @@ static void update_variables(bool first_time)
           {
             if(options.analog !=0 && control_flag !=-1)  control_flag =1;
             options.analog = 0;
-            if (running && control_flag == 1) 
+            if (running && control_flag == 1)
             {
-              change_control_type(); 
+              change_control_type();
               control_flag =0;
             }
           }
@@ -528,36 +530,43 @@ static void update_variables(bool first_time)
             options.tate_mode = 0;
           break;
 
+        case OPT_Digital_Analog:
+          if(strcmp(var.value, "enabled") == 0)
+            options.digital_analog = 1;
+          else
+            options.digital_analog = 0;
+          break;
+
         case OPT_VECTOR_RESOLUTION:
           if(strcmp(var.value, "640x480") == 0)
           {
             options.vector_width=640;
-            options.vector_height=480; 
+            options.vector_height=480;
           }
           else if(strcmp(var.value, "1024x768") == 0)
           {
             options.vector_width=1024;
-            options.vector_height=768; 
+            options.vector_height=768;
           }
           else if(strcmp(var.value, "1280x960") == 0)
           {
             options.vector_width=1280;
-            options.vector_height=960; 
+            options.vector_height=960;
           }
           else if(strcmp(var.value, "1440x1080") == 0)
           {
             options.vector_width=1440;
-            options.vector_height=1080; 
+            options.vector_height=1080;
           }
           else if(strcmp(var.value, "1600x1200") == 0)
           {
             options.vector_width=1600;
-            options.vector_height=1200; 
+            options.vector_height=1200;
           }
-          else 
+          else
           {
             options.vector_width=0; // mame will set this from the driver resolution set
-            options.vector_height=0; 
+            options.vector_height=0;
           }
           break;
 
@@ -644,13 +653,13 @@ static void update_variables(bool first_time)
             options.cheat_input_ports = true;
           else
             options.cheat_input_ports = false;
-          break;		
+          break;
 	    case OPT_Machine_Timing:
           if(strcmp(var.value, "enabled") == 0)
             options.machine_timing = true;
           else
             options.machine_timing = false;
-          break;	
+          break;
 	  }
     }
   }
@@ -672,24 +681,24 @@ static void update_variables(bool first_time)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-  mame2003_video_get_geometry(&info->geometry);  
+  mame2003_video_get_geometry(&info->geometry);
   if(options.machine_timing)
   {
     if (Machine->drv->frames_per_second < 60.0 )
-      info->timing.fps = 60.0; 
-    else 
+      info->timing.fps = 60.0;
+    else
       info->timing.fps = Machine->drv->frames_per_second; /* qbert is 61 fps */
 
-    if ( (Machine->drv->frames_per_second * 1000 < options.samplerate) || ( Machine->drv->frames_per_second < 60) ) 
+    if ( (Machine->drv->frames_per_second * 1000 < options.samplerate) || ( Machine->drv->frames_per_second < 60) )
     {
       info->timing.sample_rate = Machine->drv->frames_per_second * 1000;
       log_cb(RETRO_LOG_INFO, LOGPRE "Sample timing rate too high for framerate required dropping to %f",  Machine->drv->frames_per_second * 1000);
-    }       
+    }
 
     else
     {
       info->timing.sample_rate = options.samplerate;
-      log_cb(RETRO_LOG_INFO, LOGPRE "Sample rate set to %d\n",options.samplerate); 
+      log_cb(RETRO_LOG_INFO, LOGPRE "Sample rate set to %d\n",options.samplerate);
     }
   }
 
@@ -700,7 +709,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
      info->timing.sample_rate = 22050;
 
-    else 
+    else
      info->timing.sample_rate = options.samplerate;
   }
 
@@ -835,7 +844,7 @@ bool retro_load_game(const struct retro_game_info *game)
          default:
             break;
          }
-			
+
          break;
 		}
 	}
@@ -854,7 +863,7 @@ bool retro_load_game(const struct retro_game_info *game)
 #endif
 			   {
 				   *type=CPU_CYCLONE;
-                   log_cb(RETRO_LOG_INFO, LOGPRE "Replaced CPU_CYCLONE\n"); 
+                   log_cb(RETRO_LOG_INFO, LOGPRE "Replaced CPU_CYCLONE\n");
 			   }
         if(!(*type)){
           break;
@@ -873,7 +882,7 @@ bool retro_load_game(const struct retro_game_info *game)
 			if (type==CPU_Z80)
 			{
 				*type=CPU_DRZ80;
-        log_cb(RETRO_LOG_INFO, LOGPRE "Replaced Z80\n"); 
+        log_cb(RETRO_LOG_INFO, LOGPRE "Replaced Z80\n");
 			}
 		}
 	}
@@ -887,7 +896,7 @@ bool retro_load_game(const struct retro_game_info *game)
 			if (type==CPU_Z80 && Machine->drv->cpu[i].cpu_flags&CPU_AUDIO_CPU)
 			{
 				*type=CPU_DRZ80;
-        log_cb(RETRO_LOG_INFO, LOGPRE "Replaced Z80 sound\n"); 
+        log_cb(RETRO_LOG_INFO, LOGPRE "Replaced Z80 sound\n");
 
 			}
 		}
@@ -901,9 +910,9 @@ bool retro_load_game(const struct retro_game_info *game)
   options.libretro_content_path = strdup(game->path);
   path_basedir(options.libretro_content_path);
   /*fix trailing slash in path*/
-  for(i = 0; options.libretro_content_path[i] != '\0'; ++i); 
-  if ( options.libretro_content_path[i-1] == '/' || options.libretro_content_path[i-1]  == '\\' ) 
-   options.libretro_content_path[i-1] =0; 
+  for(i = 0; options.libretro_content_path[i] != '\0'; ++i);
+  if ( options.libretro_content_path[i-1] == '/' || options.libretro_content_path[i-1]  == '\\' )
+   options.libretro_content_path[i-1] =0;
 
   /* Get system directory from frontend */
   options.libretro_system_path = NULL;
@@ -1215,7 +1224,7 @@ void retro_run (void)
 		retroKeyState[thisInput->code] = input_cb(0, RETRO_DEVICE_KEYBOARD, 0, thisInput->code);
 		thisInput ++;
 	}
-   
+
 	for (i = 0; i < 4; i ++)
 	{
 		unsigned int offset = (i * 26);
@@ -1243,7 +1252,7 @@ void retro_run (void)
 		retroJsState[13 + offset] = input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2);
 		retroJsState[14 + offset] = input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3);
 		retroJsState[15 + offset] = input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
-      
+
 		if (options.mouse_device)
 		{
 			if (options.mouse_device == RETRO_DEVICE_MOUSE)
@@ -1278,26 +1287,26 @@ void retro_run (void)
 		retroJsState[ 24 + offset] = 0;
 		retroJsState[ 25 + offset] = 0;
 
-		if (convert_analog_scale(analogjoy[i][0]) < -pressure_check) 
-			retroJsState[ 18 + offset] = convert_analog_scale(analogjoy[i][0]); 
+		if (convert_analog_scale(analogjoy[i][0]) < -pressure_check)
+			retroJsState[ 18 + offset] = convert_analog_scale(analogjoy[i][0]);
 
 		if (convert_analog_scale(analogjoy[i][0]) >  pressure_check)
 			retroJsState[ 19 + offset] = convert_analog_scale(analogjoy[i][0]);
 
 		if (convert_analog_scale(analogjoy[i][1]) < -pressure_check)
-			retroJsState[ 20 + offset] = convert_analog_scale(analogjoy[i][1]); 
+			retroJsState[ 20 + offset] = convert_analog_scale(analogjoy[i][1]);
 
 		if (convert_analog_scale(analogjoy[i][1]) >  pressure_check)
 			retroJsState[ 21 + offset] = convert_analog_scale(analogjoy[i][1]);
-		
+
 		if (convert_analog_scale(analogjoy[i][2]) < -pressure_check)
-			retroJsState[ 22 + offset] = convert_analog_scale(analogjoy[i][2]); 
+			retroJsState[ 22 + offset] = convert_analog_scale(analogjoy[i][2]);
 
 		if (convert_analog_scale(analogjoy[i][2]) >  pressure_check)
 			retroJsState[ 23 + offset] = convert_analog_scale(analogjoy[i][2]);
 
-		if (convert_analog_scale(analogjoy[i][3]) < -pressure_check) 
-			retroJsState[ 24 + offset] = convert_analog_scale(analogjoy[i][3]); 
+		if (convert_analog_scale(analogjoy[i][3]) < -pressure_check)
+			retroJsState[ 24 + offset] = convert_analog_scale(analogjoy[i][3]);
 		if (convert_analog_scale(analogjoy[i][3]) >  pressure_check)
 			retroJsState[ 25 + offset] = convert_analog_scale(analogjoy[i][3]);
 	}
@@ -1359,7 +1368,7 @@ bool retro_serialize(void *data, size_t size)
 
 		/* finish and close */
 		state_save_save_finish();
-		
+
 		return true;
 	}
 
@@ -1432,9 +1441,9 @@ int osd_start_audio_stream(int stereo)
 {
   if (options.machine_timing)
   {
-    if ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) ) 
+    if ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) )
       Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-    
+
     else Machine->sample_rate = options.samplerate;
   }
 
@@ -1446,7 +1455,7 @@ int osd_start_audio_stream(int stereo)
     else
       Machine->sample_rate = options.samplerate;
   }
-  
+
   delta_samples = 0.0f;
   usestereo = stereo ? 1 : 0;
 
@@ -1458,7 +1467,7 @@ int osd_start_audio_stream(int stereo)
 
   samples_buffer = (short *) calloc(samples_per_frame+16, 2 + usestereo * 2);
   if (!usestereo) conversion_buffer = (short *) calloc(samples_per_frame+16, 4);
-  
+
   return samples_per_frame;
 }
 
@@ -1479,19 +1488,19 @@ int osd_update_audio_stream(INT16 *buffer)
 				conversion_buffer[j++] = samples_buffer[i];
 		        }
          		audio_batch_cb(conversion_buffer,samples_per_frame);
-		}	
-		
-			
+		}
+
+
 		//process next frame
-			
+
 		if ( samples_per_frame  != orig_samples_per_frame ) samples_per_frame = orig_samples_per_frame;
-		
+
 		// dont drop any sample frames some games like mk will drift with time
 
 		delta_samples += (Machine->sample_rate / Machine->drv->frames_per_second) - orig_samples_per_frame;
 		if ( delta_samples >= 1.0f )
 		{
-		
+
 			int integer_delta = (int)delta_samples;
 			if (integer_delta <= 16 )
                         {
@@ -1499,7 +1508,7 @@ int osd_update_audio_stream(INT16 *buffer)
 				samples_per_frame += integer_delta;
 			}
 			else if(integer_delta >= 16) log_cb(RETRO_LOG_INFO, "sound: Delta not added to samples_per_frame too large integer_delta:%d\n", integer_delta);
-			else log_cb(RETRO_LOG_DEBUG,"sound(delta) no contitions met\n");	
+			else log_cb(RETRO_LOG_DEBUG,"sound(delta) no contitions met\n");
 			delta_samples -= integer_delta;
 
 		}
@@ -1841,7 +1850,7 @@ int get_mame_ctrl_id(int display_idx, int retro_ID)
   {"RP"   #DISPLAY_IDX " AXIS 2 X-",    ((DISPLAY_IDX - 1) * 26) + 22 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_LEFT}, \
   {"RP"   #DISPLAY_IDX " AXIS 2 X+",    ((DISPLAY_IDX - 1) * 26) + 23 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_RIGHT}, \
   {"RP"   #DISPLAY_IDX " AXIS 3 Y-",    ((DISPLAY_IDX - 1) * 26) + 24 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_UP}, \
-  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN}, 
+  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN},
 
 #define EMIT_RETROPAD_MODERN(DISPLAY_IDX) \
   {"RP"   #DISPLAY_IDX " HAT Left ",     ((DISPLAY_IDX - 1) * 26) + RETRO_DEVICE_ID_JOYPAD_LEFT +3000,   JOYCODE_##DISPLAY_IDX##_LEFT}, \
@@ -1869,8 +1878,8 @@ int get_mame_ctrl_id(int display_idx, int retro_ID)
   {"RP"   #DISPLAY_IDX " AXIS 2 X-",    ((DISPLAY_IDX - 1) * 26) + 22 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_LEFT}, \
   {"RP"   #DISPLAY_IDX " AXIS 2 X+",    ((DISPLAY_IDX - 1) * 26) + 23 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_RIGHT}, \
   {"RP"   #DISPLAY_IDX " AXIS 3 Y-",    ((DISPLAY_IDX - 1) * 26) + 24 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_UP}, \
-  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN}, 
-  
+  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN},
+
 #define EMIT_RETROPAD_8BUTTON(DISPLAY_IDX) \
   {"RP"   #DISPLAY_IDX " HAT Left ",     ((DISPLAY_IDX - 1) * 26) + RETRO_DEVICE_ID_JOYPAD_LEFT +3000,   JOYCODE_##DISPLAY_IDX##_LEFT}, \
   {"RP"   #DISPLAY_IDX " HAT Right",    ((DISPLAY_IDX - 1) * 26) + RETRO_DEVICE_ID_JOYPAD_RIGHT +3000,  JOYCODE_##DISPLAY_IDX##_RIGHT}, \
@@ -1897,7 +1906,7 @@ int get_mame_ctrl_id(int display_idx, int retro_ID)
   {"RP"   #DISPLAY_IDX " AXIS 2 X-",    ((DISPLAY_IDX - 1) * 26) + 22 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_LEFT}, \
   {"RP"   #DISPLAY_IDX " AXIS 2 X+",    ((DISPLAY_IDX - 1) * 26) + 23 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_RIGHT}, \
   {"RP"   #DISPLAY_IDX " AXIS 3 Y-",    ((DISPLAY_IDX - 1) * 26) + 24 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_UP}, \
-  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN}, 
+  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN},
 
 #define EMIT_RETROPAD_6BUTTON(DISPLAY_IDX) \
   {"RP"   #DISPLAY_IDX " HAT Left ",     ((DISPLAY_IDX - 1) * 26) + RETRO_DEVICE_ID_JOYPAD_LEFT +3000,   JOYCODE_##DISPLAY_IDX##_LEFT}, \
@@ -1925,7 +1934,7 @@ int get_mame_ctrl_id(int display_idx, int retro_ID)
   {"RP"   #DISPLAY_IDX " AXIS 2 X-",    ((DISPLAY_IDX - 1) * 26) + 22 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_LEFT}, \
   {"RP"   #DISPLAY_IDX " AXIS 2 X+",    ((DISPLAY_IDX - 1) * 26) + 23 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_RIGHT}, \
   {"RP"   #DISPLAY_IDX " AXIS 3 Y-",    ((DISPLAY_IDX - 1) * 26) + 24 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_UP}, \
-  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN}, 
+  {"RP"   #DISPLAY_IDX " AXIS 3 Y+",    ((DISPLAY_IDX - 1) * 26) + 25 +2000,                            JOYCODE_##DISPLAY_IDX##_RIGHT_DOWN},
 
 struct JoystickInfo alternate_joystick_maps[PLAYER_COUNT][IDX_PAD_end][PER_PLAYER_CTRL_COUNT] =
 {
@@ -1982,10 +1991,10 @@ const struct JoystickInfo *osd_get_joy_list(void)
 int osd_is_joy_pressed(int joycode)
 {
 	if (options.input_interface == RETRO_DEVICE_KEYBOARD) return 0;
- 
+
 	if ( joycode  >=1000 &&  joycode  < 2000)
-		return  retroJsState[joycode-1000]; 
-		
+		return  retroJsState[joycode-1000];
+
 	if ( joycode >= 2000 && joycode < 3000 )
 	{
 		if (retroJsState[joycode-2000] >= 64) return  retroJsState[joycode-2000];
@@ -2030,9 +2039,9 @@ int convert_analog_scale(int input)
 	int neg_test=0;
 	float scale;
 	int trigger_deadzone;
-	
+
 	trigger_deadzone = (32678 * options.deadzone) / 100;
-	
+
 	if (input < 0) { input =abs(input); neg_test=1; }
 	scale = ((float)TRIGGER_MAX/(float)(TRIGGER_MAX - trigger_deadzone));
 
@@ -2042,7 +2051,7 @@ int convert_analog_scale(int input)
 		float scaled = (input - trigger_deadzone)*scale;
     input = (int)round(scaled);
 
-		if (input > +32767) 
+		if (input > +32767)
 		{
 			input = +32767;
 		}
@@ -2054,7 +2063,7 @@ int convert_analog_scale(int input)
 		input = 0;
 	}
 
-	
+
 	if (neg_test) input =-abs(input);
 	return (int) input * 1.28;
 }
@@ -2069,7 +2078,7 @@ void osd_analogjoy_read(int player,int analog_axis[MAX_ANALOG_AXES], InputCode a
     int code;
     value = 0;
     if (analogjoy_input[i] != CODE_NONE)
-    {  
+    {
       code = analogjoy_input[i];
 
       if ( code == (player * 26) + 18 + 2000 || code == (player * 26) + 19 + 2000 )


### PR DESCRIPTION
option for digital joystick "centering" for use in analog games - grant2258.  This emulates a analog joystick's center position for games such as food fight, road runner, and paperboy to make playable on a digital joystick.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
