### PR TITLE
add blocks for targeting rpi0 and rpi1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,6 @@ else ifeq ($(platform), rpi0)
    CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
    CPU_ARCH := arm
    ARM = 1
-   USE_CYCLONE := 1
 
 else ifeq ($(platform), rpi1)
    TARGET = $(TARGET_NAME)_libretro.so

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,29 @@ else ifeq ($(platform), ctr)
    CPU_ARCH := arm
    STATIC_LINKING = 1
 
+else ifeq ($(platform), rpi0)
+   TARGET = $(TARGET_NAME)_libretro.so
+   fpic = -fPIC
+   CFLAGS += $(fpic)
+   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+   PLATCFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+   PLATCFLAGS += -fomit-frame-pointer -ffast-math
+   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+   CPU_ARCH := arm
+   ARM = 1
+   USE_CYCLONE := 1
+
+else ifeq ($(platform), rpi1)
+   TARGET = $(TARGET_NAME)_libretro.so
+   fpic = -fPIC
+   CFLAGS += $(fpic)
+   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+   PLATCFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+   PLATCFLAGS += -fomit-frame-pointer -ffast-math
+   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+   CPU_ARCH := arm
+   ARM = 1
+
 else ifeq ($(platform), rpi2)
    TARGET = $(TARGET_NAME)_libretro.so
    fpic = -fPIC


### PR DESCRIPTION
As with the existing rpi platforms, either the user will have to manually specify the value or set it in the build environment. E.g. `make platform=rpi0`

I have set Cyclone to be used for rpi0. This won't have any effect on any existing rpi0 build environments so folks could try out the Cyclone code more easily