### PR TITLE
use libretro rotations when available and let mame sort anything that need roated

### DIFF
--- a/src/mame2003/video.c
+++ b/src/mame2003/video.c
@@ -142,7 +142,6 @@ void mame2003_video_init_orientation(void)
       video_hw_transpose = orientation & ORIENTATION_SWAP_XY;
       orientation = 0;
    }
-
    /* Otherwise try to use it to do a transpose */
    rotate_mode = 3; /* ROT90 */
    if (orientation & ORIENTATION_SWAP_XY
@@ -151,7 +150,14 @@ void mame2003_video_init_orientation(void)
       video_hw_transpose = true;
       orientation = reverse_orientation(orientation ^ ROT270);
    }
-
+  /*If Ra fails do it ourself a recent addition to the code allows this check*/
+   if (orientation & ORIENTATION_SWAP_XY
+      && !environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotate_mode))
+   {
+       video_hw_transpose = true;
+       orientation = orientation & ROT270;
+       log_cb(RETRO_LOG_INFO,"Run to the hills RA rotation failed mame is taking over the show\n");
+   }
    /* Set up native orientation flags that aren't handled by libretro */
    video_flip_x = orientation & ORIENTATION_FLIP_X;
    video_flip_y = orientation & ORIENTATION_FLIP_Y;

--- a/src/mame2003/video.c
+++ b/src/mame2003/video.c
@@ -150,14 +150,21 @@ void mame2003_video_init_orientation(void)
       video_hw_transpose = true;
       orientation = reverse_orientation(orientation ^ ROT270);
    }
-  /*If Ra fails do it ourself a recent addition to the code allows this check*/
-   if (orientation & ORIENTATION_SWAP_XY
-      && !environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotate_mode))
+  /*If Ra fails to rotate through settings->core  or doesnt implement rotation adjust for it recent addition to the code allows this check*/
+   if (!environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotate_mode))
    {
-       video_hw_transpose = true;
-       orientation = orientation & ROT270;
-       log_cb(RETRO_LOG_INFO,"Run to the hills RA rotation failed mame is taking over the show\n");
-   }
+   
+       rotate_mode = 0; /*I dont know how unspported cores react so set this to 0 incase the ra ui rotates */ 
+       environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotate_mode);
+       log_cb(RETRO_LOG_INFO,"RA rotation failed mame will assume its duties\n"); 
+       if (orientation & ORIENTATION_SWAP_XY )   
+       
+       {
+          video_hw_transpose = true;
+          orientation = orientation & ROT270;
+       }
+    }
+ 
    /* Set up native orientation flags that aren't handled by libretro */
    video_flip_x = orientation & ORIENTATION_FLIP_X;
    video_flip_y = orientation & ORIENTATION_FLIP_Y;


### PR DESCRIPTION
This code simply does rotations when need a user issue inspired me to look into this again. Only tested with disabled rotation in settings->core works as intended you will need RA 1.9.13.2 at least for the commit to be in. Im not sure how the wii port is working if it will return a fail or not when teh rotation doesnt happen if it doesnt just force it to not allow rotation in the setting mentioned above.