### PR TITLE
sbowling color correction

### DIFF
--- a/src/drivers/sbowling.c
+++ b/src/drivers/sbowling.c
@@ -288,9 +288,9 @@ INPUT_PORTS_END
 static struct GfxLayout charlayout =
 {
 	8,8,
-	256,
+	RGN_FRAC(1,3),
 	3,
-	{ 0x800*0*8, 0x800*1*8, 0x800*2*8 },
+	{ RGN_FRAC(0,3), RGN_FRAC(1,3), RGN_FRAC(2,3) },
 	{ 7, 6, 5, 4, 3, 2, 1, 0 },
 	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8 },
 	8*8
@@ -320,12 +320,13 @@ static PALETTE_INIT( sbowling )
 
 	const int resistances_rg[3] = { 470, 270, 100 };
 	const int resistances_b[2]  = { 270, 100 };
-	double weights_r[3], weights_g[3], weights_b[2];
+	double outputs_r[1<<3], outputs_g[1<<3], outputs_b[1<<2];
 
-	compute_resistor_weights(0,	255,	-1.0,
-			3,	resistances_rg,	weights_r,	0,	100,
-			3,	resistances_rg,	weights_g,	0,	100,
-			2,	resistances_b,	weights_b,	0,	100);
+	/* the game uses output collector PROMs type: NEC B406  */
+	compute_resistor_net_outputs(0, 255,	-1.0,
+		3,	resistances_rg, outputs_r,	0,	100,
+		3,	resistances_rg, outputs_g,	0,	100,
+		2,	resistances_b,  outputs_b,	0,	100);
 
 	for (i = 0;i < Machine->drv->total_colors;i++)
 	{
@@ -334,19 +335,19 @@ static PALETTE_INIT( sbowling )
 		/* blue component */
 		bit0 = (color_prom[i] >> 0) & 0x01;
 		bit1 = (color_prom[i] >> 1) & 0x01;
-		b = combine_2_weights(weights_b, bit0, bit1);
+		b = (int)(outputs_b[ (bit0<<0) | (bit1<<1) ] + 0.5);
 
 		/* green component */
 		bit0 = (color_prom[i] >> 2) & 0x01;
 		bit1 = (color_prom[i] >> 3) & 0x01;
 		bit2 = (color_prom[i+0x400] >> 0) & 0x01;
-		g = combine_3_weights(weights_g, bit0, bit1, bit2);
+		g = (int)(outputs_g[ (bit0<<0) | (bit1<<1) | (bit2<<2) ] + 0.5);
 
 		/* red component */
 		bit0 = (color_prom[i+0x400] >> 1) & 0x01;
 		bit1 = (color_prom[i+0x400] >> 2) & 0x01;
 		bit2 = (color_prom[i+0x400] >> 3) & 0x01;
-		r = combine_3_weights(weights_r, bit0, bit1, bit2);
+		r = (int)(outputs_r[ (bit0<<0) | (bit1<<1) | (bit2<<2) ] + 0.5);
 
 		palette_set_color(i,r,g,b);
 	}

--- a/src/vidhrdw/res_net.h
+++ b/src/vidhrdw/res_net.h
@@ -269,7 +269,7 @@ static double compute_resistor_net_outputs(
 	int networks_no;
 
 	int rescount[MAX_NETS];		/* number of resistors in each of the nets */
-	double r[MAX_NETS][MAX_RES_PER_NET];		/* resistances */
+	double r[MAX_NETS][18];		/* resistances */
 	double *o;					/* calulated outputs */
 	double *os;					/* calulated, scaled outputss */
 	int r_pd[MAX_NETS];			/* pulldown resistances */
@@ -286,8 +286,8 @@ static double compute_resistor_net_outputs(
 
 	/* parse input parameters */
 
-	o  = (double *) malloc( sizeof(double) * (1<<MAX_RES_PER_NET) *  MAX_NETS);
-	os = (double *) malloc( sizeof(double) * (1<<MAX_RES_PER_NET) *  MAX_NETS);
+	o  = (double *) malloc( sizeof(double) * (1<<18) *  MAX_NETS);
+	os = (double *) malloc( sizeof(double) * (1<<18) *  MAX_NETS);
 
 	networks_no = 0;
 	for (n = 0; n < MAX_NETS; n++)
@@ -322,9 +322,9 @@ static double compute_resistor_net_outputs(
 		}
 
 		/* parameters validity check */
-		if (count > MAX_RES_PER_NET)
+		if (count > 18)
 		{
-			logerror(" ERROR: res_net.h: compute_resistor_net_outputs(): too many resistors in net #%i. The maximum allowed is %i, the number requested was: %i\n",n, MAX_RES_PER_NET, count);
+			logerror(" ERROR: res_net.h: compute_resistor_net_outputs(): too many resistors in net #%i. The maximum allowed is %i, the number requested was: %i\n",n, 18, count);
 			/* quit */
 			free(o);
 			free(os);
@@ -380,7 +380,7 @@ static double compute_resistor_net_outputs(
 			/* and convert it to a destination value */
 			dst = (Vout < minval) ? minval : (Vout > maxval) ? maxval : Vout;
 
-			o[i*(1<<MAX_RES_PER_NET)+n] = dst;
+			o[i*(1<<18)+n] = dst;
 		}
 	}
 
@@ -396,10 +396,10 @@ static double compute_resistor_net_outputs(
 
 		for (n = 0; n < (1<<rescount[i]); n++)
 		{
-			if (min_tmp > o[i*(1<<MAX_RES_PER_NET)+n])
-				min_tmp = o[i*(1<<MAX_RES_PER_NET)+n];
-			if (max_tmp < o[i*(1<<MAX_RES_PER_NET)+n])
-				max_tmp = o[i*(1<<MAX_RES_PER_NET)+n];
+			if (min_tmp > o[i*(1<<18)+n])
+				min_tmp = o[i*(1<<18)+n];
+			if (max_tmp < o[i*(1<<18)+n])
+				max_tmp = o[i*(1<<18)+n];
 		}
 
 		max_out[i] = max_tmp;	/* maximum output */
@@ -429,8 +429,8 @@ static double compute_resistor_net_outputs(
 	{
 		for (n = 0; n < (1<<rescount[i]); n++)
 		{
-			os[i*(1<<MAX_RES_PER_NET)+n] = (o[i*(1<<MAX_RES_PER_NET)+n] - min) * scale;	/* scale the result */
-			(out[i])[n] = os[i*(1<<MAX_RES_PER_NET)+n];		/* fill the output table */
+			os[i*(1<<18)+n] = (o[i*(1<<18)+n] - min) * scale;	/* scale the result */
+			(out[i])[n] = os[i*(1<<18)+n];		/* fill the output table */
 		}
 	}
 
@@ -454,7 +454,7 @@ static double compute_resistor_net_outputs(
 		}
 		for (n = 0; n < (1<<rescount[i]); n++)
 		{
-			logerror("   combination %2i  out=%10.5f (scaled = %15.10f)\n", n, o[i*(1<<MAX_RES_PER_NET)+n], os[i*(1<<MAX_RES_PER_NET)+n] );
+			logerror("   combination %2i  out=%10.5f (scaled = %15.10f)\n", n, o[i*(1<<18)+n], os[i*(1<<18)+n] );
 		}
 	}
 #endif


### PR DESCRIPTION
Wip - proof of concept. MAX_RES_PER_NET was changed to 18 within compute_resistor_net_outputs only to work properly. MAX_RES_PER_NET should be set to 18.

Currently MAX_RES_PER_NET is set to 32 since our code used this hard coded value until testing can be completed to see if 18 works within the weights code as well.