### PR TITLE
cleanup, less redundancy between libretro & mame input

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1898,7 +1898,6 @@ InputSeq* input_port_type_seq(int type)
 
 InputSeq* input_port_seq(const struct InputPort *in)
 {
-// mark change the (! 0 && ((in-1)->type & IPF_CHEAT))) to a variable name if you want to make it a core option just disable for now until you make a choice
 	int i,type;
 
 	static InputSeq ip_none = SEQ_DEF_1(CODE_NONE);

--- a/src/input.c
+++ b/src/input.c
@@ -14,11 +14,6 @@
 /***************************************************************************/
 /* Codes */
 
-/* Subtype of codes */
-#define CODE_TYPE_NONE 0U /* code not assigned */
-#define CODE_TYPE_KEYBOARD 1U /* keyboard code */
-#define CODE_TYPE_JOYSTICK 2U /* joystick code */
-
 /* Informations for every input code */
 struct code_info {
 	int memory; /* boolean memory */
@@ -125,6 +120,11 @@ static int internal_oscode_find(unsigned oscode, unsigned type)
 
 	/* oscode not found */
 	return CODE_NONE;
+}
+
+int oscode_find(unsigned oscode, unsigned type)
+{
+  return internal_oscode_find(oscode, type);
 }
 
 /* Add a new oscode in the table */
@@ -257,7 +257,7 @@ static const char* internal_code_name(InputCode code)
 }
 
 /* Update the code table */
-static void internal_code_update(void)
+void internal_code_update(void)
 {
   const struct KeyboardInfo *keyinfo;
   const struct JoystickInfo *joyinfo;

--- a/src/input.h
+++ b/src/input.h
@@ -3,6 +3,11 @@
 
 typedef unsigned InputCode;
 
+/* Subtype of codes */
+#define CODE_TYPE_NONE 0U /* code not assigned */
+#define CODE_TYPE_KEYBOARD 1U /* keyboard code */
+#define CODE_TYPE_JOYSTICK 2U /* joystick code */
+
 struct KeyboardInfo
 {
   const char *name; /* OS dependant name; 0 terminates the list */
@@ -145,9 +150,12 @@ int code_init(void);
 void code_close(void);
 
 InputCode keyoscode_to_code(unsigned oscode);
-InputCode joyoscode_to_code(unsigned oscode);
+InputCode joyoscode_to_code(unsigned oscode);          /* insert if missing */
 InputCode savecode_to_code(unsigned savecode);
+int oscode_find(unsigned oscode, unsigned type);       /* does not insert if missing */
 unsigned code_to_savecode(InputCode code);
+
+void internal_code_update(void);
 
 const char *code_name(InputCode code);
 int code_pressed(InputCode code);
@@ -209,9 +217,5 @@ int input_ui_pressed_repeat(int code, int speed);
 int is_joystick_axis_code(unsigned code);
 int return_os_joycode(InputCode code);
 
-#define LIBRETRO_ANALOG_MIN -32768
-#define LIBRETRO_ANALOG_MAX 32767
-#define ANALOG_MIN -128
-#define ANALOG_MAX 128
 
 #endif

--- a/src/mame.h
+++ b/src/mame.h
@@ -169,9 +169,9 @@ enum /* used to index content-specific flags */
   CONTENT_ROTATE_JOY_45,
   CONTENT_PLAYER_COUNT,
   CONTENT_CTRL_COUNT,
+  CONTENT_DUAL_JOYSTICK,
   CONTENT_BUTTON_COUNT,
   CONTENT_JOYSTICK_DIRECTIONS,
-  CONTENT_DCS_SPEEDHACK,
   CONTENT_NVRAM_BOOTSTRAP,
   CONTENT_end,
 };
@@ -207,7 +207,8 @@ struct GameOptions
   unsigned tate_mode;
 
   int      crosshair_enable;
-  unsigned activate_dcs_speedhack;
+  bool     activate_dcs_speedhack;
+
   bool     mame_remapping;       /* display MAME input remapping menu */
 
   int      samplerate;		       /* sound sample playback rate, in KHz */

--- a/src/mame.h
+++ b/src/mame.h
@@ -200,10 +200,10 @@ struct GameOptions
 
   unsigned dial_share_xy;
   unsigned mouse_device;
-  unsigned input_interface;                    /* can be set to RETRO_DEVICE_JOYPAD, RETRO_DEVICE_KEYBOARD, or 0 (both simultaneously) */
-  unsigned retropad_layout[MAX_PLAYER_COUNT];  /* flags to indicate the default layout for each player */
-  bool 	   restrict_4_way;                     /* simulate 4-way joystick restrictor */
-  unsigned deadzone;                           /* analog deadzone in percent. 20 corresponds to 20% */
+  unsigned input_interface;                         /* can be set to RETRO_DEVICE_JOYPAD, RETRO_DEVICE_KEYBOARD, or 0 (both simultaneously) */
+  unsigned active_control_type[MAX_PLAYER_COUNT];   /* register to indicate the default control layout for each player as currently set in the frontend */
+  bool     restrict_4_way;                          /* simulate 4-way joystick restrictor */
+  unsigned deadzone;                                /* analog deadzone in percent. 20 corresponds to 20% */
   unsigned tate_mode;
 
   int      crosshair_enable;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1701,9 +1701,12 @@ void retro_describe_controls(void)
         control_name = game_driver->ctrl_dat->get_name(button_ipt_id);
       if(string_is_empty(control_name))
         continue;
-
+      
+      /* As of April 2021, there may be a RetroArch bug which doesn't accept the
+       * result of RETRO_DEVICE_SUBCLASS when passed as part of this description.
+       * For now, the device is hard-coded as RETRO_DEVICE_JOYPAD */
       needle->port         = player_number - 1;
-      needle->device       = RETRO_DEVICE_JOYPAD;
+      needle->device       = /*options.active_control_type[player_number - 1]*/ RETRO_DEVICE_JOYPAD;
       needle->index        = 0;
       needle->id           = retro_code;
       needle->description  = control_name;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1066,7 +1066,16 @@ static void set_content_flags(void)
 				case IPT_JOYSTICKLEFT_DOWN:
 				case IPT_JOYSTICKLEFT_LEFT:
 				case IPT_JOYSTICKLEFT_RIGHT:
-					break;
+        {
+          static bool dualjoy_first_announce = false;
+          if(!dualjoy_first_announce)
+          {
+            log_cb(RETRO_LOG_INFO, LOGPRE "Content identified as using dual joystick controls controls.\n");
+            dualjoy_first_announce = true;
+          }
+          /* As of now, we don't have an option flag for this field. */
+          break;
+        }
 				case IPT_BUTTON1:
 					if (options.content_flags[CONTENT_BUTTON_COUNT] < 1) options.content_flags[CONTENT_BUTTON_COUNT] = 1;
 					break;
@@ -1648,7 +1657,7 @@ void retro_describe_controls(void)
     unsigned button_ipt_id    = 0;      /* input code connects an input port with standard input code */
     bool retropad_type        = false;
 
-    log_cb(RETRO_LOG_DEBUG, "player_number: %i | active_control_type[player_number - 1]: %i\n", player_number, options.active_control_type[player_number - 1]);
+    log_cb(RETRO_LOG_DEBUG, "player_number: %i | active_control_type: %i\n", player_number, options.active_control_type[player_number - 1]);
 
     if(options.active_control_type[player_number-1] == RETRO_DEVICE_NONE)
       continue; /* the null input device is selected; move on to the next player */
@@ -2319,13 +2328,11 @@ static void remove_slash (char* temp)
 
   for(i=0; temp[i] != '\0'; ++i);
 
-  log_cb(RETRO_LOG_INFO, LOGPRE "Check for trailing slash in path: %s\n", temp);
-
   if( (temp[i-1] == '/' || temp[i-1] == '\\') && (i > 1) )
   {
     temp[i-1] = 0;
-    log_cb(RETRO_LOG_INFO, LOGPRE "Removed a trailing slash in path: %s\n", temp);
+    log_cb(RETRO_LOG_DEBUG, LOGPRE "Removed a trailing slash in path: %s\n", temp);
   }
   else
-    log_cb(RETRO_LOG_INFO, LOGPRE "Trailing slash removal was not necessary for path given.\n");
+    log_cb(RETRO_LOG_DEBUG, LOGPRE "Trailing slash removal was not necessary path: %s.\n", temp);
 }

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1128,9 +1128,10 @@ static void set_content_flags(void)
   if(game_driver->bootstrap != NULL)
     options.content_flags[CONTENT_NVRAM_BOOTSTRAP] = true;
 
-  /************ LOG THE FINAL STATE OF THE CONTENT FLAGS ************/
+
+  /************ LOG THE STATE OF THE CONTENT FLAGS ************/
   
-  log_cb(RETRO_LOG_INFO, LOGPRE "==== DRIVER CONTENT ATTRIBUTES ====\n");
+  log_cb(RETRO_LOG_INFO, LOGPRE "==== BEGIN DRIVER CONTENT ATTRIBUTES ====\n");
   
   if(options.content_flags[CONTENT_NEOGEO])     log_cb(RETRO_LOG_INFO, LOGPRE "* Neo Geo BIOS required.\n");
   if(options.content_flags[CONTENT_STV])        log_cb(RETRO_LOG_INFO, LOGPRE "* STV BIOS required.\n");
@@ -1160,6 +1161,7 @@ static void set_content_flags(void)
 
   if(options.content_flags[CONTENT_NVRAM_BOOTSTRAP])    log_cb(RETRO_LOG_INFO, LOGPRE "* Uses an NVRAM bootstrap controlled via core option.\n");
 
+  log_cb(RETRO_LOG_INFO, LOGPRE "==== END DRIVER CONTENT ATTRIBUTES ====\n");
 }
 
 void retro_reset (void)

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1029,8 +1029,8 @@ static void set_content_flags(void)
 					break;
 			}
 
-      if (input->type & IPF_4WAY) /* the controls use a 4-way joystick */
-        options.content_flags[CONTENT_JOYSTICK_DIRECTIONS] = 4;
+			if (input->type & IPF_4WAY) /* the controls use a 4-way joystick */
+				options.content_flags[CONTENT_JOYSTICK_DIRECTIONS] = 4;
 
 			switch (input->type & ~IPF_MASK)
 			{
@@ -1042,8 +1042,8 @@ static void set_content_flags(void)
 				case IPT_JOYSTICKLEFT_DOWN:
 				case IPT_JOYSTICKLEFT_LEFT:
 				case IPT_JOYSTICKLEFT_RIGHT:
-          options.content_flags[CONTENT_DUAL_JOYSTICK] = true;
-          break;
+					options.content_flags[CONTENT_DUAL_JOYSTICK] = true;
+					break;
 				case IPT_BUTTON1:
 					if (options.content_flags[CONTENT_BUTTON_COUNT] < 1) options.content_flags[CONTENT_BUTTON_COUNT] = 1;
 					break;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1066,7 +1066,6 @@ static void set_content_flags(void)
 				case IPT_JOYSTICKLEFT_DOWN:
 				case IPT_JOYSTICKLEFT_LEFT:
 				case IPT_JOYSTICKLEFT_RIGHT:
-					log_cb(RETRO_LOG_INFO, LOGPRE "Content identified as using dual joystick controls controls.\n");
 					break;
 				case IPT_BUTTON1:
 					if (options.content_flags[CONTENT_BUTTON_COUNT] < 1) options.content_flags[CONTENT_BUTTON_COUNT] = 1;

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -62,6 +62,10 @@ extern "C" {
 #define MAX_MEMORY_REGIONS      32
 
 #define NORMALIZED_ANALOG_THRESHOLD   64
+#define LIBRETRO_ANALOG_MIN -32768
+#define LIBRETRO_ANALOG_MAX 32767
+#define ANALOG_MIN -128
+#define ANALOG_MAX 128
 
 enum
 {
@@ -137,7 +141,6 @@ enum
   OSD_ANALOG_RIGHT_POSITIVE_Y,
   OSD_INPUT_CODES_PER_PLAYER
 };
-
 
 /******************************************************************************
 
@@ -342,7 +345,7 @@ const struct JoystickInfo *osd_get_joy_list(void);
 int osd_is_joy_pressed(int joycode);
 
 /* added for building joystick seq for analog inputs */
-int osd_is_joystick_axis_code(int joycode);
+int osd_is_joystick_axis_code(unsigned joycode);
 
 /* osd_analogjoy_read returns in the range -128 .. 128 (yes, 128, not 127) */
 void osd_analogjoy_read(  int player,


### PR DESCRIPTION
This gets rid up a lot of redundant lines of code to determine the button that I wrote when implementing the control names for libretro frontends.

I am still testing this to make sure there not regressions, but it should not change any functionality. I'll merge once I make sure control descriptions are still making it into the right places.