### PR TITLE
do not cache lightgun input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -708,6 +708,14 @@ else
 	CFLAGS += -D__WIN32__
 endif
 
+
+# All Android platforms       #############################
+ifneq ($(findstring Android, $(platform)), )
+	PLATCFLAGS += -D__ANDROID__
+else ifneq ($(findstring android, $(platform)), )
+	PLATCFLAGS += -D__ANDROID__
+endif
+
 # Architecture-specific flags #############################
 
 ifeq ($(BIGENDIAN), 1)
@@ -716,9 +724,10 @@ endif
 
 # End of architecture-specific flags ######################
 
-# Compiler flags for all platforms #############################
+# Compiler flags for all platforms ########################
 
-# explictly use -fsigned-char on all platforms to solve problems with code written/tested on x86 but used on ARM
+# explictly use -fsigned-char on all platforms to solve problems
+# with code written/tested on x86 but used on ARM
 # for example, audio on rtype leo is wrong on ARM without this flag
 ifeq (,$(findstring msvc,$(platform)))
 	CFLAGS += -fsigned-char

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1491,11 +1491,11 @@ profiler_mark(PROFILER_INPUT);
 		osd_analogjoy_read (i, analog_current_axis[i], analogjoy_input[i]);
 
 		/* update mouse/trackball position */
-		if(options.mouse_device == MOUSE || options.mouse_device == POINTER)
+		if(options.mouse_device == RETRO_DEVICE_MOUSE || options.mouse_device == RETRO_DEVICE_POINTER)
 			osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS]);
 
 		/* update lightgun position, if any */
-		else if(options.mouse_device == LIGHTGUN)
+		else if(options.mouse_device == RETRO_DEVICE_LIGHTGUN)
  			osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS]);
 	}
 

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1491,10 +1491,12 @@ profiler_mark(PROFILER_INPUT);
 		osd_analogjoy_read (i, analog_current_axis[i], analogjoy_input[i]);
 
 		/* update mouse/trackball position */
-		osd_trak_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS]);
+		if(options.mouse_device == MOUSE || options.mouse_device == POINTER)
+			osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS]);
 
 		/* update lightgun position, if any */
- 		osd_lightgun_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS]);
+		else if(options.mouse_device == LIGHTGUN)
+ 			osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS]);
 	}
 
 	for (i = 0;i < MAX_INPUT_PORTS;i++)

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2157,7 +2157,7 @@ int osd_is_joy_pressed(int joycode)
 
 
   /*** Use the cached input states ***/
-  return retroJsState[player_number-1][osd_code];
+  return retroJsState[port][osd_code];
 }
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2328,7 +2328,6 @@ void osd_lightgun_read(int player, int *deltax, int *deltay)
   /* simulated lightgun reload hack */
   if(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
   {
-    retroJsState[player][OSD_LIGHTGUN_IS_TRIGGER] = true;
     *deltax = -128;
     *deltay = -128;
     return;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -240,7 +240,12 @@ void retro_get_system_info(struct retro_system_info *info)
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
+
+#ifdef __ANDROID__
+  info->library_version = "ANDROID TESTING";
+#else 
   info->library_version = GIT_VERSION;
+#endif
   info->valid_extensions = "zip";
   info->need_fullpath = true;
   info->block_extract = true;
@@ -2143,7 +2148,7 @@ int osd_is_joy_pressed(int joycode)
     retro_code = get_retrogun_code(osd_code);
     if(retro_code != INT_MAX)
     {
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
       if(port > 0) return 0;
 #endif
       if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
@@ -2164,7 +2169,8 @@ int osd_is_joy_pressed(int joycode)
     retro_code = get_retromouse_code(osd_code);
     if(retro_code != INT_MAX)
     {
-#if defined(__ANDROID__)
+
+#ifdef __ANDROID__
       if(port > 0) return 0;
 #endif
 
@@ -2315,7 +2321,7 @@ void osd_joystick_end_calibration(void) { }
  */
 void osd_trak_read(int player, int *deltax, int *deltay)
 {
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     if(player > 0)
     {
       *deltax = 0;
@@ -2353,7 +2359,7 @@ void osd_lightgun_read(int player, int *deltax, int *deltay)
     return;
   }
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     if(player > 0)
     {
       *deltax = 0;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1240,6 +1240,24 @@ void retro_run (void)
 
     if(device_type == RETRO_DEVICE_NONE) continue;
 
+    /* Standard retropad */
+    retroJsState[port][OSD_JOYPAD_B]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
+    retroJsState[port][OSD_JOYPAD_Y]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
+    retroJsState[port][OSD_JOYPAD_SELECT] = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT);
+    retroJsState[port][OSD_JOYPAD_START]  = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START);
+    retroJsState[port][OSD_JOYPAD_UP]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP);
+    retroJsState[port][OSD_JOYPAD_DOWN]   = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN);
+    retroJsState[port][OSD_JOYPAD_LEFT]   = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT);
+    retroJsState[port][OSD_JOYPAD_RIGHT]  = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT);
+    retroJsState[port][OSD_JOYPAD_A]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
+    retroJsState[port][OSD_JOYPAD_X]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
+    retroJsState[port][OSD_JOYPAD_L]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L);
+    retroJsState[port][OSD_JOYPAD_R]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R);
+    retroJsState[port][OSD_JOYPAD_L2]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2);
+    retroJsState[port][OSD_JOYPAD_R2]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2);
+    retroJsState[port][OSD_JOYPAD_L3]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3);
+    retroJsState[port][OSD_JOYPAD_R3]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
+
     /* Analog joystick - read as analog axis and rescale for MAME value range */
     analogjoy[port][0] = analog_deadzone_rescale( input_cb(port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_X) );
     analogjoy[port][1] = analog_deadzone_rescale( input_cb(port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_Y) );
@@ -2135,13 +2153,6 @@ int osd_is_joy_pressed(int joycode)
       }
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
     }
-  }
-
-  /* Standard retropad */
-  retro_code = get_retropad_code(osd_code);
-  if (retro_code != INT_MAX)
-  {
-    return input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
   }
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2103,12 +2103,12 @@ int osd_is_joy_pressed(int joycode)
   if (options.mouse_device == RETRO_DEVICE_POINTER || options.mouse_device == RETRO_DEVICE_MOUSE)
   {
     retro_code = get_retromouse_code(osd_code);
-    if(retro_code != INT_MAX)
+    if (retro_code != INT_MAX)
     {
 #ifdef __ANDROID__
-      if(port > 0) return 0;
+      if (port > 0) return 0;
 #endif
-      if(options.mouse_device == RETRO_DEVICE_MOUSE)
+      if (options.mouse_device == RETRO_DEVICE_MOUSE)
         return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
       if (options.mouse_device == RETRO_DEVICE_POINTER && retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
         return input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
@@ -2118,14 +2118,14 @@ int osd_is_joy_pressed(int joycode)
   else if (options.mouse_device == RETRO_DEVICE_LIGHTGUN)
   {
     retro_code = get_retrogun_code(osd_code);
-    if(retro_code != INT_MAX)
+    if (retro_code != INT_MAX)
     {
 #ifdef __ANDROID__
-      if(port > 0) return 0;
+      if (port > 0) return 0;
 #endif
-      if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
+      if (retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
       {
-        if(input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
+        if (input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
           return 1; /* lightgun reload hack, report trigger as being pressed */
       }
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1240,24 +1240,6 @@ void retro_run (void)
 
     if(device_type == RETRO_DEVICE_NONE) continue;
 
-    /* Standard retropad */
-    retroJsState[port][OSD_JOYPAD_B]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
-    retroJsState[port][OSD_JOYPAD_Y]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
-    retroJsState[port][OSD_JOYPAD_SELECT] = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT);
-    retroJsState[port][OSD_JOYPAD_START]  = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START);
-    retroJsState[port][OSD_JOYPAD_UP]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP);
-    retroJsState[port][OSD_JOYPAD_DOWN]   = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN);
-    retroJsState[port][OSD_JOYPAD_LEFT]   = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT);
-    retroJsState[port][OSD_JOYPAD_RIGHT]  = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT);
-    retroJsState[port][OSD_JOYPAD_A]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
-    retroJsState[port][OSD_JOYPAD_X]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
-    retroJsState[port][OSD_JOYPAD_L]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L);
-    retroJsState[port][OSD_JOYPAD_R]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R);
-    retroJsState[port][OSD_JOYPAD_L2]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2);
-    retroJsState[port][OSD_JOYPAD_R2]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2);
-    retroJsState[port][OSD_JOYPAD_L3]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3);
-    retroJsState[port][OSD_JOYPAD_R3]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
-
     /* Analog joystick - read as analog axis and rescale for MAME value range */
     analogjoy[port][0] = analog_deadzone_rescale( input_cb(port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_X) );
     analogjoy[port][1] = analog_deadzone_rescale( input_cb(port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_Y) );
@@ -2153,6 +2135,13 @@ int osd_is_joy_pressed(int joycode)
       }
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
     }
+  }
+
+  /* Standard retropad */
+  retro_code = get_retropad_code(osd_code);
+  if (retro_code != INT_MAX)
+  {
+    return input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
   }
 
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1285,17 +1285,7 @@ void retro_run (void)
     /* Only poll X-Y device if selected by its core option */
     if(options.mouse_device != RETRO_DEVICE_NONE)
     {
-      if(options.mouse_device == RETRO_DEVICE_MOUSE)
-      {
-        retroJsState[port][OSD_MOUSE_BUTTON_1]  = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
-        retroJsState[port][OSD_MOUSE_BUTTON_2]  = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
-        retroJsState[port][OSD_MOUSE_BUTTON_3]  = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
-        retroJsState[port][OSD_MOUSE_BUTTON_4]  = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_4);
-        retroJsState[port][OSD_MOUSE_BUTTON_5]  = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_5);
-        mouse_x[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-        mouse_y[port] = input_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
-      }
-      else if (options.mouse_device == RETRO_DEVICE_POINTER)
+      if (options.mouse_device == RETRO_DEVICE_POINTER)
       {
         bool pointer_pressed = input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
         retroJsState[port][OSD_MOUSE_BUTTON_1]  = pointer_pressed;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -29,7 +29,7 @@
 
 static const struct GameDriver  *game_driver;
 
-int            running = 0;
+int            retro_running = 0;
 int            gotFrame;
 static float   delta_samples;
 int            samples_per_frame = 0;
@@ -1205,11 +1205,11 @@ void retro_run (void)
 {
   int port = 0;
   bool updated = false;
-  poll_cb();
+  poll_cb(); /* execute input callback */
 
-  if (running == 0) /* first time through the loop */
+  if (retro_running == 0) /* first time through the loop */
   {
-    running = 1;
+    retro_running = 1;
     log_cb(RETRO_LOG_DEBUG, LOGPRE "Entering retro_run() for the first time.\n");
   }
 
@@ -2071,8 +2071,8 @@ const struct JoystickInfo *osd_get_joy_list(void)
  */
 int osd_is_joy_pressed(int joycode)
 {
+  if (!retro_running)                                   return 0; /* input callback has not yet been polled */
   if (options.input_interface == RETRO_DEVICE_KEYBOARD) return 0; /* disregard joystick input */
-  if (!running) return 0; /* polling must be completed in retro_run */
 
   unsigned player_number = calc_player_number(joycode);
   unsigned port          = player_number - 1;
@@ -2337,10 +2337,10 @@ const struct KeyboardInfo *osd_get_key_list(void)
 
 int osd_is_key_pressed(int keycode)
 {
-  if(!running)                                        return 0; /* input callback has not yet been polled */
-  if(options.input_interface == RETRO_DEVICE_JOYPAD)  return 0; /* core option is set to retropad/joystick only */
+  if (!retro_running)                                  return 0; /* input callback has not yet been polled */
+  if (options.input_interface == RETRO_DEVICE_JOYPAD)  return 0; /* core option is set to retropad/joystick only */
 
-  if(keycode < RETROK_LAST && keycode >= 0)
+  if (keycode < RETROK_LAST && keycode >= 0)
     return input_cb(0, RETRO_DEVICE_KEYBOARD, 0, keycode);
 
   log_cb(RETRO_LOG_WARN, LOGPRE "Invalid OSD keycode received: %i\n", keycode); /* this should not happen when keycodes are properly registered with MAME */

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2142,7 +2142,7 @@ int osd_is_joy_pressed(int joycode)
   /* Standard retropad */
   retro_code = get_retropad_code(osd_code);
   if (retro_code != INT_MAX)
-    return = input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
+    return input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
 
 
   /*** Use the cached input states ***/

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -240,12 +240,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
-
-#ifdef __ANDROID__
-  info->library_version = "ANDROID TESTING";
-#else 
   info->library_version = GIT_VERSION;
-#endif
   info->valid_extensions = "zip";
   info->need_fullpath = true;
   info->block_extract = true;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2137,22 +2137,38 @@ int osd_is_joy_pressed(int joycode)
   unsigned retro_code    = INT_MAX;
 
   /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
-  
+
   if (options.mouse_device == RETRO_DEVICE_LIGHTGUN)
   {
     retro_code = get_retrogun_code(osd_code);
     if(retro_code != INT_MAX)
     {
+#if defined(__ANDROID__)
+      if(port > 0) return 0;
+#endif
       if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
       {
-        log_cb(RETRO_LOG_DEBUG, "MAME is polling a trigger -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);
+        /*log_cb(RETRO_LOG_DEBUG, "MAME is polling a trigger -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
         if(input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
         {
-          log_cb(RETRO_LOG_DEBUG, "Trigger true\n", joycode, player_number, osd_code);
+          /*log_cb(RETRO_LOG_DEBUG, "Trigger true\n", joycode, player_number, osd_code);*/
           return 1; /* lightgun reload hack, report trigger as being pressed no matter what */
         }
       }
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
+    }
+  }
+
+  if (options.mouse_device == RETRO_DEVICE_MOUSE || options.mouse_device == RETRO_DEVICE_POINTER)
+  {
+    retro_code = get_retromouse_code(osd_code);
+    if(retro_code != INT_MAX)
+    {
+#if defined(__ANDROID__)
+      if(port > 0) return 0;
+#endif
+
+      /*non-cached mouse and pointer input polling to be added here */
     }
   }
 
@@ -2299,6 +2315,14 @@ void osd_joystick_end_calibration(void) { }
  */
 void osd_trak_read(int player, int *deltax, int *deltay)
 {
+#if defined(__ANDROID__)
+    if(player > 0)
+    {
+      *deltax = 0;
+      *deltay = 0;
+      return;
+    }
+#endif
   *deltax = mouse_x[player];
   *deltay = mouse_y[player];
 }
@@ -2328,6 +2352,15 @@ void osd_lightgun_read(int player, int *deltax, int *deltay)
     *deltay = 0;
     return;
   }
+
+#if defined(__ANDROID__)
+    if(player > 0)
+    {
+      *deltax = 0;
+      *deltay = 0;
+      return;
+    }
+#endif
 
   /* simulated lightgun reload hack */
   if(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2113,7 +2113,7 @@ int osd_is_joy_pressed(int joycode)
   if (options.mouse_device == RETRO_DEVICE_POINTER)
   {
     retro_code = get_retromouse_code(osd_code);
-    if(retro_code != INT_MAX)
+    if(retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
     {
 #ifdef __ANDROID__
       if(port > 0) return 0;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1207,12 +1207,13 @@ void retro_run (void)
   int port = 0;
   const struct KeyboardInfo *thisInput;
   bool updated = false;
+  poll_cb();
+
   if (running == 0) /* first time through the loop */
   {
     running = 1;
     log_cb(RETRO_LOG_DEBUG, LOGPRE "Entering retro_run() for the first time.\n");
   }
-  poll_cb();
 
   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
     update_variables(false);
@@ -1239,24 +1240,6 @@ void retro_run (void)
     int device_parent        = get_device_parent(device_type);
 
     if(device_type == RETRO_DEVICE_NONE) continue;
-
-    /* Standard retropad */
-    retroJsState[port][OSD_JOYPAD_B]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
-    retroJsState[port][OSD_JOYPAD_Y]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
-    retroJsState[port][OSD_JOYPAD_SELECT] = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT);
-    retroJsState[port][OSD_JOYPAD_START]  = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START);
-    retroJsState[port][OSD_JOYPAD_UP]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP);
-    retroJsState[port][OSD_JOYPAD_DOWN]   = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN);
-    retroJsState[port][OSD_JOYPAD_LEFT]   = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT);
-    retroJsState[port][OSD_JOYPAD_RIGHT]  = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT);
-    retroJsState[port][OSD_JOYPAD_A]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
-    retroJsState[port][OSD_JOYPAD_X]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
-    retroJsState[port][OSD_JOYPAD_L]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L);
-    retroJsState[port][OSD_JOYPAD_R]      = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R);
-    retroJsState[port][OSD_JOYPAD_L2]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2);
-    retroJsState[port][OSD_JOYPAD_R2]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2);
-    retroJsState[port][OSD_JOYPAD_L3]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3);
-    retroJsState[port][OSD_JOYPAD_R3]     = input_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
 
     /* Analog joystick - read as analog axis and rescale for MAME value range */
     analogjoy[port][0] = analog_deadzone_rescale( input_cb(port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_X) );
@@ -2102,6 +2085,7 @@ const struct JoystickInfo *osd_get_joy_list(void)
 int osd_is_joy_pressed(int joycode)
 {
   if (options.input_interface == RETRO_DEVICE_KEYBOARD) return 0; /* disregard joystick input */
+  if (!running) return 0; /* polling must be completed in retro_run */
 
   unsigned player_number = calc_player_number(joycode);
   unsigned port          = player_number - 1;
@@ -2154,6 +2138,11 @@ int osd_is_joy_pressed(int joycode)
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
     }
   }
+
+  /* Standard retropad */
+  retro_code = get_retropad_code(osd_code);
+  if (retro_code != INT_MAX)
+    return = input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
 
 
   /*** Use the cached input states ***/

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2094,7 +2094,6 @@ int osd_is_joy_pressed(int joycode)
 
   /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
 
-
   /* standard retropad states */
   retro_code = get_retropad_code(osd_code);
   if (retro_code != INT_MAX)
@@ -2126,17 +2125,12 @@ int osd_is_joy_pressed(int joycode)
 #endif
       if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
       {
-        /*log_cb(RETRO_LOG_DEBUG, "MAME is polling a trigger -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
         if(input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
-        {
-          /*log_cb(RETRO_LOG_DEBUG, "Trigger true\n", joycode, player_number, osd_code);*/
-          return 1; /* lightgun reload hack, report trigger as being pressed no matter what */
-        }
+          return 1; /* lightgun reload hack, report trigger as being pressed */
       }
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
     }
   }
-
 
   /* Use the cached input states */
   return retroJsState[port][osd_code];

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2094,19 +2094,14 @@ int osd_is_joy_pressed(int joycode)
 
   /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
 
-  if (options.mouse_device == RETRO_DEVICE_POINTER)
-  {
-    retro_code = get_retromouse_code(osd_code);
-    if(retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
-    {
-#ifdef __ANDROID__
-      if(port > 0) return 0;
-#endif
-      return input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
-    }
-  }
 
-  else if (options.mouse_device == RETRO_DEVICE_MOUSE)
+  /* standard retropad states */
+  retro_code = get_retropad_code(osd_code);
+  if (retro_code != INT_MAX)
+    return input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
+
+  /* pointer, mouse, or lightgun states if selected by core option */
+  if (options.mouse_device == RETRO_DEVICE_POINTER || options.mouse_device == RETRO_DEVICE_MOUSE)
   {
     retro_code = get_retromouse_code(osd_code);
     if(retro_code != INT_MAX)
@@ -2114,7 +2109,10 @@ int osd_is_joy_pressed(int joycode)
 #ifdef __ANDROID__
       if(port > 0) return 0;
 #endif
-      return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
+      if(options.mouse_device == RETRO_DEVICE_MOUSE)
+        return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
+      if (options.mouse_device == RETRO_DEVICE_POINTER && retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
+        return input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
     }
   }
 
@@ -2139,13 +2137,8 @@ int osd_is_joy_pressed(int joycode)
     }
   }
 
-  /* Standard retropad */
-  retro_code = get_retropad_code(osd_code);
-  if (retro_code != INT_MAX)
-    return input_cb(port, RETRO_DEVICE_JOYPAD, 0, retro_code);
 
-
-  /*** Use the cached input states ***/
+  /* Use the cached input states */
   return retroJsState[port][osd_code];
 }
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2110,7 +2110,31 @@ int osd_is_joy_pressed(int joycode)
 
   /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
 
-  if (options.mouse_device == RETRO_DEVICE_LIGHTGUN)
+  if (options.mouse_device == RETRO_DEVICE_POINTER)
+  {
+    retro_code = get_retromouse_code(osd_code);
+    if(retro_code != INT_MAX)
+    {
+#ifdef __ANDROID__
+      if(port > 0) return 0;
+#endif
+      return input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
+    }
+  }
+
+  else if (options.mouse_device == RETRO_DEVICE_MOUSE)
+  {
+    retro_code = get_retromouse_code(osd_code);
+    if(retro_code != INT_MAX)
+    {
+#ifdef __ANDROID__
+      if(port > 0) return 0;
+#endif
+      return input_cb(player, RETRO_DEVICE_MOUSE, 0, retro_code);
+    }
+  }
+
+  else if (options.mouse_device == RETRO_DEVICE_LIGHTGUN)
   {
     retro_code = get_retrogun_code(osd_code);
     if(retro_code != INT_MAX)
@@ -2131,19 +2155,6 @@ int osd_is_joy_pressed(int joycode)
     }
   }
 
-  if (options.mouse_device == RETRO_DEVICE_MOUSE || options.mouse_device == RETRO_DEVICE_POINTER)
-  {
-    retro_code = get_retromouse_code(osd_code);
-    if(retro_code != INT_MAX)
-    {
-
-#ifdef __ANDROID__
-      if(port > 0) return 0;
-#endif
-
-      /*non-cached mouse and pointer input polling to be added here */
-    }
-  }
 
   /*** Use the cached input states ***/
   return retroJsState[player_number-1][osd_code];

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2136,7 +2136,7 @@ int osd_is_joy_pressed(int joycode)
   unsigned osd_code      = decode_osd_joycode(joycode);
   unsigned retro_code    = INT_MAX;
 
-  /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code); */
+  /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/
   
   if (options.mouse_device == RETRO_DEVICE_LIGHTGUN)
   {
@@ -2145,8 +2145,12 @@ int osd_is_joy_pressed(int joycode)
     {
       if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
       {
+        log_cb(RETRO_LOG_DEBUG, "MAME is polling a trigger -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);
         if(input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
+        {
+          log_cb(RETRO_LOG_DEBUG, "Trigger true\n", joycode, player_number, osd_code);
           return 1; /* lightgun reload hack, report trigger as being pressed no matter what */
+        }
       }
       return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
     }

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -427,9 +427,9 @@ static void update_variables(bool first_time)
             options.input_interface = RETRO_DEVICE_JOYPAD;
           else if(strcmp(var.value, "keyboard") == 0)
             options.input_interface = RETRO_DEVICE_KEYBOARD;
-		    else
-			    options.input_interface = RETRO_DEVICE_KEYBOARD + RETRO_DEVICE_JOYPAD;
-        break;
+          else
+            options.input_interface = RETRO_DEVICE_KEYBOARD + RETRO_DEVICE_JOYPAD;
+          break;
 
         case OPT_4WAY:
           if( (strcmp(var.value, "enabled") == 0) && (options.content_flags[CONTENT_JOYSTICK_DIRECTIONS] == 4) )

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2138,16 +2138,18 @@ int osd_is_joy_pressed(int joycode)
 
   /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code); */
   
-  /*** Check whether this is an osd code from the range for lightguns ***/
-  retro_code = get_retrogun_code(osd_code);
-  if(retro_code != INT_MAX)
+  if (options.mouse_device == RETRO_DEVICE_LIGHTGUN)
   {
-    if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
+    retro_code = get_retrogun_code(osd_code);
+    if(retro_code != INT_MAX)
     {
-      if(input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
-        return 1; /* lightgun reload hack, report trigger as being pressed no matter what */
+      if(retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
+      {
+        if(input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
+          return 1; /* lightgun reload hack, report trigger as being pressed no matter what */
+      }
+      return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
     }
-    return input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, retro_code);
   }
 
   /*** Use the cached input states ***/

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2118,7 +2118,7 @@ int osd_is_joy_pressed(int joycode)
 #ifdef __ANDROID__
       if(port > 0) return 0;
 #endif
-      return input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
+      return input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
     }
   }
 
@@ -2130,7 +2130,7 @@ int osd_is_joy_pressed(int joycode)
 #ifdef __ANDROID__
       if(port > 0) return 0;
 #endif
-      return input_cb(player, RETRO_DEVICE_MOUSE, 0, retro_code);
+      return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
     }
   }
 

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -401,7 +401,7 @@ void osd_joystick_end_calibration(void);
 
 ******************************************************************************/
 
-/* TO DO: notes */
+/*** TO DO: notes ***/
 void osd_xy_device_read(int player, int *deltax, int *deltay);
 
 

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -55,17 +55,18 @@ extern "C" {
 
 ***************************************************************************/
 
-#define APPNAME         "mame2003-plus"
+#define APPNAME           "mame2003-plus"
 
-#define FRAMES_PER_FPS_UPDATE		12
-#define MAX_GFX_ELEMENTS        32
-#define MAX_MEMORY_REGIONS      32
+#define FRAMES_PER_FPS_UPDATE         12
+#define MAX_GFX_ELEMENTS              32
+#define MAX_MEMORY_REGIONS            32
+
+#define LIBRETRO_ANALOG_MIN       -32768
+#define LIBRETRO_ANALOG_MAX        32767
+#define MAME_ANALOG_MIN             -128
+#define MAME_ANALOG_MAX              128
 
 #define INPUT_BUTTON_AXIS_THRESHOLD   64
-#define LIBRETRO_ANALOG_MIN -32768
-#define LIBRETRO_ANALOG_MAX 32767
-#define ANALOG_MIN -128
-#define ANALOG_MAX 128
 
 enum
 {

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -397,37 +397,12 @@ void osd_joystick_end_calibration(void);
 
 /******************************************************************************
 
-	Trackball, Spinner, Mouse
+	Trackball, Spinner, Mouse, Pointer, Lightgun
 
 ******************************************************************************/
 
-/* osd_track_read expects the OSD to return the relative change in mouse or trackball
- * coordinates since the last reading. If the user has set their mouse type to
- * `pointer` in the core options, its coordinates are translated from absolute to
- * relative coordinates before being stored in `mouse_x[]`.
- */
-void osd_trak_read(int player, int *deltax, int *deltay);
-
-
-/******************************************************************************
-
-	Lightgun
-
-******************************************************************************/
-
-/******************************************************************************
-    The osd_lightgun_read call should return the delta from the middle of the screen
-		when the gun is fired (not the absolute pixel value), and 0 when the gun is
-		inactive.
-
-    When osd_lightgun_read returns 0, control passes through to the analog joystick,
-    and mouse, in that order. In other words, when osd_lightgun_read returns a
-    value it overrides both mouse & analog joystick.
-
-		The value returned by the OSD layer should be -128 to 128, same as analog
-		joysticks. (yes, 128, not 127).
-*******************************************************************************/
-void osd_lightgun_read(int player, int *deltax, int *deltay);
+/* TO DO: notes */
+void osd_xy_device_read(int player, int *deltax, int *deltay);
 
 
 /******************************************************************************


### PR DESCRIPTION
I have tested this locally and it's working as it should.

I would like to trim away the other input caching eventually, but the lightgun seemed like a good place to start rather than biting off the whole thing at once the way I did with my previous PR https://github.com/libretro/mame2003-plus-libretro/pull/1044