### PR TITLE
Add Amlogic S812 platform + cleanup unused vars in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,8 +268,6 @@ else ifeq ($(platform), classic_armv7_a7)
 	ASFLAGS += $(CFLAGS)
 	HAVE_NEON = 1
 	ARCH = arm
-	BUILTIN_GPU = neon
-	USE_DYNAREC = 1
 	CPU_ARCH := arm
 	ARM = 1
 	ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
@@ -281,6 +279,27 @@ else ifeq ($(platform), classic_armv7_a7)
 			LDFLAGS += -static-libgcc -static-libstdc++
 		endif
 	endif
+
+# Amlogic S812
+else ifeq ($(platform), s812)
+	TARGET := $(TARGET_NAME)_libretro.so
+	fpic := -fPIC
+	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+	CFLAGS += -Ofast \
+	-flto=4 -fwhole-program -fuse-linker-plugin \
+	-fdata-sections -ffunction-sections -Wl,--gc-sections \
+	-fno-stack-protector -fno-ident -fomit-frame-pointer \
+	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
+	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
+	-fmerge-all-constants -fno-math-errno \
+	-marm -mtune=cortex-a9 -mfpu=neon-vfpv3 -mfloat-abi=hard
+	CXXFLAGS += $(CFLAGS)
+	CPPFLAGS += $(CFLAGS)
+	ASFLAGS += $(CFLAGS)
+	HAVE_NEON = 1
+	ARCH = arm
+	CPU_ARCH := arm
+	ARM = 1
 
 # Playstation Classic
 else ifeq ($(platform), classic_armv8_a35)
@@ -300,8 +319,6 @@ else ifeq ($(platform), classic_armv8_a35)
 	ASFLAGS += $(CFLAGS)
 	HAVE_NEON = 1
 	ARCH = arm
-	BUILTIN_GPU = neon
-	USE_DYNAREC = 1
 	CPU_ARCH := arm
 	ARM = 1
 	CFLAGS += -march=armv8-a


### PR DESCRIPTION
Add Amlogic S812 platform
Cleanup some vars unused for this core for other targets, wrongly copy/pasted from pcsx
--

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
