### PR TITLE
pass RETRO_PROFILE from Makefile to frontend

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -259,8 +259,14 @@ void retro_init (void)
 
 static void check_system_specs(void)
 {
-   /* Should we set level variably like the API asks? Are there any frontends that implement this? */
-   unsigned level = 10; /* For stub purposes, set to the highest level */
+  #ifndef RETRO_PROFILE
+  #define RETRO_PROFILE 10
+  #endif
+   /* Should we set level variably like the API asks?
+    * That can be done in the Makefile, and then modified here before being passed,
+    * even down to an individual game basis. But are there any frontends that implement it?
+    */
+   unsigned level = (unsigned)RETRO_PROFILE;
    environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, &level);
 }
 


### PR DESCRIPTION
All the other cores pass this value with by reference, so I figured let's explicitly cast to unsigned, and give it a variable instead of a literal. I want to make sure this compiles everywhere before declaring victory.
