### PR TITLE
Controller info to frontend

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Controller
 
 # Android 64-bit x86
 android-x86_64:


### PR DESCRIPTION
@markwkidd  I know you worked on this input code, does this commit make sense? Creating the structure based on supported players without sending unsupported controllers?

I figure if the controllers aren't supported why bother sending them? But I may be missing something. We only describe the supported players so I figured this would be suitable.