### PR TITLE
revert android mouse/gun input driver workaround

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -2071,9 +2071,6 @@ int osd_is_joy_pressed(int joycode)
     retro_code = get_retromouse_code(osd_code);
     if (retro_code != INT_MAX)
     {
-#ifdef __ANDROID__
-      if (port > 0) return 0;
-#endif
       if (options.mouse_device == RETRO_DEVICE_MOUSE)
         return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
       if (options.mouse_device == RETRO_DEVICE_POINTER && retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
@@ -2086,9 +2083,6 @@ int osd_is_joy_pressed(int joycode)
     retro_code = get_retrogun_code(osd_code);
     if (retro_code != INT_MAX)
     {
-#ifdef __ANDROID__
-      if (port > 0) return 0;
-#endif
       if (retro_code == RETRO_DEVICE_ID_LIGHTGUN_TRIGGER)
       {
         if (input_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
@@ -2236,14 +2230,6 @@ void osd_joystick_end_calibration(void) { }
 
 void osd_xy_device_read(int player, int *deltax, int *deltay)
 {
-#ifdef __ANDROID__
-  if(player > 0)
-  {
-    *deltax = 0;
-    *deltay = 0;
-    return;
-  }
-#endif
 
   if (options.mouse_device == RETRO_DEVICE_POINTER)
   {


### PR DESCRIPTION
jdgleaver from RetroArch compiled an android build of my RetroArch PR that disables duplicating mouse and gun input from the first port to the other ports.

This my proposed commit: https://git.libretro.com/libretro/RetroArch/-/commit/f74fddf3fd913ff916d0163023ade43877f2bce8

This is the RA build: https://git.libretro.com/libretro/RetroArch/-/jobs/504439/artifacts/browse/retroarch-precompiled/pkg/android/phoenix/build/outputs/apk/normal/release/

They do not have an automated build system for branches for RA like we do here. If I knew I couldn't easily add to the PR I would have aimed to actually put in support for multimouse and multigun, but if the PR works and gets merged, we can at least get rid of the ANDROID ifdefs in the input polling.

Today I got pulled into a more urgent retroarch bug fix situation, so am going to leave this here for now. It's not exactly a passive way of asking you to do testing on this, mahoney944. You are welcome to kick the tires if you want.