### PR TITLE
fix the mouse recalibrating in operation wolf

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1491,10 +1491,10 @@ profiler_mark(PROFILER_INPUT);
 		osd_analogjoy_read (i, analog_current_axis[i], analogjoy_input[i]);
 
 		/* update mouse/trackball position */
-		osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS],0);
+		osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS], "relative");
 
 		/* update lightgun position, if any */
-		osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS],1);
+		osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS], "absolute");
 	}
 
 	for (i = 0;i < MAX_INPUT_PORTS;i++)

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1491,12 +1491,10 @@ profiler_mark(PROFILER_INPUT);
 		osd_analogjoy_read (i, analog_current_axis[i], analogjoy_input[i]);
 
 		/* update mouse/trackball position */
-		if(options.xy_device == RETRO_DEVICE_MOUSE || options.xy_device == RETRO_DEVICE_POINTER)
-			osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS]);
+		osd_xy_device_read (i, &(mouse_delta_axis[i])[X_AXIS], &(mouse_delta_axis[i])[Y_AXIS],0);
 
 		/* update lightgun position, if any */
-		else if(options.xy_device == RETRO_DEVICE_LIGHTGUN)
- 			osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS]);
+		osd_xy_device_read (i, &(lightgun_delta_axis[i])[X_AXIS], &(lightgun_delta_axis[i])[Y_AXIS],1);
 	}
 
 	for (i = 0;i < MAX_INPUT_PORTS;i++)

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1406,40 +1406,50 @@ void osd_joystick_end_calibration(void) { }
 
 ******************************************************************************/
 
-void osd_xy_device_read(int player, int *deltax, int *deltay)
+void osd_xy_device_read(int player, int *deltax, int *deltay, bool type /*0 = rel(mouse), 1=abs*/) 
 {
 
-  if (options.xy_device == RETRO_DEVICE_POINTER && input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED))
-  {
-    static int16_t prev_pointer_x; /* temporary variables to convert absolute coordinates polled by pointer to relative mouse coordinates */
-    static int16_t prev_pointer_y;
-    *deltax = get_pointer_delta(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X), &prev_pointer_x);
-    *deltay = get_pointer_delta(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y), &prev_pointer_y);
-  }
 
-  else if (options.xy_device == RETRO_DEVICE_MOUSE)
+  if (type == 0 && options.xy_device)
   {
+    /* always read the device as a mouse for relative */
     *deltax = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
     *deltay = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
   }
 
-  else if (options.xy_device == RETRO_DEVICE_LIGHTGUN)
+
+  else if (type == 1 && options.xy_device)
   {
-    /* simulated lightgun reload hack */
-    if(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
+    if (options.xy_device == RETRO_DEVICE_POINTER) 
     {
-      *deltax = -128;
-      *deltay = -128;
-      return;
+      *deltax = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X));
+      *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y));
     }
-    *deltax = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X));
-    *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y));
+
+    else if (RETRO_DEVICE_LIGHTGUN )
+    {
+      /* simulated lightgun reload hack */
+      if(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
+      {
+        *deltax = -128;
+        *deltay = -128;
+        return;
+      }
+      *deltax = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X));
+      *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y));
+    }
+    else /* if there are no matches set the delta to zero abs so we dont mess with the rel mouse tracking in mame code as analog overides */
+    {
+      *deltax = 0;
+      *deltay = 0;
+    }
   }
 
-  else    /* RETRO_DEVICE_NONE */
+  else if (!options.xy_device)
   {
-    *deltax = 0;
-    *deltay = 0;
+      *deltax = 0;
+      *deltay = 0;
+
   }
 }
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1426,7 +1426,7 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, bool type /*0 = re
       *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y));
     }
 
-    else if (RETRO_DEVICE_LIGHTGUN )
+    else if (options.xy_device == RETRO_DEVICE_LIGHTGUN )
     {
       /* simulated lightgun reload hack */
       if(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1408,8 +1408,6 @@ void osd_joystick_end_calibration(void) { }
 
 void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type) 
 {
-
-
   if ((strcmp(type, "relative") == 0) && options.xy_device)
   {
     /* always read the device as a mouse for relative mames will priortize the ligtgun read if analog is avaialble
@@ -1418,7 +1416,6 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type)
     *deltax = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
     *deltay = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
   }
-
 
   else if ((strcmp(type, "absolute") == 0) && options.xy_device)
   {
@@ -1452,7 +1449,6 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type)
   {
       *deltax = 0;
       *deltay = 0;
-
   }
 }
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1406,11 +1406,11 @@ void osd_joystick_end_calibration(void) { }
 
 ******************************************************************************/
 
-void osd_xy_device_read(int player, int *deltax, int *deltay, bool type /*0 = rel(mouse), 1=abs*/) 
+void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type) 
 {
 
 
-  if (!type && options.xy_device)
+  if ((strcmp(type, "relative") == 0) && options.xy_device)
   {
     /* always read the device as a mouse for relative mames will priortize the ligtgun read if analog is avaialble
      * this is do mouse and dial trackball ect is updated regardless of your abs pointer type you want */
@@ -1420,7 +1420,7 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, bool type /*0 = re
   }
 
 
-  else if (type && options.xy_device)
+  else if ((strcmp(type, "absolute") == 0) && options.xy_device)
   {
     if (options.xy_device == RETRO_DEVICE_POINTER ) 
     {
@@ -1440,6 +1440,7 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, bool type /*0 = re
       *deltax = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X));
       *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y));
     }
+
     else /* if there are no matches set the delta to zero abs so we dont mess with the rel mouse tracking in mame code as analog overides */
     {
       *deltax = 0;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1410,8 +1410,8 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type)
 {
   if ((strcmp(type, "relative") == 0) && options.xy_device)
   {
-    /* always read the device as a mouse for relative mames will priortize the ligtgun read if analog is avaialble
-     * this is do mouse and dial trackball ect is updated regardless of your abs pointer type you want */
+    /* always read the device as a relative mouse. Mame will prioritize the lightgun read if analog is available.
+     * Mouse, dial, trackball, etc is updated regardless of the absolute pointer type you want */
 
     *deltax = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
     *deltay = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
@@ -1438,17 +1438,17 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type)
       *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y));
     }
 
-    else /* if there are no matches set the delta to zero abs so we dont mess with the rel mouse tracking in mame code as analog overides */
+    else /* if there are no matches, set the delta to zero abs so we don't mess with the rel mouse tracking in mame code as analog overides */
     {
       *deltax = 0;
       *deltay = 0;
     }
   }
 
-  else if (!options.xy_device)
+  else /* RETRO_DEVICE_NONE */
   {
-      *deltax = 0;
-      *deltay = 0;
+    *deltax = 0;
+    *deltay = 0;
   }
 }
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1410,17 +1410,19 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, bool type /*0 = re
 {
 
 
-  if (type == 0 && options.xy_device)
+  if (!type && options.xy_device)
   {
-    /* always read the device as a mouse for relative */
+    /* always read the device as a mouse for relative mames will priortize the ligtgun read if analog is avaialble
+     * this is do mouse and dial trackball ect is updated regardless of your abs pointer type you want */
+     
     *deltax = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
     *deltay = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
   }
 
 
-  else if (type == 1 && options.xy_device)
+  else if (type && options.xy_device)
   {
-    if (options.xy_device == RETRO_DEVICE_POINTER) 
+    if (options.xy_device == RETRO_DEVICE_POINTER ) 
     {
       *deltax = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X));
       *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y));

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1445,7 +1445,7 @@ void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type)
     }
   }
 
-  else /* RETRO_DEVICE_NONE */
+  else    /* RETRO_DEVICE_NONE */
   {
     *deltax = 0;
     *deltay = 0;

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -1406,20 +1406,20 @@ void osd_joystick_end_calibration(void) { }
 
 ******************************************************************************/
 
-void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type) 
+void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type)
 {
   if ((strcmp(type, "relative") == 0) && options.xy_device)
   {
     /* always read the device as a mouse for relative mames will priortize the ligtgun read if analog is avaialble
      * this is do mouse and dial trackball ect is updated regardless of your abs pointer type you want */
-     
+
     *deltax = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
     *deltay = input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
   }
 
   else if ((strcmp(type, "absolute") == 0) && options.xy_device)
   {
-    if (options.xy_device == RETRO_DEVICE_POINTER ) 
+    if (options.xy_device == RETRO_DEVICE_POINTER )
     {
       *deltax = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X));
       *deltay = rescale_analog(input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y));

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -440,7 +440,7 @@ void osd_joystick_end_calibration(void);
 
 ******************************************************************************/
 
-/*** TO DO: notes ***/
+/* Returns relative or absolute positions for various X-Y coordinate devices */
 void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type);
 
 

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -441,7 +441,7 @@ void osd_joystick_end_calibration(void);
 ******************************************************************************/
 
 /*** TO DO: notes ***/
-void osd_xy_device_read(int player, int *deltax, int *deltay);
+void osd_xy_device_read(int player, int *deltax, int *deltay, bool type);
 
 
 /******************************************************************************

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -441,7 +441,7 @@ void osd_joystick_end_calibration(void);
 ******************************************************************************/
 
 /*** TO DO: notes ***/
-void osd_xy_device_read(int player, int *deltax, int *deltay, bool type);
+void osd_xy_device_read(int player, int *deltax, int *deltay, const char* type);
 
 
 /******************************************************************************


### PR DESCRIPTION
@mahoneyt944 this should fix us up for the issue we had before. With othunder the relative and abs have been seperated are still on one function though.

points to note
a mouse/pointer device can be rel or abs this shouldnt matter to the core. The driver should send the appropriate data back when we request if no need for us to do any conversion.

input_cb(player, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X)
input_cb(player, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X)
input_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X)

we just read what data we need from that device its down to the frontend to handle it properly and send it back if.

@markwkidd  @mahoneyt944  if there is any issues on platforms ive tested on udev let me know ill look at it then we can post an issue on RA to get the drivers in shape or get help doing it so it all works like it should.