### PR TITLE
pointer device should be analog do not pull yet

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1491,11 +1491,11 @@ profiler_mark(PROFILER_INPUT);
 		osd_analogjoy_read (i, analog_current_axis[i], analogjoy_input[i]);
 
 		/* update mouse/trackball position */
-		if(options.xy_device == RETRO_DEVICE_MOUSE || options.xy_device == RETRO_DEVICE_POINTER)
+		if(options.xy_device == RETRO_DEVICE_MOUSE )
 			osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS]);
 
 		/* update lightgun position, if any */
-		else if(options.xy_device == RETRO_DEVICE_LIGHTGUN)
+		else if(options.xy_device == RETRO_DEVICE_LIGHTGUN || options.xy_device == RETRO_DEVICE_POINTER )
  			osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS]);
 	}
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1219,7 +1219,7 @@ int osd_is_joy_pressed(int joycode)
     {
       if (options.xy_device == RETRO_DEVICE_MOUSE)
         return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
-      if (options.xy_device == RETRO_DEVICE_POINTER)
+      if (options.xy_device == RETRO_DEVICE_POINTER && retro_code == RETRO_DEVICE_ID_MOUSE_LEFT) /* only return the left mouse button pointer only has one button atm */
         return input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
     }
   }

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1219,7 +1219,7 @@ int osd_is_joy_pressed(int joycode)
     {
       if (options.xy_device == RETRO_DEVICE_MOUSE)
         return input_cb(port, RETRO_DEVICE_MOUSE, 0, retro_code);
-      if (options.xy_device == RETRO_DEVICE_POINTER && retro_code == RETRO_DEVICE_ID_MOUSE_LEFT)
+      if (options.xy_device == RETRO_DEVICE_POINTER)
         return input_cb(port, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
     }
   }
@@ -1409,12 +1409,11 @@ void osd_joystick_end_calibration(void) { }
 void osd_xy_device_read(int player, int *deltax, int *deltay)
 {
 
-  if (options.xy_device == RETRO_DEVICE_POINTER && input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED))
+  if (options.xy_device == RETRO_DEVICE_POINTER)
   {
-    static int16_t prev_pointer_x; /* temporary variables to convert absolute coordinates polled by pointer to relative mouse coordinates */
-    static int16_t prev_pointer_y;
-    *deltax = get_pointer_delta(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X), &prev_pointer_x);
-    *deltay = get_pointer_delta(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y), &prev_pointer_y);
+   
+    *deltax =  rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X));
+    *deltay =  rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y));
   }
 
   else if (options.xy_device == RETRO_DEVICE_MOUSE)

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1411,7 +1411,6 @@ void osd_xy_device_read(int player, int *deltax, int *deltay)
 
   if (options.xy_device == RETRO_DEVICE_POINTER)
   {
-   
     *deltax =  rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X));
     *deltay =  rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y));
   }


### PR DESCRIPTION
Need to make some udev updates in retroarch to let the mouse return a valid pointer pressed when its not a touch device. We need to start doing things the way the api does expects it