### PR TITLE
fix artwork heap overflow

### DIFF
--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1392,7 +1392,7 @@ static void update_palette_lookup(struct mame_display *display)
 
 			/* loop over all 32 bits and update dirty entries */
 			for (j = 0; j < 32; j++, dirtyflags >>= 1)
-				if (dirtyflags & 1)
+				if ( (dirtyflags & 1) && (i + j < display->game_palette_entries ) )
 				{
 					/* extract the RGB values */
 					rgb_t rgbvalue = display->game_palette[i + j];


### PR DESCRIPTION
fix artwork heap overflow found this when testing golly ghost. If the pallet didnt divide into 32 it could cause an overflow since buffer overflows are unpredicable  with side effects this should be fixed.
