### PR TITLE
Missing includes

### DIFF
--- a/src/drivers/foodf.c
+++ b/src/drivers/foodf.c
@@ -78,6 +78,7 @@
 #include "vidhrdw/generic.h"
 #include "foodf.h"
 #include "bootstrap.h"
+#include "inptport.h"
 
 
 

--- a/src/drivers/midyunit.c
+++ b/src/drivers/midyunit.c
@@ -32,6 +32,7 @@
 #include "sndhrdw/williams.h"
 #include "midyunit.h"
 #include "bootstrap.h"
+#include "inptport.h"
 
 const char *const mk_sample_names_yunit[] =
 {

--- a/src/drivers/mystwarr.c
+++ b/src/drivers/mystwarr.c
@@ -33,6 +33,7 @@
 #include "machine/eeprom.h"
 #include "sound/k054539.h"
 #include "bootstrap.h"
+#include "inptport.h"
 
 VIDEO_START(gaiapols);
 VIDEO_START(dadandrn);

--- a/src/drivers/simpl156.c
+++ b/src/drivers/simpl156.c
@@ -94,6 +94,7 @@ Are the OKI M6295 clocks from Heavy Smash are correct at least for the Mitchell 
 #include "deco16ic.h"
 #include "vidhrdw/generic.h"
 #include "bootstrap.h"
+#include "inptport.h"
 
 static UINT32 *simpl156_systemram;
 static const UINT8 *simpl156_default_eeprom = NULL;


### PR DESCRIPTION
Missing `#include "inptport.h"` for bootstraps.