### PR TITLE
DCS reset and set active low midway

### DIFF
--- a/src/drivers/kinst.c
+++ b/src/drivers/kinst.c
@@ -171,6 +171,10 @@ static WRITE32_HANDLER( kinst_control_w )
 			kinst_buffer_vram(&rambase1[0x30000/4]);
 			break;
 
+    case 1:     /* $88 - sound reset */
+      dcs_reset_w(data & 0x01);
+      break;
+
 		case 2:		/* $90 - sound control */
 			if (!(olddata & 0x02) && (kinst_control[offset] & 0x02))
 				dcs_data_w(kinst_control[3]);

--- a/src/drivers/midvunit.c
+++ b/src/drivers/midvunit.c
@@ -56,8 +56,8 @@ static data32_t *midvplus_misc;
 
 static MACHINE_INIT( midvunit )
 {
-	dcs_reset_w(1);
 	dcs_reset_w(0);
+	dcs_reset_w(1);
 
 	cpu_setbank(1, memory_region(REGION_USER1));
 	memcpy(ram_base, memory_region(REGION_USER1), 0x20000*4);
@@ -69,8 +69,8 @@ static MACHINE_INIT( midvunit )
 
 static MACHINE_INIT( midvplus )
 {
-	dcs_reset_w(1);
 	dcs_reset_w(0);
+	dcs_reset_w(1);
 
 /*	cpu_setbank(1, ram_base);*/
 	memcpy(ram_base, memory_region(REGION_USER1), 0x20000*4);
@@ -210,7 +210,7 @@ WRITE32_HANDLER( midvunit_control_w )
 		watchdog_reset_w(0, 0);
 
 	/* bit 1 is the DCS sound reset */
-	dcs_reset_w((~control_data >> 1) & 1);
+	dcs_reset_w((control_data >> 1) & 1);
 
 	/* log anything unusual */
 	if ((olddata ^ control_data) & ~0x00e8)
@@ -224,7 +224,7 @@ WRITE32_HANDLER( crusnwld_control_w )
 	COMBINE_DATA(&control_data);
 
 	/* bit 11 is the DCS sound reset */
-	dcs_reset_w((~control_data >> 11) & 1);
+	dcs_reset_w((control_data >> 11) & 1);
 
 	/* bit 9 is the watchdog */
 	if ((olddata ^ control_data) & 0x0200)

--- a/src/drivers/seattle.c
+++ b/src/drivers/seattle.c
@@ -92,8 +92,8 @@ static MACHINE_INIT( seattle )
 
 	if (mame_find_cpu_index("dcs2") != -1)
 	{
-		dcs_reset_w(1);
 		dcs_reset_w(0);
+		dcs_reset_w(1);
 	}
 	else if (mame_find_cpu_index("cage") != -1)
 	{

--- a/src/machine/midtunit_machine.c
+++ b/src/machine/midtunit_machine.c
@@ -632,8 +632,8 @@ MACHINE_INIT( midtunit )
 			break;
 
 		case SOUND_DCS:
-			dcs_reset_w(1);
 			dcs_reset_w(0);
+			dcs_reset_w(1);
 			break;
 	}
 }
@@ -695,7 +695,7 @@ WRITE16_HANDLER( midtunit_sound_w )
 
 			case SOUND_DCS:
 				/*logerror("%08X:Sound write = %04X\n", activecpu_get_pc(), data);*/
-				dcs_reset_w(~data & 0x100);
+				dcs_reset_w(data & 0x100);
 				dcs_data_w(data & 0xff);
 				/* the games seem to check for $82 loops, so this should be just barely enough */
 				fake_sound_state = 128;

--- a/src/machine/midwayic.c
+++ b/src/machine/midwayic.c
@@ -839,7 +839,7 @@ WRITE32_HANDLER( midway_ioasic_w )
 			/* sound reset? */
 			if (ioasic.has_dcs)
 			{
-				dcs_reset_w(~newreg & 1);
+				dcs_reset_w(newreg & 1);
 				
 			}
 			else if (ioasic.has_cage)

--- a/src/machine/midwunit_machine.c
+++ b/src/machine/midwunit_machine.c
@@ -122,7 +122,7 @@ WRITE16_HANDLER( midwunit_io_w )
 			log_cb(RETRO_LOG_DEBUG, LOGPRE "%08X:Control W @ %05X = %04X\n", activecpu_get_pc(), offset, data);
 
 			/* bit 4 reset sound CPU */
-			dcs_reset_w(newword & 0x10);
+			dcs_reset_w(~newword & 0x10);
 
 			/* bit 5 (active low) reset security chip */
 			midway_serial_pic_reset_w(newword & 0x20);
@@ -170,8 +170,10 @@ WRITE16_HANDLER( midxunit_io_w )
 WRITE16_HANDLER( midxunit_unknown_w )
 {
 	int offs = offset / 0x40000;
+
 	if (offs == 1 && ACCESSING_LSB)
-		dcs_reset_w(data & 2);
+		dcs_reset_w(~data & 2);
+
 	if (ACCESSING_LSB && offset % 0x40000 == 0)
 		log_cb(RETRO_LOG_DEBUG, LOGPRE "%08X:midxunit_unknown_w @ %d = %02X\n", activecpu_get_pc(), offs, data & 0xff);
 }
@@ -616,8 +618,8 @@ MACHINE_INIT( midwunit )
 	int i;
 
 	/* reset sound */
-	dcs_reset_w(1);
 	dcs_reset_w(0);
+	dcs_reset_w(1);
 
 	/* reset I/O shuffling */
 	for (i = 0; i < 16; i++)

--- a/src/machine/midwunit_machine.c
+++ b/src/machine/midwunit_machine.c
@@ -170,6 +170,8 @@ WRITE16_HANDLER( midxunit_io_w )
 WRITE16_HANDLER( midxunit_unknown_w )
 {
 	int offs = offset / 0x40000;
+	if (offs == 1 && ACCESSING_LSB)
+		dcs_reset_w(data & 2);
 	if (ACCESSING_LSB && offset % 0x40000 == 0)
 		log_cb(RETRO_LOG_DEBUG, LOGPRE "%08X:midxunit_unknown_w @ %d = %02X\n", activecpu_get_pc(), offs, data & 0xff);
 }

--- a/src/sndhrdw/dcs.c
+++ b/src/sndhrdw/dcs.c
@@ -656,8 +656,8 @@ int dcs_control_r(void)
 
 void dcs_reset_w(int state)
 {
-	/* going high halts the CPU */
-	if (state)
+	/* going low halts the CPU */
+	if (!state)
 	{
 		log_cb(RETRO_LOG_DEBUG, LOGPRE "%08x: DCS reset = %d\n", activecpu_get_pc(), state);
 
@@ -666,7 +666,7 @@ void dcs_reset_w(int state)
 		cpu_set_reset_line(dcs_cpunum, ASSERT_LINE);
 	}
 	
-	/* going low resets and reactivates the CPU */
+	/* going high resets and reactivates the CPU */
 	else
 		cpu_set_reset_line(dcs_cpunum, CLEAR_LINE);
 }


### PR DESCRIPTION
dcs reset - midway dcs active low

Fixes volume initiation for revx, along with other midway titles #856 