### PR TITLE
Remove Final Fight AE OST from DAT

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -18,7 +18,7 @@
 	const char* ost_drivers[] = {	"outrun", "outruna", "outrunb","toutrun","toutruna", \
 				"mk", "mkr4", "mkprot9", "mkla1", "mkla2",  "mkla3", "mkla4", \
 				"nbajam", "nbajamr2", "nbajamte", "nbajamt12", "nbajamt2",  "nbajamt3", \
-				"ffight", "ffightu", "ffightj",  "ffightj1", \
+				"ffight", "ffightu", "ffightj",  "ffightj1", "ffightae", \
 				"ddragon", "ddragonu", "ddragonw",  "ddragonb", \
 				"moonwalk", "moonwlka", "moonwlkb", 0
 		 };    


### PR DESCRIPTION
This will remove the custom OST files from the DAT for Final Fight Anniversary Edition. It won't affect the original audio or samples in any way. Since no other custom OST samples are present in the DAT it will also make the DAT uniform.

I will update the DAT under metadata once the OST files are removed.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
