### PR TITLE
Street Fighter 2 ost sample support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Sf2
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Sf2
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/drivers/cps1.c
+++ b/src/drivers/cps1.c
@@ -102,9 +102,15 @@ static WRITE16_HANDLER( cps1_sound_command_w )
 	}
 	*/
 	
-	/* We are playing Final Fight. Let's use the samples.*/
+	/* We are playing Final Fight. */
 	if(ff_playing_final_fight && options.use_alt_sound) {
 		if(generate_ost_sound_ffight( data )) {
+			if(ACCESSING_LSB) soundlatch_w(0,data & 0xff);
+		}
+	}
+	/* We are playing Street Fighter 2. */
+	else if(sf2_playing_street_fighter && options.use_alt_sound) {
+		if(generate_ost_sound_sf2( data )) {
 			if(ACCESSING_LSB) soundlatch_w(0,data & 0xff);
 		}
 	}
@@ -158,6 +164,9 @@ static INTERRUPT_GEN( cps1_interrupt )
 	/* works without it (maybe it's used to multiplex controls). It is the */
 	/* *only* game to have that. */
 	cpu_set_irq_line(0, 2, HOLD_LINE);
+
+	if(sf2_playing_street_fighter && options.use_alt_sound)
+		ost_fade_volume();
 }
 
 /********************************************************************
@@ -4018,6 +4027,13 @@ static MACHINE_DRIVER_START( sf2 )
 	/* basic machine hardware */
 	MDRV_IMPORT_FROM(cps1)
 	MDRV_CPU_REPLACE("main", M68000, 12000000)
+
+	/* Lets add our Street Fighter 2 music sample packs.*/
+	MDRV_SOUND_ATTRIBUTES(SOUND_SUPPORTS_STEREO)
+	MDRV_SOUND_ADD_TAG("OST Samples", SAMPLES, ost_sf2)
+	sf2_playing_street_fighter = true;
+	fadingMusic = false;
+
 MACHINE_DRIVER_END
 
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1658,7 +1658,7 @@ bool generate_ost_sound_sf2(int data)
 {
 	/* initialize game config */
 	schedule_default_sound = false;
-	if(data == 249) usrintf_showmessage("%i", data);
+	if(data == 36) usrintf_showmessage("%i", data);
 
 	switch (data)
 	{
@@ -1977,7 +1977,8 @@ bool generate_ost_sound_sf2(int data)
 			ost_start_samples(80, 81, 1);
 			break;
 
-		case 0x52: /* You win or lose */
+		case 0x52: /* you win or lose */
+		case 0x24: /* adding bonus points */
 			fadingMusic = true;
 			schedule_default_sound = true;
 			break;

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1658,7 +1658,6 @@ bool generate_ost_sound_sf2(int data)
 {
 	/* initialize game config */
 	schedule_default_sound = false;
-	if(data == 36) usrintf_showmessage("%i", data);
 
 	switch (data)
 	{

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1658,7 +1658,7 @@ bool generate_ost_sound_sf2(int data)
 {
 	/* initialize game config */
 	schedule_default_sound = false;
-	if(data == 249) usrintf("%i", data);
+	if(data == 249) usrintf_showmessage("%i", data);
 
 	switch (data)
 	{

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -455,6 +455,7 @@ static void ost_mix_samples(void)
 void ost_fade_volume(void)
 {
   static bool allow_fade = true;
+  usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);
 
   if(fadingMusic == false) return;
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1648,7 +1648,445 @@ bool generate_ost_sound_sf2(int data)
 	schedule_default_sound = false;
 	sa_volume = 100;
 
-	/* switch data */
+		switch (data)
+		{
+			case 0x1:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// ryu music slow
+				sample_start(0, 0, 1);
+				sample_start(1, 1, 1);
+				break;
+			}
+			case 0x2:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// e honda music slow
+				sample_start(0, 12, 1);
+				sample_start(1, 13, 1);
+				break;
+			}
+			case 0x3:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// blanka music slow
+				sample_start(0, 4, 1);
+				sample_start(1, 5, 1);
+				break;
+			}
+			case 0x4:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// ken music slow
+				sample_start(0, 52, 1);
+				sample_start(1, 53, 1);
+				break;
+			}
+			case 0x5:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// guile music slow
+				sample_start(0, 16, 1);
+				sample_start(1, 17, 1);
+				break;
+			}
+			case 0x6:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// chun li music slow
+				sample_start(0, 8, 1);
+				sample_start(1, 9, 1);
+				break;
+			}
+			case 0x7:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// zangief music slow
+				sample_start(0, 56, 1);
+				sample_start(1, 57, 1);
+				break;
+			}
+			case 0x8:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// dhalsim music slow
+				sample_start(0, 20, 1);
+				sample_start(1, 21, 1);
+				break;
+			}
+			case 0x9:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// balrog music slow
+				sample_start(0, 24, 1);
+				sample_start(1, 25, 1);
+				break;
+			}
+			case 0xa:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// vega music slow
+				sample_start(0, 60, 1);
+				sample_start(1, 61, 1);
+				break;
+			}
+			case 0xb:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// sagat music slow
+				sample_start(0, 28, 1);
+				sample_start(1, 29, 1);
+				break;
+			}
+			case 0xc:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// m. bison music slow
+				sample_start(0, 32, 1);
+				sample_start(1, 33, 1);
+				break;
+			}
+			case 0xd:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// bonus stage music
+				sample_start(0, 64, 1);
+				sample_start(1, 65, 1);
+				break;
+			}
+			case 0xe:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// character select stage
+				sample_start(0, 48, 1);
+				sample_start(1, 49, 1);
+				break;
+			}
+			case 0xf:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// versus screen ditty
+				sample_start(0, 36, 0);
+				sample_start(1, 37, 0);
+				break;
+			}
+			case 0x10:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// end of fight dialog/resolution screen
+				sample_start(0, 38, 0);
+				sample_start(1, 39, 0);
+				break;
+			}
+			case 0x11:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// continue music
+				sample_start(0, 40, 0);
+				sample_start(1, 41, 0);
+				break;
+			}
+			case 0x13:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// failed to continue?
+				sample_start(0, 90, 0);
+				sample_start(1, 91, 0);
+				break;
+			}
+			case 0x14:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// high score screen
+				sample_start(0, 42, 0);
+				sample_start(1, 43, 0);
+				break;
+			}
+			case 0x15:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// player joined music
+				sample_start(0, 46, 0);
+				sample_start(1, 47, 0);
+				break;
+			}
+			case 0x16:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// intro music
+				sample_start(0, 44, 1);
+				sample_start(1, 45, 1);
+				break;
+			}
+			case 0x18:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// ryu ending music
+				sample_start(0, 82, 0);
+				sample_start(1, 83, 0);
+				break;
+			}
+			case 0x19:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// e.honda ending music
+				sample_start(0, 72, 1);
+				sample_start(1, 73, 1);
+				break;
+			}
+			case 0x1a:
+			{
+				sample_stop(0);
+				sample_stop(1);
+
+				fadingMusic = false;
+				fadeMusicVolume = 1.0f;
+
+				// blanka ending music
+				sample_start(0, 74, 1);
+				sample_start(1, 75, 1);
+				break;
+			}
+			case 0x1b:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// guile ending music
+				sample_start(0, 76, 1);
+				sample_start(1, 77, 1);
+				break;
+			}
+			case 0x1c:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// ken ending music
+				sample_start(0, 68, 1);
+				sample_start(1, 69, 1);
+				break;
+			}
+			case 0x1d:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// chun li ending music?
+				sample_start(0, 86, 1);
+				sample_start(1, 87, 1);
+				break;
+			}
+			case 0x1e:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// zangief ending music
+				sample_start(0, 78, 1);
+				sample_start(1, 79, 1);
+				break;
+			}
+			case 0x1f:
+			{
+				sample_stop(0);
+				sample_stop(1);
+
+				fadingMusic = false;
+				fadeMusicVolume = 1.0f;
+
+				// dhalsim ending music
+				sample_start(0, 84, 1);
+				sample_start(1, 85, 1);
+				break;
+			}
+			case 0x34:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// wedding music -- ken ending
+				sample_start(0, 70, 1);
+				sample_start(1, 71, 1);
+				break;
+			}
+			case 0x35:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// chun li ending #2
+				sample_start(0, 88, 1);
+				sample_start(1, 89, 1);
+				break;
+			}
+			case 0x79:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// ryu music fast
+				sample_start(0, 2, 1);
+				sample_start(1, 3, 1);
+				break;
+			}
+			case 0x7a:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// e. honda music fast
+				sample_start(0, 14, 1);
+				sample_start(1, 15, 1);
+				break;
+			}
+			case 0x7b:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// blanka music fast
+				sample_start(0, 6, 1);
+				sample_start(1, 7, 1);
+				break;
+			}
+			case 0x7c:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// guile music fast
+				sample_start(0, 18, 1);
+				sample_start(1, 19, 1);
+				break;
+			}
+			case 0x7d:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// ken music fast
+				sample_start(0, 54, 1);
+				sample_start(1, 55, 1);
+				break;
+			}
+			case 0x7e:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// fast chun li music
+				sample_start(0, 10, 1);
+				sample_start(1, 11, 1);
+				break;
+			}
+			case 0x7f:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// zangief music fast
+				sample_start(0, 58, 1);
+				sample_start(1, 59, 1);
+				break;
+			}
+			case 0x80:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// dhalsim music fast
+				sample_start(0, 22, 1);
+				sample_start(1, 23, 1);
+				break;
+			}
+			case 0x81:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// fast balrog music
+				sample_start(0, 26, 1);
+				sample_start(1, 27, 1);
+				break;
+			}
+			case 0x82:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// fast vega music
+				sample_start(0, 62, 1);
+				sample_start(1, 63, 1);
+				break;
+			}
+			case 0x83:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// fast sagat music
+				sample_start(0, 30, 1);
+				sample_start(1, 31, 1);
+				break;
+			}
+			case 0x84:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// fast m. bison music
+				sample_start(0, 34, 1);
+				sample_start(1, 35, 1);
+				break;
+			}
+			case 0x8c:
+			{
+				fadeMusicVolume = 1.0f;
+
+				// m. bison ending
+				sample_start(0, 66, 1);
+				sample_start(1, 67, 1);
+				break;
+			}
+			case 0x8d:
+			{
+				// there's no stop music command after the ending music plays for some of them so we have to make sure that we're still not stuck in fading mode
+				sample_stop(0);
+				sample_stop(1);
+
+				fadingMusic = false;
+				// special ending
+				fadeMusicVolume = 1.0f;
+
+				sample_start(0, 80, 1);
+				sample_start(1, 81, 1);
+				break;
+			}
+			case 0xf9:
+			{
+				fadingMusic = true;
+
+				schedule_default_sound = true;
+
+				break;
+			}
+
+			default:
+				schedule_default_sound = true;
+
+				if(data == 0xf0 || data == 0xf2 || data == 0xf7) {
+					sample_stop(0);
+					sample_stop(1);
+				}
+
+				break;
+		}
 
 	ost_mix_samples();
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -453,7 +453,7 @@ static void ost_mix_samples(void)
 void ost_fade_volume(void)
 {
   static bool allow_fade = true;
-  usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);
+  /*usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);*/
 
   if(fadingMusic == false) return;
 
@@ -1658,6 +1658,7 @@ bool generate_ost_sound_sf2(int data)
 {
 	/* initialize game config */
 	schedule_default_sound = false;
+	if(data == 249) usrintf("%i", data);
 
 	switch (data)
 	{

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1764,9 +1764,9 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		case 0x13:
-			// failed to continue?
+			// game over
 			sa_volume = 100;
-			ost_start_samples(90, 91, 0);
+			ost_start_samples(50, 51, 0);
 			break;
 
 		case 0x14:

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1939,9 +1939,9 @@ bool generate_ost_sound_sf2(int data)
 			ost_start_samples(80, 81, 1);
 			break;
 
-		case 0xf9:
+		case 0x53: /* Win  */
+		case 0x54: /* Lose */
 			fadingMusic = true;
-			schedule_default_sound = true;
 			break;
 
 		/* Time to stop the Street Fighter 2 music samples.*/

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1648,445 +1648,394 @@ bool generate_ost_sound_sf2(int data)
 	schedule_default_sound = false;
 	sa_volume = 100;
 
-		switch (data)
-		{
-			case 0x1:
-			{
-				fadeMusicVolume = 1.0f;
+	switch (data)
+	{
+		case 0x1:
+			fadeMusicVolume = 1.0f;
 
-				// ryu music slow
-				sample_start(0, 0, 1);
-				sample_start(1, 1, 1);
-				break;
-			}
-			case 0x2:
-			{
-				fadeMusicVolume = 1.0f;
+			// ryu music slow
+			sample_start(0, 0, 1);
+			sample_start(1, 1, 1);
+			break;
 
-				// e honda music slow
-				sample_start(0, 12, 1);
-				sample_start(1, 13, 1);
-				break;
-			}
-			case 0x3:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x2:
+			fadeMusicVolume = 1.0f;
 
-				// blanka music slow
-				sample_start(0, 4, 1);
-				sample_start(1, 5, 1);
-				break;
-			}
-			case 0x4:
-			{
-				fadeMusicVolume = 1.0f;
+			// e honda music slow
+			sample_start(0, 12, 1);
+			sample_start(1, 13, 1);
+			break;
 
-				// ken music slow
-				sample_start(0, 52, 1);
-				sample_start(1, 53, 1);
-				break;
-			}
-			case 0x5:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x3:
+			fadeMusicVolume = 1.0f;
 
-				// guile music slow
-				sample_start(0, 16, 1);
-				sample_start(1, 17, 1);
-				break;
-			}
-			case 0x6:
-			{
-				fadeMusicVolume = 1.0f;
+			// blanka music slow
+			sample_start(0, 4, 1);
+			sample_start(1, 5, 1);
+			break;
 
-				// chun li music slow
-				sample_start(0, 8, 1);
-				sample_start(1, 9, 1);
-				break;
-			}
-			case 0x7:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x4:
+			fadeMusicVolume = 1.0f;
 
-				// zangief music slow
-				sample_start(0, 56, 1);
-				sample_start(1, 57, 1);
-				break;
-			}
-			case 0x8:
-			{
-				fadeMusicVolume = 1.0f;
+			// ken music slow
+			sample_start(0, 52, 1);
+			sample_start(1, 53, 1);
+			break;
 
-				// dhalsim music slow
-				sample_start(0, 20, 1);
-				sample_start(1, 21, 1);
-				break;
-			}
-			case 0x9:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x5:
+			fadeMusicVolume = 1.0f;
 
-				// balrog music slow
-				sample_start(0, 24, 1);
-				sample_start(1, 25, 1);
-				break;
-			}
-			case 0xa:
-			{
-				fadeMusicVolume = 1.0f;
+			// guile music slow
+			sample_start(0, 16, 1);
+			sample_start(1, 17, 1);
+			break;
 
-				// vega music slow
-				sample_start(0, 60, 1);
-				sample_start(1, 61, 1);
-				break;
-			}
-			case 0xb:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x6:
+			fadeMusicVolume = 1.0f;
 
-				// sagat music slow
-				sample_start(0, 28, 1);
-				sample_start(1, 29, 1);
-				break;
-			}
-			case 0xc:
-			{
-				fadeMusicVolume = 1.0f;
+			// chun li music slow
+			sample_start(0, 8, 1);
+			sample_start(1, 9, 1);
+			break;
 
-				// m. bison music slow
-				sample_start(0, 32, 1);
-				sample_start(1, 33, 1);
-				break;
-			}
-			case 0xd:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x7:
+			fadeMusicVolume = 1.0f;
 
-				// bonus stage music
-				sample_start(0, 64, 1);
-				sample_start(1, 65, 1);
-				break;
-			}
-			case 0xe:
-			{
-				fadeMusicVolume = 1.0f;
+			// zangief music slow
+			sample_start(0, 56, 1);
+			sample_start(1, 57, 1);
+			break;
 
-				// character select stage
-				sample_start(0, 48, 1);
-				sample_start(1, 49, 1);
-				break;
-			}
-			case 0xf:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x8:
+			fadeMusicVolume = 1.0f;
 
-				// versus screen ditty
-				sample_start(0, 36, 0);
-				sample_start(1, 37, 0);
-				break;
-			}
-			case 0x10:
-			{
-				fadeMusicVolume = 1.0f;
+			// dhalsim music slow
+			sample_start(0, 20, 1);
+			sample_start(1, 21, 1);
+			break;
 
-				// end of fight dialog/resolution screen
-				sample_start(0, 38, 0);
-				sample_start(1, 39, 0);
-				break;
-			}
-			case 0x11:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x9:
+			fadeMusicVolume = 1.0f;
 
-				// continue music
-				sample_start(0, 40, 0);
-				sample_start(1, 41, 0);
-				break;
-			}
-			case 0x13:
-			{
-				fadeMusicVolume = 1.0f;
+			// balrog music slow
+			sample_start(0, 24, 1);
+			sample_start(1, 25, 1);
+			break;
 
-				// failed to continue?
-				sample_start(0, 90, 0);
-				sample_start(1, 91, 0);
-				break;
-			}
-			case 0x14:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0xa:
+			fadeMusicVolume = 1.0f;
 
-				// high score screen
-				sample_start(0, 42, 0);
-				sample_start(1, 43, 0);
-				break;
-			}
-			case 0x15:
-			{
-				fadeMusicVolume = 1.0f;
+			// vega music slow
+			sample_start(0, 60, 1);
+			sample_start(1, 61, 1);
+			break;
 
-				// player joined music
-				sample_start(0, 46, 0);
-				sample_start(1, 47, 0);
-				break;
-			}
-			case 0x16:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0xb:
+			fadeMusicVolume = 1.0f;
 
-				// intro music
-				sample_start(0, 44, 1);
-				sample_start(1, 45, 1);
-				break;
-			}
-			case 0x18:
-			{
-				fadeMusicVolume = 1.0f;
+			// sagat music slow
+			sample_start(0, 28, 1);
+			sample_start(1, 29, 1);
+			break;
 
-				// ryu ending music
-				sample_start(0, 82, 0);
-				sample_start(1, 83, 0);
-				break;
-			}
-			case 0x19:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0xc:
+			fadeMusicVolume = 1.0f;
 
-				// e.honda ending music
-				sample_start(0, 72, 1);
-				sample_start(1, 73, 1);
-				break;
-			}
-			case 0x1a:
-			{
-				sample_stop(0);
-				sample_stop(1);
+			// m. bison music slow
+			sample_start(0, 32, 1);
+			sample_start(1, 33, 1);
+			break;
 
-				fadingMusic = false;
-				fadeMusicVolume = 1.0f;
+		case 0xd:
+			fadeMusicVolume = 1.0f;
 
-				// blanka ending music
-				sample_start(0, 74, 1);
-				sample_start(1, 75, 1);
-				break;
-			}
-			case 0x1b:
-			{
-				fadeMusicVolume = 1.0f;
+			// bonus stage music
+			sample_start(0, 64, 1);
+			sample_start(1, 65, 1);
+			break;
 
-				// guile ending music
-				sample_start(0, 76, 1);
-				sample_start(1, 77, 1);
-				break;
-			}
-			case 0x1c:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0xe:
+			fadeMusicVolume = 1.0f;
 
-				// ken ending music
-				sample_start(0, 68, 1);
-				sample_start(1, 69, 1);
-				break;
-			}
-			case 0x1d:
-			{
-				fadeMusicVolume = 1.0f;
+			// character select stage
+			sample_start(0, 48, 1);
+			sample_start(1, 49, 1);
+			break;
 
-				// chun li ending music?
-				sample_start(0, 86, 1);
-				sample_start(1, 87, 1);
-				break;
-			}
-			case 0x1e:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0xf:
+			fadeMusicVolume = 1.0f;
 
-				// zangief ending music
-				sample_start(0, 78, 1);
-				sample_start(1, 79, 1);
-				break;
-			}
-			case 0x1f:
-			{
-				sample_stop(0);
-				sample_stop(1);
+			// versus screen ditty
+			sample_start(0, 36, 0);
+			sample_start(1, 37, 0);
+			break;
 
-				fadingMusic = false;
-				fadeMusicVolume = 1.0f;
+		case 0x10:
+			fadeMusicVolume = 1.0f;
 
-				// dhalsim ending music
-				sample_start(0, 84, 1);
-				sample_start(1, 85, 1);
-				break;
-			}
-			case 0x34:
-			{
-				fadeMusicVolume = 1.0f;
+			// end of fight dialog/resolution screen
+			sample_start(0, 38, 0);
+			sample_start(1, 39, 0);
+			break;
 
-				// wedding music -- ken ending
-				sample_start(0, 70, 1);
-				sample_start(1, 71, 1);
-				break;
-			}
-			case 0x35:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x11:
+			fadeMusicVolume = 1.0f;
 
-				// chun li ending #2
-				sample_start(0, 88, 1);
-				sample_start(1, 89, 1);
-				break;
-			}
-			case 0x79:
-			{
-				fadeMusicVolume = 1.0f;
+			// continue music
+			sample_start(0, 40, 0);
+			sample_start(1, 41, 0);
+			break;
 
-				// ryu music fast
-				sample_start(0, 2, 1);
-				sample_start(1, 3, 1);
-				break;
-			}
-			case 0x7a:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x13:
+			fadeMusicVolume = 1.0f;
 
-				// e. honda music fast
-				sample_start(0, 14, 1);
-				sample_start(1, 15, 1);
-				break;
-			}
-			case 0x7b:
-			{
-				fadeMusicVolume = 1.0f;
+			// failed to continue?
+			sample_start(0, 90, 0);
+			sample_start(1, 91, 0);
+			break;
 
-				// blanka music fast
-				sample_start(0, 6, 1);
-				sample_start(1, 7, 1);
-				break;
-			}
-			case 0x7c:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x14:
+			fadeMusicVolume = 1.0f;
 
-				// guile music fast
-				sample_start(0, 18, 1);
-				sample_start(1, 19, 1);
-				break;
-			}
-			case 0x7d:
-			{
-				fadeMusicVolume = 1.0f;
+			// high score screen
+			sample_start(0, 42, 0);
+			sample_start(1, 43, 0);
+			break;
 
-				// ken music fast
-				sample_start(0, 54, 1);
-				sample_start(1, 55, 1);
-				break;
-			}
-			case 0x7e:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x15:
+			fadeMusicVolume = 1.0f;
 
-				// fast chun li music
-				sample_start(0, 10, 1);
-				sample_start(1, 11, 1);
-				break;
-			}
-			case 0x7f:
-			{
-				fadeMusicVolume = 1.0f;
+			// player joined music
+			sample_start(0, 46, 0);
+			sample_start(1, 47, 0);
+			break;
 
-				// zangief music fast
-				sample_start(0, 58, 1);
-				sample_start(1, 59, 1);
-				break;
-			}
-			case 0x80:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x16:
+			fadeMusicVolume = 1.0f;
 
-				// dhalsim music fast
-				sample_start(0, 22, 1);
-				sample_start(1, 23, 1);
-				break;
-			}
-			case 0x81:
-			{
-				fadeMusicVolume = 1.0f;
+			// intro music
+			sample_start(0, 44, 1);
+			sample_start(1, 45, 1);
+			break;
 
-				// fast balrog music
-				sample_start(0, 26, 1);
-				sample_start(1, 27, 1);
-				break;
-			}
-			case 0x82:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x18:
+			fadeMusicVolume = 1.0f;
 
-				// fast vega music
-				sample_start(0, 62, 1);
-				sample_start(1, 63, 1);
-				break;
-			}
-			case 0x83:
-			{
-				fadeMusicVolume = 1.0f;
+			// ryu ending music
+			sample_start(0, 82, 0);
+			sample_start(1, 83, 0);
+			break;
 
-				// fast sagat music
-				sample_start(0, 30, 1);
-				sample_start(1, 31, 1);
-				break;
-			}
-			case 0x84:
-			{
-				fadeMusicVolume = 1.0f;
+		case 0x19:
+			fadeMusicVolume = 1.0f;
 
-				// fast m. bison music
-				sample_start(0, 34, 1);
-				sample_start(1, 35, 1);
-				break;
-			}
-			case 0x8c:
-			{
-				fadeMusicVolume = 1.0f;
+			// e.honda ending music
+			sample_start(0, 72, 1);
+			sample_start(1, 73, 1);
+			break;
 
-				// m. bison ending
-				sample_start(0, 66, 1);
-				sample_start(1, 67, 1);
-				break;
-			}
-			case 0x8d:
-			{
-				// there's no stop music command after the ending music plays for some of them so we have to make sure that we're still not stuck in fading mode
-				sample_stop(0);
-				sample_stop(1);
+		case 0x1a:
+			ost_stop_samples();
 
-				fadingMusic = false;
-				// special ending
-				fadeMusicVolume = 1.0f;
+			fadingMusic = false;
+			fadeMusicVolume = 1.0f;
 
-				sample_start(0, 80, 1);
-				sample_start(1, 81, 1);
-				break;
-			}
-			case 0xf9:
-			{
-				fadingMusic = true;
+			// blanka ending music
+			sample_start(0, 74, 1);
+			sample_start(1, 75, 1);
+			break;
 
-				schedule_default_sound = true;
+		case 0x1b:
+			fadeMusicVolume = 1.0f;
 
-				break;
-			}
+			// guile ending music
+			sample_start(0, 76, 1);
+			sample_start(1, 77, 1);
+			break;
 
-			default:
-				schedule_default_sound = true;
+		case 0x1c:
+			fadeMusicVolume = 1.0f;
 
-				if(data == 0xf0 || data == 0xf2 || data == 0xf7) {
-					sample_stop(0);
-					sample_stop(1);
-				}
+			// ken ending music
+			sample_start(0, 68, 1);
+			sample_start(1, 69, 1);
+			break;
 
-				break;
-		}
+		case 0x1d:
+			fadeMusicVolume = 1.0f;
+
+			// chun li ending music?
+			sample_start(0, 86, 1);
+			sample_start(1, 87, 1);
+			break;
+
+		case 0x1e:
+			fadeMusicVolume = 1.0f;
+
+			// zangief ending music
+			sample_start(0, 78, 1);
+			sample_start(1, 79, 1);
+			break;
+
+		case 0x1f:
+			ost_stop_samples();
+
+			fadingMusic = false;
+			fadeMusicVolume = 1.0f;
+
+			// dhalsim ending music
+			sample_start(0, 84, 1);
+			sample_start(1, 85, 1);
+			break;
+
+		case 0x34:
+			fadeMusicVolume = 1.0f;
+
+			// wedding music -- ken ending
+			sample_start(0, 70, 1);
+			sample_start(1, 71, 1);
+			break;
+
+		case 0x35:
+			fadeMusicVolume = 1.0f;
+
+			// chun li ending #2
+			sample_start(0, 88, 1);
+			sample_start(1, 89, 1);
+			break;
+
+		case 0x79:
+			fadeMusicVolume = 1.0f;
+
+			// ryu music fast
+			sample_start(0, 2, 1);
+			sample_start(1, 3, 1);
+			break;
+
+		case 0x7a:
+			fadeMusicVolume = 1.0f;
+
+			// e. honda music fast
+			sample_start(0, 14, 1);
+			sample_start(1, 15, 1);
+			break;
+
+		case 0x7b:
+			fadeMusicVolume = 1.0f;
+
+			// blanka music fast
+			sample_start(0, 6, 1);
+			sample_start(1, 7, 1);
+			break;
+
+		case 0x7c:
+			fadeMusicVolume = 1.0f;
+
+			// guile music fast
+			sample_start(0, 18, 1);
+			sample_start(1, 19, 1);
+			break;
+
+		case 0x7d:
+			fadeMusicVolume = 1.0f;
+
+			// ken music fast
+			sample_start(0, 54, 1);
+			sample_start(1, 55, 1);
+			break;
+
+		case 0x7e:
+			fadeMusicVolume = 1.0f;
+
+			// fast chun li music
+			sample_start(0, 10, 1);
+			sample_start(1, 11, 1);
+			break;
+
+		case 0x7f:
+			fadeMusicVolume = 1.0f;
+
+			// zangief music fast
+			sample_start(0, 58, 1);
+			sample_start(1, 59, 1);
+			break;
+
+		case 0x80:
+			fadeMusicVolume = 1.0f;
+
+			// dhalsim music fast
+			sample_start(0, 22, 1);
+			sample_start(1, 23, 1);
+			break;
+
+		case 0x81:
+			fadeMusicVolume = 1.0f;
+
+			// fast balrog music
+			sample_start(0, 26, 1);
+			sample_start(1, 27, 1);
+			break;
+
+		case 0x82:
+			fadeMusicVolume = 1.0f;
+
+			// fast vega music
+			sample_start(0, 62, 1);
+			sample_start(1, 63, 1);
+			break;
+
+		case 0x83:
+			fadeMusicVolume = 1.0f;
+
+			// fast sagat music
+			sample_start(0, 30, 1);
+			sample_start(1, 31, 1);
+			break;
+
+		case 0x84:
+			fadeMusicVolume = 1.0f;
+
+			// fast m. bison music
+			sample_start(0, 34, 1);
+			sample_start(1, 35, 1);
+			break;
+
+		case 0x8c:
+			fadeMusicVolume = 1.0f;
+
+			// m. bison ending
+			sample_start(0, 66, 1);
+			sample_start(1, 67, 1);
+			break;
+
+		case 0x8d:
+			// there's no stop music command after the ending music plays for some of them so we have to make sure that we're still not stuck in fading mode
+			ost_stop_samples();
+
+			fadingMusic = false;
+			// special ending
+			fadeMusicVolume = 1.0f;
+
+			sample_start(0, 80, 1);
+			sample_start(1, 81, 1);
+			break;
+
+		case 0xf9:
+			fadingMusic = true;
+			schedule_default_sound = true;
+			break;
+
+		/* Time to stop the Street Fighter 2 music samples.*/
+		case 0xf0:
+		case 0xf2:
+		case 0xf7:
+			ost_stop_samples();
+			break;
+
+		default:
+			schedule_default_sound = true;
+			break;
+	}
 
 	ost_mix_samples();
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1802,8 +1802,6 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		case 0x1a:
-			fadingMusic = false;
-
 			// blanka ending music
 			sa_volume = 100;
 			ost_start_samples(74, 75, 1);
@@ -1834,8 +1832,6 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		case 0x1f:
-			fadingMusic = false;
-
 			// dhalsim ending music
 			sa_volume = 100;
 			ost_start_samples(84, 85, 1);
@@ -1932,8 +1928,6 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		case 0x8d:
-			fadingMusic = false;
-
 			// special ending
 			sa_volume = 100;
 			ost_start_samples(80, 81, 1);
@@ -1942,6 +1936,7 @@ bool generate_ost_sound_sf2(int data)
 		case 0x53: /* Win  */
 		case 0x54: /* Lose */
 			fadingMusic = true;
+			schedule_default_sound = true;
 			break;
 
 		/* Time to stop the Street Fighter 2 music samples.*/

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1944,7 +1944,7 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		default:
-			if(data != 255) usrintf_showmessage("data: %i", data);
+			if(data != 255 && data != 67 && data != 249) usrintf_showmessage("data: %i", data);
 			schedule_default_sound = true;
 			break;
 	}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -453,7 +453,7 @@ static void ost_mix_samples(void)
 void ost_fade_volume(void)
 {
   static bool allow_fade = true;
-  /*usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);*/
+  usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);
 
   if(fadingMusic == false) return;
 
@@ -1944,7 +1944,6 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		default:
-			if(data != 255 && data != 67 && data != 249 && data != 0) usrintf_showmessage("data: %i", data);
 			schedule_default_sound = true;
 			break;
 	}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1758,9 +1758,9 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		case 0x11:
-			// continue music
+			// continue music, loop for ending credits
 			sa_volume = 100;
-			ost_start_samples(40, 41, 0);
+			ost_start_samples(40, 41, 1);
 			break;
 
 		case 0x13:

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1663,270 +1663,315 @@ bool generate_ost_sound_sf2(int data)
 	{
 		case 0x1:
 			// ryu music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(0, 1, 1);
 			break;
 
 		case 0x2:
 			// e honda music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(12, 13, 1);
 			break;
 
 		case 0x3:
 			// blanka music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(4, 5, 1);
 			break;
 
 		case 0x4:
 			// ken music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(52, 53, 1);
 			break;
 
 		case 0x5:
 			// guile music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(16, 17, 1);
 			break;
 
 		case 0x6:
 			// chun li music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(8, 9, 1);
 			break;
 
 		case 0x7:
 			// zangief music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(56, 57, 1);
 			break;
 
 		case 0x8:
 			// dhalsim music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(20, 21, 1);
 			break;
 
 		case 0x9:
 			// balrog music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(24, 25, 1);
 			break;
 
 		case 0xa:
 			// vega music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(60, 61, 1);
 			break;
 
 		case 0xb:
 			// sagat music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(28, 29, 1);
 			break;
 
 		case 0xc:
 			// m. bison music slow
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(32, 33, 1);
 			break;
 
 		case 0xd:
 			// bonus stage music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(64, 65, 1);
 			break;
 
 		case 0xe:
 			// character select stage
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(48, 49, 1);
 			break;
 
 		case 0xf:
 			// versus screen ditty
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(36, 37, 0);
 			break;
 
 		case 0x10:
 			// end of fight dialog/resolution screen
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(38, 39, 0);
 			break;
 
 		case 0x11:
 			// continue music, loop for ending credits
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(40, 41, 1);
 			break;
 
 		case 0x13:
 			// game over
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(50, 51, 0);
 			break;
 
 		case 0x14:
 			// high score screen
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(42, 43, 0);
 			break;
 
 		case 0x15:
 			// player joined music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(46, 47, 0);
 			break;
 
 		case 0x16:
 			// intro music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(44, 45, 1);
 			break;
 
 		case 0x18:
 			// ryu ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(82, 83, 0);
 			break;
 
 		case 0x19:
 			// e.honda ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(72, 73, 1);
 			break;
 
 		case 0x1a:
 			// blanka ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(74, 75, 1);
 			break;
 
 		case 0x1b:
 			// guile ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(76, 77, 1);
 			break;
 
 		case 0x1c:
 			// ken ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(68, 69, 1);
 			break;
 
 		case 0x1d:
 			// chun li ending music?
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(86, 87, 1);
 			break;
 
 		case 0x1e:
 			// zangief ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(78, 79, 1);
 			break;
 
 		case 0x1f:
 			// dhalsim ending music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(84, 85, 1);
 			break;
 
 		case 0x34:
 			// wedding music -- ken ending
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(70, 71, 1);
 			break;
 
 		case 0x35:
 			// chun li ending #2
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(88, 89, 1);
 			break;
 
 		case 0x79:
 			// ryu music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(2, 3, 1);
 			break;
 
 		case 0x7a:
 			// e. honda music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(14, 15, 1);
 			break;
 
 		case 0x7b:
 			// blanka music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(6, 7, 1);
 			break;
 
 		case 0x7c:
 			// guile music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(18, 19, 1);
 			break;
 
 		case 0x7d:
 			// ken music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(54, 55, 1);
 			break;
 
 		case 0x7e:
 			// fast chun li music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(10, 11, 1);
 			break;
 
 		case 0x7f:
 			// zangief music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(58, 59, 1);
 			break;
 
 		case 0x80:
 			// dhalsim music fast
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(22, 23, 1);
 			break;
 
 		case 0x81:
 			// fast balrog music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(26, 27, 1);
 			break;
 
 		case 0x82:
 			// fast vega music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(62, 63, 1);
 			break;
 
 		case 0x83:
 			// fast sagat music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(30, 31, 1);
 			break;
 
 		case 0x84:
 			// fast m. bison music
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(34, 35, 1);
 			break;
 
 		case 0x8c:
 			// m. bison ending
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(66, 67, 1);
 			break;
 
 		case 0x8d:
 			// special ending
+			fadingMusic = false;
 			sa_volume = 100;
 			ost_start_samples(80, 81, 1);
 			break;

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1640,3 +1640,16 @@ bool generate_ost_sound_outrun(int data)
 
 	return schedule_default_sound;
 }
+
+bool generate_ost_sound_sf2(int data)
+{
+	/* initialize game config */
+	schedule_default_sound = false;
+	sa_volume = 100;
+
+	/* switch data */
+
+	ost_mix_samples();
+
+	return schedule_default_sound;
+}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1952,7 +1952,7 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		default:
-			usrintf_showmessage("data: %i", data);
+			if(data != 255) usrintf_showmessage("data: %i", data);
 			schedule_default_sound = true;
 			break;
 	}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -455,7 +455,7 @@ static void ost_mix_samples(void)
 void ost_fade_volume(void)
 {
   static bool allow_fade = true;
-  usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);
+  /*usrintf_showmessage("fadingMusic:%i  volume:%i", fadingMusic, sa_volume);*/
 
   if(fadingMusic == false) return;
 
@@ -1952,6 +1952,7 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		default:
+			usrintf_showmessage("data: %i", data);
 			schedule_default_sound = true;
 			break;
 	}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1933,8 +1933,7 @@ bool generate_ost_sound_sf2(int data)
 			ost_start_samples(80, 81, 1);
 			break;
 
-		case 0x53: /* Win  */
-		case 0x54: /* Lose */
+		case 0x52: /* You win or lose */
 			fadingMusic = true;
 			schedule_default_sound = true;
 			break;

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -355,8 +355,6 @@ const char *const sf2_sample_set_names[] =
 	"chunliendinga-02",
 	"chunliendingb-01",
 	"chunliendingb-02",
-	"gameover-01",
-	"gameover-02",
 	0
 };
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -49,6 +49,7 @@ bool     outrun_lastwave;
 int      outrun_start_counter;
 
 bool     sf2_playing_street_fighter = false;
+bool     fadingMusic;
 
 
 /* ost functions */
@@ -453,6 +454,10 @@ static void ost_mix_samples(void)
 
 void ost_fade_volume(void)
 {
+  if(fadingMusic == false) return;
+
+  /* Need to adjust sa_volume before remixing */
+  ost_mix_samples();
 }
 
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -53,7 +53,6 @@ int      outrun_start_counter;
 static void ost_start_samples(int sa_left, int sa_right, int sa_loop);
 static void ost_stop_samples(void);
 static void ost_mix_samples(void);
-       void ost_fade_volume(void);
 
 
 const char *const ddragon_sample_set_names[] =

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -462,6 +462,9 @@ void ost_fade_volume(void)
   allow_fade = (allow_fade) ? 0:1;
   if(allow_fade && sa_volume > 0) sa_volume -= 1;
 
+  /* end fading */
+  if(sa_volume == 0) fadingMusic = false;
+
   ost_mix_samples();
 }
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -454,9 +454,14 @@ static void ost_mix_samples(void)
 
 void ost_fade_volume(void)
 {
+  static bool allow_fade = true;
+
   if(fadingMusic == false) return;
 
-  /* Need to adjust sa_volume before remixing */
+  /* slow volume fading */
+  allow_fade = (allow_fade) ? 0:1;
+  if(allow_fade && sa_volume > 0) sa_volume -= 1;
+
   ost_mix_samples();
 }
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1944,7 +1944,7 @@ bool generate_ost_sound_sf2(int data)
 			break;
 
 		default:
-			if(data != 255 && data != 67 && data != 249) usrintf_showmessage("data: %i", data);
+			if(data != 255 && data != 67 && data != 249 && data != 0) usrintf_showmessage("data: %i", data);
 			schedule_default_sound = true;
 			break;
 	}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1654,184 +1654,161 @@ bool generate_ost_sound_sf2(int data)
 			fadeMusicVolume = 1.0f;
 
 			// ryu music slow
-			sample_start(0, 0, 1);
-			sample_start(1, 1, 1);
+			ost_start_samples(0, 1, 1);
 			break;
 
 		case 0x2:
 			fadeMusicVolume = 1.0f;
 
 			// e honda music slow
-			sample_start(0, 12, 1);
-			sample_start(1, 13, 1);
+			ost_start_samples(12, 13, 1);
 			break;
 
 		case 0x3:
 			fadeMusicVolume = 1.0f;
 
 			// blanka music slow
-			sample_start(0, 4, 1);
-			sample_start(1, 5, 1);
+			ost_start_samples(4, 5, 1);
 			break;
 
 		case 0x4:
 			fadeMusicVolume = 1.0f;
 
 			// ken music slow
-			sample_start(0, 52, 1);
-			sample_start(1, 53, 1);
+			ost_start_samples(52, 53, 1);
 			break;
 
 		case 0x5:
 			fadeMusicVolume = 1.0f;
 
 			// guile music slow
-			sample_start(0, 16, 1);
-			sample_start(1, 17, 1);
+			ost_start_samples(16, 17, 1);
 			break;
 
 		case 0x6:
 			fadeMusicVolume = 1.0f;
 
 			// chun li music slow
-			sample_start(0, 8, 1);
-			sample_start(1, 9, 1);
+			ost_start_samples(8, 9, 1);
 			break;
 
 		case 0x7:
 			fadeMusicVolume = 1.0f;
 
 			// zangief music slow
-			sample_start(0, 56, 1);
-			sample_start(1, 57, 1);
+			ost_start_samples(56, 57, 1);
 			break;
 
 		case 0x8:
 			fadeMusicVolume = 1.0f;
 
 			// dhalsim music slow
-			sample_start(0, 20, 1);
-			sample_start(1, 21, 1);
+			ost_start_samples(20, 21, 1);
 			break;
 
 		case 0x9:
 			fadeMusicVolume = 1.0f;
 
 			// balrog music slow
-			sample_start(0, 24, 1);
-			sample_start(1, 25, 1);
+			ost_start_samples(24, 25, 1);
 			break;
 
 		case 0xa:
 			fadeMusicVolume = 1.0f;
 
 			// vega music slow
-			sample_start(0, 60, 1);
-			sample_start(1, 61, 1);
+			ost_start_samples(60, 61, 1);
 			break;
 
 		case 0xb:
 			fadeMusicVolume = 1.0f;
 
 			// sagat music slow
-			sample_start(0, 28, 1);
-			sample_start(1, 29, 1);
+			ost_start_samples(28, 29, 1);
 			break;
 
 		case 0xc:
 			fadeMusicVolume = 1.0f;
 
 			// m. bison music slow
-			sample_start(0, 32, 1);
-			sample_start(1, 33, 1);
+			ost_start_samples(32, 33, 1);
 			break;
 
 		case 0xd:
 			fadeMusicVolume = 1.0f;
 
 			// bonus stage music
-			sample_start(0, 64, 1);
-			sample_start(1, 65, 1);
+			ost_start_samples(64, 65, 1);
 			break;
 
 		case 0xe:
 			fadeMusicVolume = 1.0f;
 
 			// character select stage
-			sample_start(0, 48, 1);
-			sample_start(1, 49, 1);
+			ost_start_samples(48, 49, 1);
 			break;
 
 		case 0xf:
 			fadeMusicVolume = 1.0f;
 
 			// versus screen ditty
-			sample_start(0, 36, 0);
-			sample_start(1, 37, 0);
+			ost_start_samples(36, 37, 0);
 			break;
 
 		case 0x10:
 			fadeMusicVolume = 1.0f;
 
 			// end of fight dialog/resolution screen
-			sample_start(0, 38, 0);
-			sample_start(1, 39, 0);
+			ost_start_samples(38, 39, 0);
 			break;
 
 		case 0x11:
 			fadeMusicVolume = 1.0f;
 
 			// continue music
-			sample_start(0, 40, 0);
-			sample_start(1, 41, 0);
+			ost_start_samples(40, 41, 0);
 			break;
 
 		case 0x13:
 			fadeMusicVolume = 1.0f;
 
 			// failed to continue?
-			sample_start(0, 90, 0);
-			sample_start(1, 91, 0);
+			ost_start_samples(90, 91, 0);
 			break;
 
 		case 0x14:
 			fadeMusicVolume = 1.0f;
 
 			// high score screen
-			sample_start(0, 42, 0);
-			sample_start(1, 43, 0);
+			ost_start_samples(42, 43, 0);
 			break;
 
 		case 0x15:
 			fadeMusicVolume = 1.0f;
 
 			// player joined music
-			sample_start(0, 46, 0);
-			sample_start(1, 47, 0);
+			ost_start_samples(46, 47, 0);
 			break;
 
 		case 0x16:
 			fadeMusicVolume = 1.0f;
 
 			// intro music
-			sample_start(0, 44, 1);
-			sample_start(1, 45, 1);
+			ost_start_samples(44, 45, 1);
 			break;
 
 		case 0x18:
 			fadeMusicVolume = 1.0f;
 
 			// ryu ending music
-			sample_start(0, 82, 0);
-			sample_start(1, 83, 0);
+			ost_start_samples(82, 83, 0);
 			break;
 
 		case 0x19:
 			fadeMusicVolume = 1.0f;
 
 			// e.honda ending music
-			sample_start(0, 72, 1);
-			sample_start(1, 73, 1);
+			ost_start_samples(72, 73, 1);
 			break;
 
 		case 0x1a:
@@ -1841,40 +1818,35 @@ bool generate_ost_sound_sf2(int data)
 			fadeMusicVolume = 1.0f;
 
 			// blanka ending music
-			sample_start(0, 74, 1);
-			sample_start(1, 75, 1);
+			ost_start_samples(74, 75, 1);
 			break;
 
 		case 0x1b:
 			fadeMusicVolume = 1.0f;
 
 			// guile ending music
-			sample_start(0, 76, 1);
-			sample_start(1, 77, 1);
+			ost_start_samples(76, 77, 1);
 			break;
 
 		case 0x1c:
 			fadeMusicVolume = 1.0f;
 
 			// ken ending music
-			sample_start(0, 68, 1);
-			sample_start(1, 69, 1);
+			ost_start_samples(68, 69, 1);
 			break;
 
 		case 0x1d:
 			fadeMusicVolume = 1.0f;
 
 			// chun li ending music?
-			sample_start(0, 86, 1);
-			sample_start(1, 87, 1);
+			ost_start_samples(86, 87, 1);
 			break;
 
 		case 0x1e:
 			fadeMusicVolume = 1.0f;
 
 			// zangief ending music
-			sample_start(0, 78, 1);
-			sample_start(1, 79, 1);
+			ost_start_samples(78, 79, 1);
 			break;
 
 		case 0x1f:
@@ -1884,128 +1856,112 @@ bool generate_ost_sound_sf2(int data)
 			fadeMusicVolume = 1.0f;
 
 			// dhalsim ending music
-			sample_start(0, 84, 1);
-			sample_start(1, 85, 1);
+			ost_start_samples(84, 85, 1);
 			break;
 
 		case 0x34:
 			fadeMusicVolume = 1.0f;
 
 			// wedding music -- ken ending
-			sample_start(0, 70, 1);
-			sample_start(1, 71, 1);
+			ost_start_samples(70, 71, 1);
 			break;
 
 		case 0x35:
 			fadeMusicVolume = 1.0f;
 
 			// chun li ending #2
-			sample_start(0, 88, 1);
-			sample_start(1, 89, 1);
+			ost_start_samples(88, 89, 1);
 			break;
 
 		case 0x79:
 			fadeMusicVolume = 1.0f;
 
 			// ryu music fast
-			sample_start(0, 2, 1);
-			sample_start(1, 3, 1);
+			ost_start_samples(2, 3, 1);
 			break;
 
 		case 0x7a:
 			fadeMusicVolume = 1.0f;
 
 			// e. honda music fast
-			sample_start(0, 14, 1);
-			sample_start(1, 15, 1);
+			ost_start_samples(14, 15, 1);
 			break;
 
 		case 0x7b:
 			fadeMusicVolume = 1.0f;
 
 			// blanka music fast
-			sample_start(0, 6, 1);
-			sample_start(1, 7, 1);
+			ost_start_samples(6, 7, 1);
 			break;
 
 		case 0x7c:
 			fadeMusicVolume = 1.0f;
 
 			// guile music fast
-			sample_start(0, 18, 1);
-			sample_start(1, 19, 1);
+			ost_start_samples(18, 19, 1);
 			break;
 
 		case 0x7d:
 			fadeMusicVolume = 1.0f;
 
 			// ken music fast
-			sample_start(0, 54, 1);
-			sample_start(1, 55, 1);
+			ost_start_samples(54, 55, 1);
 			break;
 
 		case 0x7e:
 			fadeMusicVolume = 1.0f;
 
 			// fast chun li music
-			sample_start(0, 10, 1);
-			sample_start(1, 11, 1);
+			ost_start_samples(10, 11, 1);
 			break;
 
 		case 0x7f:
 			fadeMusicVolume = 1.0f;
 
 			// zangief music fast
-			sample_start(0, 58, 1);
-			sample_start(1, 59, 1);
+			ost_start_samples(58, 59, 1);
 			break;
 
 		case 0x80:
 			fadeMusicVolume = 1.0f;
 
 			// dhalsim music fast
-			sample_start(0, 22, 1);
-			sample_start(1, 23, 1);
+			ost_start_samples(22, 23, 1);
 			break;
 
 		case 0x81:
 			fadeMusicVolume = 1.0f;
 
 			// fast balrog music
-			sample_start(0, 26, 1);
-			sample_start(1, 27, 1);
+			ost_start_samples(26, 27, 1);
 			break;
 
 		case 0x82:
 			fadeMusicVolume = 1.0f;
 
 			// fast vega music
-			sample_start(0, 62, 1);
-			sample_start(1, 63, 1);
+			ost_start_samples(62, 63, 1);
 			break;
 
 		case 0x83:
 			fadeMusicVolume = 1.0f;
 
 			// fast sagat music
-			sample_start(0, 30, 1);
-			sample_start(1, 31, 1);
+			ost_start_samples(30, 31, 1);
 			break;
 
 		case 0x84:
 			fadeMusicVolume = 1.0f;
 
 			// fast m. bison music
-			sample_start(0, 34, 1);
-			sample_start(1, 35, 1);
+			ost_start_samples(34, 35, 1);
 			break;
 
 		case 0x8c:
 			fadeMusicVolume = 1.0f;
 
 			// m. bison ending
-			sample_start(0, 66, 1);
-			sample_start(1, 67, 1);
+			ost_start_samples(66, 67, 1);
 			break;
 
 		case 0x8d:
@@ -2016,8 +1972,7 @@ bool generate_ost_sound_sf2(int data)
 			// special ending
 			fadeMusicVolume = 1.0f;
 
-			sample_start(0, 80, 1);
-			sample_start(1, 81, 1);
+			ost_start_samples(80, 81, 1);
 			break;
 
 		case 0xf9:

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -48,6 +48,8 @@ bool     outrun_title;
 bool     outrun_lastwave;
 int      outrun_start_counter;
 
+bool     sf2_playing_street_fighter = false;
+
 
 /* ost functions */
 static void ost_start_samples(int sa_left, int sa_right, int sa_loop);

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -1646,332 +1646,282 @@ bool generate_ost_sound_sf2(int data)
 {
 	/* initialize game config */
 	schedule_default_sound = false;
-	sa_volume = 100;
 
 	switch (data)
 	{
 		case 0x1:
-			fadeMusicVolume = 1.0f;
-
 			// ryu music slow
+			sa_volume = 100;
 			ost_start_samples(0, 1, 1);
 			break;
 
 		case 0x2:
-			fadeMusicVolume = 1.0f;
-
 			// e honda music slow
+			sa_volume = 100;
 			ost_start_samples(12, 13, 1);
 			break;
 
 		case 0x3:
-			fadeMusicVolume = 1.0f;
-
 			// blanka music slow
+			sa_volume = 100;
 			ost_start_samples(4, 5, 1);
 			break;
 
 		case 0x4:
-			fadeMusicVolume = 1.0f;
-
 			// ken music slow
+			sa_volume = 100;
 			ost_start_samples(52, 53, 1);
 			break;
 
 		case 0x5:
-			fadeMusicVolume = 1.0f;
-
 			// guile music slow
+			sa_volume = 100;
 			ost_start_samples(16, 17, 1);
 			break;
 
 		case 0x6:
-			fadeMusicVolume = 1.0f;
-
 			// chun li music slow
+			sa_volume = 100;
 			ost_start_samples(8, 9, 1);
 			break;
 
 		case 0x7:
-			fadeMusicVolume = 1.0f;
-
 			// zangief music slow
+			sa_volume = 100;
 			ost_start_samples(56, 57, 1);
 			break;
 
 		case 0x8:
-			fadeMusicVolume = 1.0f;
-
 			// dhalsim music slow
+			sa_volume = 100;
 			ost_start_samples(20, 21, 1);
 			break;
 
 		case 0x9:
-			fadeMusicVolume = 1.0f;
-
 			// balrog music slow
+			sa_volume = 100;
 			ost_start_samples(24, 25, 1);
 			break;
 
 		case 0xa:
-			fadeMusicVolume = 1.0f;
-
 			// vega music slow
+			sa_volume = 100;
 			ost_start_samples(60, 61, 1);
 			break;
 
 		case 0xb:
-			fadeMusicVolume = 1.0f;
-
 			// sagat music slow
+			sa_volume = 100;
 			ost_start_samples(28, 29, 1);
 			break;
 
 		case 0xc:
-			fadeMusicVolume = 1.0f;
-
 			// m. bison music slow
+			sa_volume = 100;
 			ost_start_samples(32, 33, 1);
 			break;
 
 		case 0xd:
-			fadeMusicVolume = 1.0f;
-
 			// bonus stage music
+			sa_volume = 100;
 			ost_start_samples(64, 65, 1);
 			break;
 
 		case 0xe:
-			fadeMusicVolume = 1.0f;
-
 			// character select stage
+			sa_volume = 100;
 			ost_start_samples(48, 49, 1);
 			break;
 
 		case 0xf:
-			fadeMusicVolume = 1.0f;
-
 			// versus screen ditty
+			sa_volume = 100;
 			ost_start_samples(36, 37, 0);
 			break;
 
 		case 0x10:
-			fadeMusicVolume = 1.0f;
-
 			// end of fight dialog/resolution screen
+			sa_volume = 100;
 			ost_start_samples(38, 39, 0);
 			break;
 
 		case 0x11:
-			fadeMusicVolume = 1.0f;
-
 			// continue music
+			sa_volume = 100;
 			ost_start_samples(40, 41, 0);
 			break;
 
 		case 0x13:
-			fadeMusicVolume = 1.0f;
-
 			// failed to continue?
+			sa_volume = 100;
 			ost_start_samples(90, 91, 0);
 			break;
 
 		case 0x14:
-			fadeMusicVolume = 1.0f;
-
 			// high score screen
+			sa_volume = 100;
 			ost_start_samples(42, 43, 0);
 			break;
 
 		case 0x15:
-			fadeMusicVolume = 1.0f;
-
 			// player joined music
+			sa_volume = 100;
 			ost_start_samples(46, 47, 0);
 			break;
 
 		case 0x16:
-			fadeMusicVolume = 1.0f;
-
 			// intro music
+			sa_volume = 100;
 			ost_start_samples(44, 45, 1);
 			break;
 
 		case 0x18:
-			fadeMusicVolume = 1.0f;
-
 			// ryu ending music
+			sa_volume = 100;
 			ost_start_samples(82, 83, 0);
 			break;
 
 		case 0x19:
-			fadeMusicVolume = 1.0f;
-
 			// e.honda ending music
+			sa_volume = 100;
 			ost_start_samples(72, 73, 1);
 			break;
 
 		case 0x1a:
-			ost_stop_samples();
-
 			fadingMusic = false;
-			fadeMusicVolume = 1.0f;
 
 			// blanka ending music
+			sa_volume = 100;
 			ost_start_samples(74, 75, 1);
 			break;
 
 		case 0x1b:
-			fadeMusicVolume = 1.0f;
-
 			// guile ending music
+			sa_volume = 100;
 			ost_start_samples(76, 77, 1);
 			break;
 
 		case 0x1c:
-			fadeMusicVolume = 1.0f;
-
 			// ken ending music
+			sa_volume = 100;
 			ost_start_samples(68, 69, 1);
 			break;
 
 		case 0x1d:
-			fadeMusicVolume = 1.0f;
-
 			// chun li ending music?
+			sa_volume = 100;
 			ost_start_samples(86, 87, 1);
 			break;
 
 		case 0x1e:
-			fadeMusicVolume = 1.0f;
-
 			// zangief ending music
+			sa_volume = 100;
 			ost_start_samples(78, 79, 1);
 			break;
 
 		case 0x1f:
-			ost_stop_samples();
-
 			fadingMusic = false;
-			fadeMusicVolume = 1.0f;
 
 			// dhalsim ending music
+			sa_volume = 100;
 			ost_start_samples(84, 85, 1);
 			break;
 
 		case 0x34:
-			fadeMusicVolume = 1.0f;
-
 			// wedding music -- ken ending
+			sa_volume = 100;
 			ost_start_samples(70, 71, 1);
 			break;
 
 		case 0x35:
-			fadeMusicVolume = 1.0f;
-
 			// chun li ending #2
+			sa_volume = 100;
 			ost_start_samples(88, 89, 1);
 			break;
 
 		case 0x79:
-			fadeMusicVolume = 1.0f;
-
 			// ryu music fast
+			sa_volume = 100;
 			ost_start_samples(2, 3, 1);
 			break;
 
 		case 0x7a:
-			fadeMusicVolume = 1.0f;
-
 			// e. honda music fast
+			sa_volume = 100;
 			ost_start_samples(14, 15, 1);
 			break;
 
 		case 0x7b:
-			fadeMusicVolume = 1.0f;
-
 			// blanka music fast
+			sa_volume = 100;
 			ost_start_samples(6, 7, 1);
 			break;
 
 		case 0x7c:
-			fadeMusicVolume = 1.0f;
-
 			// guile music fast
+			sa_volume = 100;
 			ost_start_samples(18, 19, 1);
 			break;
 
 		case 0x7d:
-			fadeMusicVolume = 1.0f;
-
 			// ken music fast
+			sa_volume = 100;
 			ost_start_samples(54, 55, 1);
 			break;
 
 		case 0x7e:
-			fadeMusicVolume = 1.0f;
-
 			// fast chun li music
+			sa_volume = 100;
 			ost_start_samples(10, 11, 1);
 			break;
 
 		case 0x7f:
-			fadeMusicVolume = 1.0f;
-
 			// zangief music fast
+			sa_volume = 100;
 			ost_start_samples(58, 59, 1);
 			break;
 
 		case 0x80:
-			fadeMusicVolume = 1.0f;
-
 			// dhalsim music fast
+			sa_volume = 100;
 			ost_start_samples(22, 23, 1);
 			break;
 
 		case 0x81:
-			fadeMusicVolume = 1.0f;
-
 			// fast balrog music
+			sa_volume = 100;
 			ost_start_samples(26, 27, 1);
 			break;
 
 		case 0x82:
-			fadeMusicVolume = 1.0f;
-
 			// fast vega music
+			sa_volume = 100;
 			ost_start_samples(62, 63, 1);
 			break;
 
 		case 0x83:
-			fadeMusicVolume = 1.0f;
-
 			// fast sagat music
+			sa_volume = 100;
 			ost_start_samples(30, 31, 1);
 			break;
 
 		case 0x84:
-			fadeMusicVolume = 1.0f;
-
 			// fast m. bison music
+			sa_volume = 100;
 			ost_start_samples(34, 35, 1);
 			break;
 
 		case 0x8c:
-			fadeMusicVolume = 1.0f;
-
 			// m. bison ending
+			sa_volume = 100;
 			ost_start_samples(66, 67, 1);
 			break;
 
 		case 0x8d:
-			// there's no stop music command after the ending music plays for some of them so we have to make sure that we're still not stuck in fading mode
-			ost_stop_samples();
-
 			fadingMusic = false;
-			// special ending
-			fadeMusicVolume = 1.0f;
 
+			// special ending
+			sa_volume = 100;
 			ost_start_samples(80, 81, 1);
 			break;
 

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -53,6 +53,7 @@ int      outrun_start_counter;
 static void ost_start_samples(int sa_left, int sa_right, int sa_loop);
 static void ost_stop_samples(void);
 static void ost_mix_samples(void);
+       void ost_fade_volume(void);
 
 
 const char *const ddragon_sample_set_names[] =
@@ -259,6 +260,104 @@ const char *const outrun_sample_set_names[] =
 	0
 };
 
+const char *const sf2_sample_set_names[] =
+{
+	"*sf2",
+	"ryuslow-01",
+	"ryuslow-02",
+	"ryufast-01",
+	"ryufast-02",
+	"blankaslow-01",
+	"blankaslow-02",
+	"blankafast-01",
+	"blankafast-02",
+	"chunlislow-01",
+	"chunlislow-02",
+	"chunlifast-01",
+	"chunlifast-02",
+	"ehondaslow-01",
+	"ehondaslow-02",
+	"ehondafast-01",
+	"ehondafast-02",
+	"guileslow-01",
+	"guileslow-02",
+	"guilefast-01",
+	"guilefast-02",
+	"dhalsimslow-01",
+	"dhalsimslow-02",
+	"dhalsimfast-01",
+	"dhalsimfast-02",
+	"balrogslow-01",
+	"balrogslow-02",
+	"balrogfast-01",
+	"balrogfast-02",
+	"sagatslow-01",
+	"sagatslow-02",
+	"sagatfast-01",
+	"sagatfast-02",
+	"mbisonslow-01",
+	"mbisonslow-02",
+	"mbisonfast-01",
+	"mbisonfast-02",
+	"versus-01",
+	"versus-02",
+	"endfight-01",
+	"endfight-02",
+	"continue-01",
+	"continue-02",
+	"highscore-01",
+	"highscore-02",
+	"intro-01",
+	"intro-02",
+	"playerjoin-01",
+	"playerjoin-02",
+	"playerselect-01",
+	"playerselect-02",
+	"gameover-01",
+	"gameover-02",
+	"kenslow-01",
+	"kenslow-02",
+	"kenfast-01",
+	"kenfast-02",
+	"zangiefslow-01",
+	"zangiefslow-02",
+	"zangieffast-01",
+	"zangieffast-02",
+	"vegaslow-01",
+	"vegaslow-02",
+	"vegafast-01",
+	"vegafast-02",
+	"bonusstage-01",
+	"bonusstage-02",
+	"mbisonending-01",
+	"mbisonending-02",
+	"kenendinga-01",
+	"kenendinga-02",
+	"kenendingb-01",
+	"kenendingb-02",
+	"ehondaending-01",
+	"ehondaending-02",
+	"blankaending-01",
+	"blankaending-02",
+	"guileending-01",
+	"guileending-02",
+	"zangiefending-01",
+	"zangiefending-02",
+	"specialending-01",
+	"specialending-02",
+	"ryuending-01",
+	"ryuending-02",
+	"dhalsimending-01",
+	"dhalsimending-02",
+	"chunliendinga-01",
+	"chunliendinga-02",
+	"chunliendingb-01",
+	"chunliendingb-02",
+	"gameover-01",
+	"gameover-02",
+	0
+};
+
 
 struct Samplesinterface ost_ddragon =
 {
@@ -302,6 +401,13 @@ struct Samplesinterface ost_outrun =
 	outrun_sample_set_names
 };
 
+struct Samplesinterface ost_sf2 =
+{
+	2,	/* 2 channels*/
+	100, /* volume*/
+	sf2_sample_set_names
+};
+
 
 static void ost_start_samples(int sa_left, int sa_right, int sa_loop)
 {
@@ -341,6 +447,11 @@ static void ost_mix_samples(void)
     ddragon_current_music = 0;
     mj_current_music = 0;
   }
+}
+
+
+void ost_fade_volume(void)
+{
 }
 
 

--- a/src/ost_samples.h
+++ b/src/ost_samples.h
@@ -46,6 +46,7 @@ extern struct Samplesinterface ost_mk;
 extern struct Samplesinterface ost_moonwalker;
 extern struct Samplesinterface ost_nba_jam;
 extern struct Samplesinterface ost_outrun;
+extern struct Samplesinterface ost_sf2;
 
 
 extern bool generate_ost_sound_ddragon    (int data);
@@ -55,3 +56,6 @@ extern bool generate_ost_sound_mk_tunit   (int data);
 extern bool generate_ost_sound_moonwalker (int data);
 extern bool generate_ost_sound_nba_jam    (int data);
 extern bool generate_ost_sound_outrun     (int data);
+extern bool generate_ost_sound_sf2        (int data);
+
+extern void ost_fade_volume (void);

--- a/src/ost_samples.h
+++ b/src/ost_samples.h
@@ -40,6 +40,7 @@ extern bool     outrun_lastwave;
 extern int      outrun_start_counter;
 
 extern bool     sf2_playing_street_fighter;
+extern bool     fadingMusic;
 
 
 extern struct Samplesinterface ost_ddragon;

--- a/src/ost_samples.h
+++ b/src/ost_samples.h
@@ -39,6 +39,8 @@ extern bool     outrun_title;
 extern bool     outrun_lastwave;
 extern int      outrun_start_counter;
 
+extern bool     sf2_playing_street_fighter;
+
 
 extern struct Samplesinterface ost_ddragon;
 extern struct Samplesinterface ost_ffight;


### PR DESCRIPTION
- removed duplicate "gameover" samples 90/91 and corrected with 50/51
- rewrote volume fade controller for simplistic design
- re-hooked fading triggers, should fix fading on all endings, and prevent fade loops
- found a dispute in case 0x11 (gameover and credits screen), original sound loops on the special credits screen but the ost sample ends with a fade which sounds a little odd looping....however not looping means a silent credit screen. I decided to loop for now. We may want to use the default sound here instead since it fills both conditions better.