### PR TITLE
add helpers to set 7-code input sequences

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -588,6 +588,33 @@ void seq_set_5(InputSeq* a, InputCode code1, InputCode code2, InputCode code3, I
 		(*a)[j] = CODE_NONE;
 }
 
+void seq_set_6(InputSeq* a, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6)
+{
+	int j;
+	(*a)[0] = code1;
+	(*a)[1] = code2;
+	(*a)[2] = code3;
+	(*a)[3] = code4;
+	(*a)[4] = code5;
+	(*a)[5] = code6;
+	for(j=6;j<SEQ_MAX;++j)
+		(*a)[j] = CODE_NONE;
+}
+
+void seq_set_7(InputSeq* a, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6, InputCode code7)
+{
+	int j;
+	(*a)[0] = code1;
+	(*a)[1] = code2;
+	(*a)[2] = code3;
+	(*a)[3] = code4;
+	(*a)[4] = code5;
+	(*a)[5] = code6;
+	(*a)[6] = code7;
+	for(j=7;j<SEQ_MAX;++j)
+		(*a)[j] = CODE_NONE;
+}
+
 void seq_copy(InputSeq* a, InputSeq* b)
 {
 	int j;

--- a/src/input.h
+++ b/src/input.h
@@ -189,6 +189,8 @@ void seq_set_2(InputSeq* seq, InputCode code1, InputCode code2);
 void seq_set_3(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3);
 void seq_set_4(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4);
 void seq_set_5(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5);
+void seq_set_6(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6);
+void seq_set_7(InputSeq* seq, InputCode code1, InputCode code2, InputCode code3, InputCode code4, InputCode code5, InputCode code6, InputCode code7);
 void seq_copy(InputSeq* seqdst, InputSeq* seqsrc);
 int seq_cmp(InputSeq* seq1, InputSeq* seq2);
 void seq_name(InputSeq* seq, char* buffer, unsigned max);
@@ -196,8 +198,9 @@ int seq_pressed(InputSeq* seq);
 void seq_read_async_start(void);
 int seq_read_async(InputSeq* code, int first);
 
-/* NOTE: It's very important that this sequence is EXACLY long SEQ_MAX */
-#define SEQ_DEF_6(a,b,c,d,e,f) { a, b, c, d, e, f, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE }
+/* NOTE: It's very important that this sequence is EXACTLY long SEQ_MAX */
+#define SEQ_DEF_7(a,b,c,d,e,f,g) { a, b, c, d, e, f, g, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE, CODE_NONE }
+#define SEQ_DEF_6(a,b,c,d,e,f) SEQ_DEF_7(a,b,c,d,e,f,CODE_NONE)
 #define SEQ_DEF_5(a,b,c,d,e) SEQ_DEF_6(a,b,c,d,e,CODE_NONE)
 #define SEQ_DEF_4(a,b,c,d) SEQ_DEF_5(a,b,c,d,CODE_NONE)
 #define SEQ_DEF_3(a,b,c) SEQ_DEF_4(a,b,c,CODE_NONE)


### PR DESCRIPTION
I'm trying to break down some larger changes into small PRs. This one is pretty simple -- it just adds helpers to let us pre-set input sequences with up to 7 codes (for example: [keyboard up OR dpad up OR left joystick up OR lightgun dpad UP]).

This functionality already exists in terms of the core being able to handle 16 codes per sequence, there just aren't functions to pre-set that many codes until now.