### PR TITLE
clean up makefile, revert android mouse/gun input workaround

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -260,8 +260,11 @@ void retro_init (void)
 static void check_system_specs(void)
 {
    /* Should we set level variably like the API asks? Are there any frontends that implement this? */
-   unsigned level = 10; /* For stub purposes, set to the highest level */
-   environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, &level);
+
+#ifndef RETRO_PROFILE
+#define RETRO_PROFILE 10 /* For stub purposes, set to the highest level */
+#endif
+   environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, RETRO_PROFILE);
 }
 
 
@@ -2071,9 +2074,6 @@ int osd_is_joy_pressed(int joycode)
     retro_code = get_retromouse_code(osd_code);
     if (retro_code != INT_MAX)
     {
-#ifdef __ANDROID__
-      if (port > 0) return 0;
-#endif
       if (options.mouse_device == RETRO_DEVICE_MOUSE)
         return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
       if (options.mouse_device == RETRO_DEVICE_POINTER && retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
@@ -2086,9 +2086,6 @@ int osd_is_joy_pressed(int joycode)
     retro_code = get_retrogun_code(osd_code);
     if (retro_code != INT_MAX)
     {
-#ifdef __ANDROID__
-      if (port > 0) return 0;
-#endif
       if (retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
       {
         if (input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
@@ -2236,14 +2233,6 @@ void osd_joystick_end_calibration(void) { }
 
 void osd_xy_device_read(int player, int *deltax, int *deltay)
 {
-#ifdef __ANDROID__
-  if(player > 0)
-  {
-    *deltax = 0;
-    *deltay = 0;
-    return;
-  }
-#endif
 
   if (options.mouse_device == RETRO_DEVICE_POINTER)
   {


### PR DESCRIPTION
Why do I invite the wrath of the gods by tampering with a makefile?

Well, some of the comments are plain wrong, and compiler flags which get applied to many systems are added in at various times. I'm in no hurry to merge this and I'll definitely be keeping an eye on the automated build :)
