### PR TITLE
Cfg save protection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Save
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Save
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -58,7 +58,7 @@ extern unsigned int coins[COIN_COUNTERS];
 extern unsigned int lastcoin[COIN_COUNTERS];
 extern unsigned int coinlockedout[COIN_COUNTERS];
 
-extern int legacy_flag;
+extern bool save_protection;
 
 static unsigned short input_port_value[MAX_INPUT_PORTS];
 static unsigned short input_vblank[MAX_INPUT_PORTS];
@@ -708,7 +708,7 @@ getout:
 
 void save_input_port_settings(void)
 {
-	if (legacy_flag)
+	if (save_protection == options.mame_remapping)
 	{
 		config_file *cfg;
 		struct mixer_config mixercfg;

--- a/src/mame2003/core_options.c
+++ b/src/mame2003/core_options.c
@@ -14,8 +14,8 @@
 static struct retro_core_option_v2_definition  default_options[OPT_end + 1];    /* need the plus one for the NULL entries at the end */
 static struct retro_core_option_v2_definition  effective_defaults[OPT_end + 1];
 
-/* used in inptport.c when saving input port settings */
-int legacy_flag = -1;
+/* prevent saving corrupt cfgs when the save type does not match the type initiated */
+bool save_protection;
 
 /******************************************************************************
 
@@ -1141,18 +1141,14 @@ void update_variables(bool first_time)
 
         case OPT_MAME_REMAPPING:
           if(strcmp(var.value, "enabled") == 0)
-          {
-            if( !options.mame_remapping && legacy_flag != -1) legacy_flag =0;
             options.mame_remapping = true;
-          }
           else
-          {
-            if( options.mame_remapping && legacy_flag != -1) legacy_flag =0;
             options.mame_remapping = false;
-          }
-          if(!first_time)
+
+          if(first_time)
+            save_protection = options.mame_remapping;
+          else
             setup_menu_init();
-          if(legacy_flag ==-1) legacy_flag = 1;
           break;
 
         case OPT_FRAMESKIP:


### PR DESCRIPTION
Legacy_flag has been replaced with save_protection. This allows saving when the initiated cfg type matches the current selected type and disables saving when it does not.