### PR TITLE
Update inptport.c

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -2463,7 +2463,7 @@ void update_analog_port(int port)
 		int new, prev;
 
 		/* center stick */
-		if (delta == 0 && options.digital_analog )
+		if (delta == 0 && options.digital_analog && (type == IPT_AD_STICK_X || type == IPT_AD_STICK_Y))
 			current = default_value;
 
 		else if ((delta == 0) && (in->type & IPF_CENTER))


### PR DESCRIPTION
Updated centering feature to only apply this correction when AD_STICK type is being used. This allows this feature to always be left on in the core options without effecting other input types such as lightgun, etc where auto centering is unwanted.