### PR TITLE
frontend testing - try passing SET_PERFORMANCE_LEVEL by value

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -267,7 +267,7 @@ static void check_system_specs(void)
     * even down to an individual game basis. But are there any frontends that implement it?
     */
    unsigned level = (unsigned)RETRO_PROFILE;
-   environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, &level);
+   environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, level);
 }
 
 


### PR DESCRIPTION
I'm working on a bug report about this RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL business