### PR TITLE
Use control name before universal default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -788,18 +788,23 @@ void retro_describe_controls(void)
       retro_code = get_retro_code("retropad", osd_code);
       if(retro_code != INT_MAX)
       {
-        switch(retro_code) /* universal default mappings */
+        /* First try to get specific name */
+        control_name = game_driver->ctrl_dat->get_name(ctrl_ipt_code);
+
+        if(string_is_empty(control_name))
         {
-          //case RETRO_DEVICE_ID_JOYPAD_LEFT:   control_name = "Left";  break;
-          //case RETRO_DEVICE_ID_JOYPAD_RIGHT:  control_name = "Right"; break;
-          //case RETRO_DEVICE_ID_JOYPAD_UP:     control_name = "Up";    break;
-          //case RETRO_DEVICE_ID_JOYPAD_DOWN:   control_name = "Down";  break;
-          case RETRO_DEVICE_ID_JOYPAD_SELECT: control_name = "Coin";  break;
-          case RETRO_DEVICE_ID_JOYPAD_START:  control_name = "Start"; break;
+          switch(retro_code) /* universal default mappings */
+          {
+            case RETRO_DEVICE_ID_JOYPAD_LEFT:   control_name = "Left";  break;
+            case RETRO_DEVICE_ID_JOYPAD_RIGHT:  control_name = "Right"; break;
+            case RETRO_DEVICE_ID_JOYPAD_UP:     control_name = "Up";    break;
+            case RETRO_DEVICE_ID_JOYPAD_DOWN:   control_name = "Down";  break;
+            case RETRO_DEVICE_ID_JOYPAD_SELECT: control_name = "Coin";  break;
+            case RETRO_DEVICE_ID_JOYPAD_START:  control_name = "Start"; break;
+          }
         }
       }
 
-      if(string_is_empty(control_name) && retro_code != INT_MAX)  control_name = game_driver->ctrl_dat->get_name(ctrl_ipt_code);
       if(string_is_empty(control_name))  continue;
 
       /* With regard to the device number, we refer to the input polling comments in

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -790,10 +790,10 @@ void retro_describe_controls(void)
       {
         switch(retro_code) /* universal default mappings */
         {
-          case RETRO_DEVICE_ID_JOYPAD_LEFT:   control_name = "Left";  break;
-          case RETRO_DEVICE_ID_JOYPAD_RIGHT:  control_name = "Right"; break;
-          case RETRO_DEVICE_ID_JOYPAD_UP:     control_name = "Up";    break;
-          case RETRO_DEVICE_ID_JOYPAD_DOWN:   control_name = "Down";  break;
+          //case RETRO_DEVICE_ID_JOYPAD_LEFT:   control_name = "Left";  break;
+          //case RETRO_DEVICE_ID_JOYPAD_RIGHT:  control_name = "Right"; break;
+          //case RETRO_DEVICE_ID_JOYPAD_UP:     control_name = "Up";    break;
+          //case RETRO_DEVICE_ID_JOYPAD_DOWN:   control_name = "Down";  break;
           case RETRO_DEVICE_ID_JOYPAD_SELECT: control_name = "Coin";  break;
           case RETRO_DEVICE_ID_JOYPAD_START:  control_name = "Start"; break;
         }


### PR DESCRIPTION
Uses the specific control name before filling with our universal defaults. Also update dat.