### PR TITLE
fix stack-use-after-scope

### DIFF
--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -1961,6 +1961,8 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 	struct InputPort *in;
 	int total,total2;
 	int arrowize;
+	char label[30][40];
+	char setting[30][40];
 
 
 	sel = selected - 1;
@@ -2001,8 +2003,6 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 	{
 		if (i < total2 - 1)
 		{
-			char label[30][40];
-			char setting[30][40];
 			int sensitivity,delta;
 			int reverse;
 


### PR DESCRIPTION
Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
