### PR TITLE
comply as best as possible with analog input api

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -170,24 +170,22 @@ extern void mame2003_video_get_geometry(struct retro_game_geometry *geom);
 /* the first of our controllers can use the base retropad type and rename it,
  * while any layout variations must subclass the type.
  */
-#define PAD_MODERN  RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 0)
-#define PAD_8BUTTON RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 1)
-#define PAD_6BUTTON RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 2)
+#define PAD_MODERN  RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 0)
+#define PAD_8BUTTON RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 1)
+#define PAD_6BUTTON RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 2)
 
 static struct retro_controller_description controllers[] = {
-  { "Classic Gamepad",    RETRO_DEVICE_JOYPAD },
+  { "Classic Gamepad",    RETRO_DEVICE_ANALOG },
   { "Modern Fightstick",  PAD_MODERN  },
   { "8-Button",           PAD_8BUTTON },
   { "6-Button",           PAD_6BUTTON },
-  { NULL, 0 },
 };
 
 static struct retro_controller_description unsupported_controllers[] = {
-  { "UNSUPPORTED (Classic Gamepad)",    RETRO_DEVICE_JOYPAD },
+  { "UNSUPPORTED (Classic Gamepad)",    RETRO_DEVICE_ANALOG },
   { "UNSUPPORTED (Modern Fightstick)",  PAD_MODERN  },
   { "UNSUPPORTED (8-Button)",           PAD_8BUTTON },
   { "UNSUPPORTED (6-Button)",           PAD_6BUTTON },
-  { NULL, 0 },
 };
 
 static struct retro_controller_info retropad_subdevice_ports[] = {
@@ -427,11 +425,11 @@ static void update_variables(bool first_time)
       {
         case OPT_INPUT_INTERFACE:
           if(strcmp(var.value, "retropad") == 0)
-            options.input_interface = RETRO_DEVICE_JOYPAD;
+            options.input_interface = RETRO_DEVICE_ANALOG;
           else if(strcmp(var.value, "keyboard") == 0)
             options.input_interface = RETRO_DEVICE_KEYBOARD;
 		    else
-			    options.input_interface = RETRO_DEVICE_KEYBOARD + RETRO_DEVICE_JOYPAD;
+			    options.input_interface = RETRO_DEVICE_KEYBOARD + RETRO_DEVICE_ANALOG;
         break;
 
         case OPT_4WAY:
@@ -1657,7 +1655,7 @@ void retro_describe_controls(void)
         continue;
 
       needle->port = display_idx - 1;
-      needle->device = RETRO_DEVICE_JOYPAD;
+      needle->device = RETRO_DEVICE_ANALOG;
       needle->index = 0;
       needle->id = retro_type;
       needle->description = control_name;
@@ -1730,7 +1728,7 @@ int get_mame_ctrl_id(int display_idx, int retro_ID)
   log_cb(RETRO_LOG_DEBUG, "display_idx: %i | options.retropad_layout[display_idx - 1]: %i\n", display_idx, options.retropad_layout[display_idx - 1]);
   switch(options.retropad_layout[display_idx - 1])
   {
-    case RETRO_DEVICE_JOYPAD:
+    case RETRO_DEVICE_ANALOG:
     {
       switch(retro_ID)
       {
@@ -1924,7 +1922,7 @@ const struct JoystickInfo *osd_get_joy_list(void)
 
       switch(coded_layout)
       {
-        case RETRO_DEVICE_JOYPAD: layout_idx = IDX_CLASSIC; break;
+        case RETRO_DEVICE_ANALOG: layout_idx = IDX_CLASSIC; break;
         case PAD_MODERN:          layout_idx = IDX_MODERN;  break;
         case PAD_8BUTTON:         layout_idx = IDX_8BUTTON; break;
         case PAD_6BUTTON:         layout_idx = IDX_6BUTTON; break;
@@ -2133,7 +2131,7 @@ const struct KeyboardInfo *osd_get_key_list(void)
 
 int osd_is_key_pressed(int keycode)
 {
-	if (options.input_interface == RETRO_DEVICE_JOYPAD)
+	if (options.input_interface == RETRO_DEVICE_ANALOG)
 		return 0; /* do not return keyboard input if the core option is set to retropad/joystick only */
 
 	if (keycode < RETROK_LAST && keycode >= 0)


### PR DESCRIPTION
FWIW I have done a lot of the writing and editorial work that has gone into the libretro input API developer docs. I have been expanding them the last few weeks, but it's still pretty sparse: https://github.com/libretro/docs/blob/master/docs/development/input-api.md

That said, I have been studying `libretro.h` closely and making use of the reference input implementation here: https://github.com/libretro/libretro-samples/blob/master/tests/test/libretro-test.c

This PR is my attempt to see if netplay issues could be related to currently declaring `RETRO_DEVICE_JOYPAD` instead of `RETRO_DEVICE_ANALOG` as my reading of these sources suggests is the way to do it.