### PR TITLE
add helper to pre-set input sequences with 7 codes

### DIFF
--- a/src/drivers/pacman.c
+++ b/src/drivers/pacman.c
@@ -775,11 +775,17 @@ static MEMORY_WRITE_START( mspacman_writemem )
 MEMORY_END
 
 
+READ_HANDLER(mspactwin_spriteram_r)
+{
+	return spriteram[offset];
+}
+
 static MEMORY_READ_START( mspactwin_readmem )
 	{ 0x0000, 0x1fff, MRA_ROM },
 	{ 0x2000, 0x3fff, MRA_ROM },
 	{ 0x4000, 0x47ff, MRA_RAM },	/* video and color RAM */
-	{ 0x4c00, 0x4fff, MRA_RAM },	/* including sprite codes at 4ff0-4fff */
+	{ 0x4c00, 0x4fef, MRA_RAM },
+	{ 0x4ff0, 0x4fff, mspactwin_spriteram_r },	/*sprite codes at 4ff0-4fff */
 	{ 0x5000, 0x5000, input_port_0_r },	/* IN0 */
 	{ 0x5040, 0x5040, input_port_1_r },	/* IN1 */
 	{ 0x5080, 0x50bf, input_port_4_r },	/* DSW1 */

--- a/src/input.c
+++ b/src/input.c
@@ -588,6 +588,33 @@ void seq_set_5(InputSeq* a, InputCode code1, InputCode code2, InputCode code3, I
 		(*a)[j] = CODE_NONE;
 }
 
+void seq_set_6(InputSeq* a, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6)
+{
+	int j;
+	(*a)[0] = code1;
+	(*a)[1] = code2;
+	(*a)[2] = code3;
+	(*a)[3] = code4;
+	(*a)[4] = code5;
+	(*a)[5] = code6;
+	for(j=6;j<SEQ_MAX;++j)
+		(*a)[j] = CODE_NONE;
+}
+
+void seq_set_7(InputSeq* a, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6, InputCode code7)
+{
+	int j;
+	(*a)[0] = code1;
+	(*a)[1] = code2;
+	(*a)[2] = code3;
+	(*a)[3] = code4;
+	(*a)[4] = code5;
+	(*a)[5] = code6;
+	(*a)[6] = code7;
+	for(j=7;j<SEQ_MAX;++j)
+		(*a)[j] = CODE_NONE;
+}
+
 void seq_copy(InputSeq* a, InputSeq* b)
 {
 	int j;

--- a/src/input.h
+++ b/src/input.h
@@ -198,8 +198,9 @@ int seq_pressed(InputSeq* seq);
 void seq_read_async_start(void);
 int seq_read_async(InputSeq* code, int first);
 
-/* NOTE: It's very important that this sequence is EXACLY long SEQ_MAX */
-#define SEQ_DEF_6(a,b,c,d,e,f) { a, b, c, d, e, f, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE }
+/* NOTE: It's very important that this sequence is EXACTLY long SEQ_MAX */
+#define SEQ_DEF_7(a,b,c,d,e,f,g) { a, b, c, d, e, f, g, h, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE }
+#define SEQ_DEF_6(a,b,c,d,e,f) SEQ_DEF_7(a,b,c,d,e,f,g,CODE_NONE)
 #define SEQ_DEF_5(a,b,c,d,e) SEQ_DEF_6(a,b,c,d,e,CODE_NONE)
 #define SEQ_DEF_4(a,b,c,d) SEQ_DEF_5(a,b,c,d,CODE_NONE)
 #define SEQ_DEF_3(a,b,c) SEQ_DEF_4(a,b,c,CODE_NONE)

--- a/src/input.h
+++ b/src/input.h
@@ -189,6 +189,8 @@ void seq_set_2(InputSeq* seq, InputCode code1, InputCode code2);
 void seq_set_3(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3);
 void seq_set_4(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4);
 void seq_set_5(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5);
+void seq_set_6(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6);
+void seq_set_7(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6, InputCode code7);
 void seq_copy(InputSeq* seqdst, InputSeq* seqsrc);
 int seq_cmp(InputSeq* seq1, InputSeq* seq2);
 void seq_name(InputSeq* seq, char* buffer, unsigned max);


### PR DESCRIPTION
I'm trying to break down some larger changes into small PRs. This one is pretty simple -- it just adds helpers to let us pre-set input sequences with up to 7 codes (for example: [keyboard up OR dpad up OR left joystick up OR lightgun dpad UP]).

This functionality already exists in terms of the core being able to handle 16 codes per sequence, there just aren't functions to pre-set that many codes until now.