### PR TITLE
Use rzip to speed up cheat.dat loading

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Rzip
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Rzip
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,7 +276,7 @@ libretro-build-vita:
 # Nintendo 3DS
 libretro-build-ctr:
   extends:
-    - .libretro-ctr-static-retroarch-master
+    - .libretro-ctr-legacy-static-retroarch-master
     - .core-defs
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ include:
 
   # Nintendo 3DS
   - project: 'libretro-infrastructure/ci-templates'
-    file: '/ctr-static.yml'
+    file: '/ctr-legacy-static.yml'
 
   # Nintendo WiiU
   - project: 'libretro-infrastructure/ci-templates'

--- a/Makefile
+++ b/Makefile
@@ -802,6 +802,9 @@ CFLAGS += -DHAVE_SOCKLEN_T
 CFLAGS += -D_LARGEFILE_SOURCE
 CFLAGS += -D_FILE_OFFSET_BITS=64
 
+# Required for RZIP support in cheat.c
+CFLAGS += -DHAVE_ZLIB
+
 # In theory, the RETRO_PROFILE could be set to different values for different
 # architectures or for special builds to hint to the host system how many
 # resources to allocate. In practice, there seems to be no standard way to

--- a/Makefile.common
+++ b/Makefile.common
@@ -2681,10 +2681,19 @@ SOURCES_C += \
 	$(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
 	$(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 	$(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
+	$(LIBRETRO_COMM_DIR)/encodings/encoding_crc32.c \
 	$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
 	$(LIBRETRO_COMM_DIR)/file/file_path.c \
 	$(LIBRETRO_COMM_DIR)/file/file_path_io.c \
 	$(LIBRETRO_COMM_DIR)/streams/file_stream.c \
+	$(LIBRETRO_COMM_DIR)/streams/file_stream_transforms.c \
+	$(LIBRETRO_COMM_DIR)/streams/interface_stream.c \
+	$(LIBRETRO_COMM_DIR)/streams/memory_stream.c \
+	$(LIBRETRO_COMM_DIR)/streams/rzip_stream.c \
+	$(LIBRETRO_COMM_DIR)/streams/stdin_stream.c \
+	$(LIBRETRO_COMM_DIR)/streams/trans_stream.c \
+	$(LIBRETRO_COMM_DIR)/streams/trans_stream_pipe.c \
+	$(LIBRETRO_COMM_DIR)/streams/trans_stream_zlib.c \
 	$(LIBRETRO_COMM_DIR)/string/stdstring.c \
 	$(LIBRETRO_COMM_DIR)/utils/md5.c \
 	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -5,7 +5,7 @@ CORE_DIR := $(ROOT_DIR)/src
 
 include $(ROOT_DIR)/Makefile.common
 
-COREFLAGS := $(DEFS) $(COREDEFS) $(CPUDEFS) $(SOUNDDEFS) $(ASMDEFS) $(DBGDEFS) -ffast-math -funroll-loops -DANDROID $(INCFLAGS)
+COREFLAGS := $(DEFS) $(COREDEFS) $(CPUDEFS) $(SOUNDDEFS) $(ASMDEFS) $(DBGDEFS) -ffast-math -funroll-loops -DANDROID -DHAVE_ZLIB $(INCFLAGS)
 
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8261,7 +8261,7 @@ static void LoadCheatDatabase()
 		rzip_file = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_WRITE);
 		if(!rzip_file)
 		{
-			log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to create cheat.rzip\n");
+			log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to create cheat.rzip  path: %s\n", cheat_path);
 			goto bail;
 		}
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -379,6 +379,8 @@ is selected
 
 
 #define CHEAT_DATABASE_FILENAME  "cheat.dat"
+#define CHEAT_SAVE_FILENAME      "save_cheat.dat"
+
 
 #define OSD_READKEY_KLUDGE	1
 
@@ -8399,7 +8401,7 @@ static void SaveCheat(CheatEntry * entry)
 	if(!entry || !entry->actionList)
 		return;
 
-	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 1);
+	theFile = mame_fopen(NULL, CHEAT_SAVE_FILENAME, FILETYPE_CHEAT, 1);
 
 	if(!theFile)
 		return;

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8272,6 +8272,7 @@ static void LoadCheatDatabase()
 			data_read = intfstream_read(DAT_FILE, buffer, sizeof(buffer));
 			if (data_read == 0);
 			{
+				intfstream_flush(RZIP_FILE);
 				intfstream_close(RZIP_FILE);
 				RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 				goto end;

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8230,6 +8230,9 @@ static void LoadCheatDatabase()
 	char		oldFormatString[256];
 	char		buf[2048];
 	int			recordNames = 0;
+	char		* directory;
+
+	osd_get_path(FILETYPE_CHEAT, directory);
 
 	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 0);
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8228,8 +8228,8 @@ static void HandleLocalCommandCheat(UINT32 type, UINT32 address, UINT32 data, UI
 
 static void LoadCheatDatabase()
 {
-	intfstream_t	* RZIP_FILE = NULL;
-	intfstream_t	* DAT_FILE  = NULL;
+	intfstream_t	* rzip_file = NULL;
+	intfstream_t	* dat_file  = NULL;
 	char 		cheat_directory[PATH_MAX_LENGTH];
 	char 		cheat_path[PATH_MAX_LENGTH];
 	char		formatString[256];
@@ -8244,22 +8244,22 @@ static void LoadCheatDatabase()
 	snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_RZIP_FILENAME);
 
 	/* Open existing cheat.rzip */
-	RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
+	rzip_file = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 
-	if(!RZIP_FILE)
+	if(!rzip_file)
 	{
 		/* Try to open cheat.dat */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
-		DAT_FILE = intfstream_open_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
-		if(!DAT_FILE)
+		dat_file = intfstream_open_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+		if(!dat_file)
 			goto bail;
 
 		/* Create new cheat.rzip file */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_RZIP_FILENAME);
-		RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_WRITE);
-		if(!RZIP_FILE)
+		rzip_file = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_WRITE);
+		if(!rzip_file)
 		{
 			log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to create cheat.rzip\n");
 			goto bail;
@@ -8269,7 +8269,7 @@ static void LoadCheatDatabase()
 		for(;;)
 		{
 			uint8_t buffer[4096];
-			int64_t data_read    = intfstream_read(DAT_FILE, buffer, sizeof(buffer));
+			int64_t data_read    = intfstream_read(dat_file, buffer, sizeof(buffer));
 			int64_t data_write   = 0;
 
 			if (data_read < 0)
@@ -8281,9 +8281,9 @@ static void LoadCheatDatabase()
 			if (data_read == 0)
 			{
 				/* Finished, close cheat.rzip and re-open as read file */
-				intfstream_close(RZIP_FILE);
-				RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
-				if(!RZIP_FILE)
+				intfstream_close(rzip_file);
+				rzip_file = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
+				if(!rzip_file)
 				{
 					log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to open cheat.rzip\n");
 					goto bail;
@@ -8291,7 +8291,7 @@ static void LoadCheatDatabase()
 				break;
 			}
 
-			data_write = intfstream_write(RZIP_FILE, buffer, data_read);
+			data_write = intfstream_write(rzip_file, buffer, data_read);
 
 			if (data_write != data_read)
 			{
@@ -8307,7 +8307,7 @@ static void LoadCheatDatabase()
 	sprintf(formatString, ":%s:%s", Machine->gamedrv->name, "%x:%x:%x:%x:%[^:\n\r]:%[^:\n\r]");
 	sprintf(oldFormatString, "%s:%s", Machine->gamedrv->name, "%d:%x:%x:%d:%[^:\n\r]:%[^:\n\r]");
 
-	while(intfstream_gets(RZIP_FILE, buf, 2048))
+	while(intfstream_gets(rzip_file, buf, 2048))
 	{
 		int			type;
 		int			address;
@@ -8429,16 +8429,16 @@ static void LoadCheatDatabase()
 
 	bail:
 
-	if(DAT_FILE)
+	if(dat_file)
 	{
-		intfstream_close(DAT_FILE);
-		free(DAT_FILE);
+		intfstream_close(dat_file);
+		free(dat_file);
 	}
 
-	if(RZIP_FILE)
+	if(rzip_file)
 	{
-		intfstream_close(RZIP_FILE);
-		free(RZIP_FILE);
+		intfstream_close(rzip_file);
+		free(rzip_file);
 	}
 
 	UpdateAllCheatInfo();

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8403,10 +8403,8 @@ static void SaveCheat(CheatEntry * entry)
 
 	theFile = mame_fopen(NULL, CHEAT_SAVE_FILENAME, FILETYPE_CHEAT, 1);
 
-	if(!theFile) {
-		mame_fopen("save_cheat", 0, FILETYPE_CHEAT, 1);
-		if(!theFile) return;
-	}
+	if(!theFile)
+		return;
 
 	mame_fseek(theFile, 0, SEEK_END);
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8284,7 +8284,10 @@ static void LoadCheatDatabase()
 				intfstream_close(RZIP_FILE);
 				RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 				if(!RZIP_FILE)
+				{
+					log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to open cheat.rzip\n");
 					goto bail;
+				}
 				break;
 			}
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -376,7 +376,7 @@ is selected
 #include "artwork.h"
 #include "machine/eeprom.h"
 #include <ctype.h>
-#include <interface_stream.h>
+#include <streams/interface_stream.h>
 
 
 #define CHEAT_DATABASE_RZIP_FILENAME  "cheat.rzip"

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8253,8 +8253,8 @@ static void LoadCheatDatabase()
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
 		DAT_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
-		if(!DAT_FILE)
-			return;
+		//if(!DAT_FILE)
+			//return;
 log_cb(RETRO_LOG_INFO, "LOG....... dat found\n");
 		/* Create new cheat.rzip file */
 		cheat_path[0] = '\0';

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8228,7 +8228,7 @@ static void HandleLocalCommandCheat(UINT32 type, UINT32 address, UINT32 data, UI
 
 static void LoadCheatDatabase()
 {
-	intfstream_t	* RZIP_FILE;
+	intfstream_t	* RZIP_FILE = NULL;
 	char		formatString[256];
 	char		oldFormatString[256];
 	char		buf[2048];
@@ -8247,7 +8247,7 @@ static void LoadCheatDatabase()
 
 	if(!RZIP_FILE)
 	{
-		intfstream_t         * DAT_FILE;
+		intfstream_t         * DAT_FILE = NULL;
 		int64_t data_read    = 0;
 		int64_t data_write   = 0;
 		uint8_t buffer[4096];

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8278,7 +8278,7 @@ static void LoadCheatDatabase()
 				goto bail;
 			}
 	
-			if (data_read == 0);
+			if (data_read == 0)
 			{
 				/* Finished, close cheat.rzip and re-open as read file */
 				intfstream_close(RZIP_FILE);

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -379,8 +379,6 @@ is selected
 
 
 #define CHEAT_DATABASE_FILENAME  "cheat.dat"
-#define CHEAT_SAVE_FILENAME      "save_cheat.dat"
-
 
 #define OSD_READKEY_KLUDGE	1
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8258,14 +8258,14 @@ static void LoadCheatDatabase()
 		DAT_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 		if(!DAT_FILE)
 			return;
-
+log_cb(RETRO_LOG_INFO, "LOG....... dat found\n");
 		/* Create new cheat.rzip file */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_RZIP_FILENAME);
 		RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_WRITE);
 		if(!RZIP_FILE)
 			goto end;
-
+log_cb(RETRO_LOG_INFO, "LOG....... rzip open\n");
 		/* Compression loop */
 		for(;;)
 		{
@@ -8274,6 +8274,7 @@ static void LoadCheatDatabase()
 			{
 				intfstream_flush(RZIP_FILE);
 				intfstream_close(RZIP_FILE);
+log_cb(RETRO_LOG_INFO, "LOG....... Rzip close\n");
 				RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 				goto end;
 			}

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8244,18 +8244,18 @@ static void LoadCheatDatabase()
 
 	/* Open existing cheat.rzip */
 	RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
-
+log_cb(RETRO_LOG_INFO, "LOG....... Check start\n");
 	if(!RZIP_FILE)
 	{
 		intfstream_t         * DAT_FILE = NULL;
 		int64_t data_read    = 0;
 		int64_t data_write   = 0;
 		uint8_t buffer[4096];
-
+log_cb(RETRO_LOG_INFO, "LOG....... No rzip\n");
 		/* Attempt to open cheat.dat */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
-		DAT_FILE = intfstream_open_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
+		DAT_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 		if(!DAT_FILE)
 			return;
 log_cb(RETRO_LOG_INFO, "LOG....... dat found\n");

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8230,12 +8230,12 @@ static void LoadCheatDatabase()
 {
 	intfstream_t	* RZIP_FILE = NULL;
 	intfstream_t	* DAT_FILE  = NULL;
+	char 		cheat_directory[PATH_MAX_LENGTH];
+	char 		cheat_path[PATH_MAX_LENGTH];
 	char		formatString[256];
 	char		oldFormatString[256];
 	char		buf[2048];
 	int			recordNames = 0;
-	char 		cheat_directory[PATH_MAX_LENGTH];
-	char 		cheat_path[PATH_MAX_LENGTH];
 
 	cheat_directory[0] = '\0';
 	cheat_path[0]      = '\0';

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8251,7 +8251,7 @@ static void LoadCheatDatabase()
 		/* Try to open cheat.dat */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
-		DAT_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
+		DAT_FILE = intfstream_open_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
 		if(!DAT_FILE)
 			goto bail;
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8231,10 +8231,14 @@ static void LoadCheatDatabase()
 	char		oldFormatString[256];
 	char		buf[2048];
 	int			recordNames = 0;
+	char 		cheat_directory[PATH_MAX_LENGTH];
 	char 		cheat_path[PATH_MAX_LENGTH];
 
-	cheat_path[0] = '\0';
-	osd_get_path(FILETYPE_CHEAT, cheat_path);
+	cheat_directory[0] = '\0';
+	cheat_path[0]      = '\0';
+
+	osd_get_path(FILETYPE_CHEAT, cheat_directory);
+	snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
 	log_cb(RETRO_LOG_INFO, "dir:  %s\n", cheat_path);
 
 	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 0);

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8249,20 +8249,20 @@ static void LoadCheatDatabase()
 	{
 		intfstream_t	* DAT_FILE = NULL;
 
-		/* Attempt to open cheat.dat */
+		/* Try to open cheat.dat */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
 		DAT_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
-		//if(!DAT_FILE)
-			//return;
-log_cb(RETRO_LOG_INFO, "LOG....... dat found\n");
+		if(!DAT_FILE)
+			return;
+
 		/* Create new cheat.rzip file */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_RZIP_FILENAME);
 		RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_WRITE);
 		if(!RZIP_FILE)
 			goto end;
-log_cb(RETRO_LOG_INFO, "LOG....... rzip open\n");
+
 		/* Compression loop */
 		for(;;)
 		{
@@ -8274,13 +8274,11 @@ log_cb(RETRO_LOG_INFO, "LOG....... rzip open\n");
 			{
 				intfstream_flush(RZIP_FILE);
 				intfstream_close(RZIP_FILE);
-log_cb(RETRO_LOG_INFO, "LOG....... Rzip close\n");
 				RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 				goto end;
 			}
 			data_write = intfstream_write(RZIP_FILE, buffer, data_read);
 		}
-
 
 		end:
 		intfstream_close(DAT_FILE);

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8235,6 +8235,7 @@ static void LoadCheatDatabase()
 	char		* directory;
 
 	osd_get_path(FILETYPE_CHEAT, directory);
+	log_cb(RETRO_LOG_INFO, "dir:  %s\n", directory);
 
 	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 0);
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -379,6 +379,7 @@ is selected
 
 
 #define CHEAT_DATABASE_FILENAME  "cheat.dat"
+#define CHEAT_SAVE_FILENAME      "save_cheat.dat"
 
 #define OSD_READKEY_KLUDGE	1
 
@@ -8400,7 +8401,7 @@ static void SaveCheat(CheatEntry * entry)
 	if(!entry || !entry->actionList)
 		return;
 
-	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 1);
+	theFile = mame_fopen(NULL, CHEAT_SAVE_FILENAME, FILETYPE_CHEAT, 1);
 
 	if(!theFile)
 		return;

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8244,14 +8244,11 @@ static void LoadCheatDatabase()
 
 	/* Open existing cheat.rzip */
 	RZIP_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
-log_cb(RETRO_LOG_INFO, "LOG....... Check start\n");
+
 	if(!RZIP_FILE)
 	{
-		intfstream_t         * DAT_FILE = NULL;
-		int64_t data_read    = 0;
-		int64_t data_write   = 0;
-		uint8_t buffer[4096];
-log_cb(RETRO_LOG_INFO, "LOG....... No rzip\n");
+		intfstream_t	* DAT_FILE = NULL;
+
 		/* Attempt to open cheat.dat */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
@@ -8269,7 +8266,10 @@ log_cb(RETRO_LOG_INFO, "LOG....... rzip open\n");
 		/* Compression loop */
 		for(;;)
 		{
-			data_read = intfstream_read(DAT_FILE, buffer, sizeof(buffer));
+			uint8_t buffer[4096];
+			int64_t data_read    = intfstream_read(DAT_FILE, buffer, sizeof(buffer));
+			int64_t data_write   = 0;
+	
 			if (data_read == 0);
 			{
 				intfstream_flush(RZIP_FILE);

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8226,7 +8226,7 @@ static void HandleLocalCommandCheat(UINT32 type, UINT32 address, UINT32 data, UI
 
 static void LoadCheatDatabase()
 {
-	mame_file	* theFile;
+	intfstream_t	* theFile;
 	char		formatString[256];
 	char		oldFormatString[256];
 	char		buf[2048];
@@ -8241,7 +8241,7 @@ static void LoadCheatDatabase()
 	snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
 	log_cb(RETRO_LOG_INFO, "dir:  %s\n", cheat_path);
 
-	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 0);
+	theFile = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 
 	if(!theFile)
 		return;
@@ -8252,7 +8252,7 @@ static void LoadCheatDatabase()
 	sprintf(formatString, ":%s:%s", Machine->gamedrv->name, "%x:%x:%x:%x:%[^:\n\r]:%[^:\n\r]");
 	sprintf(oldFormatString, "%s:%s", Machine->gamedrv->name, "%d:%x:%x:%d:%[^:\n\r]:%[^:\n\r]");
 
-	while(mame_fgets(buf, 2048, theFile))
+	while(intfstream_gets(theFile, buf, 2048))
 	{
 		int			type;
 		int			address;
@@ -8374,8 +8374,8 @@ static void LoadCheatDatabase()
 
 	bail:
 
-	mame_fclose(theFile);
-
+	intfstream_close(theFile);
+	free(theFile);
 	UpdateAllCheatInfo();
 }
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8401,7 +8401,7 @@ static void SaveCheat(CheatEntry * entry)
 	if(!entry || !entry->actionList)
 		return;
 
-	theFile = mame_fopen(NULL, CHEAT_SAVE_FILENAME, FILETYPE_CHEAT, 1);
+	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 1);
 
 	if(!theFile)
 		return;

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8231,10 +8231,11 @@ static void LoadCheatDatabase()
 	char		oldFormatString[256];
 	char		buf[2048];
 	int			recordNames = 0;
-	char		* directory;
+	char 		cheat_path[PATH_MAX_LENGTH];
 
-	//osd_get_path(FILETYPE_CHEAT, directory);
-	log_cb(RETRO_LOG_INFO, "dir:  %s\n", directory);
+	cheat_path[0] = '\0';
+	osd_get_path(FILETYPE_CHEAT, cheat_path);
+	log_cb(RETRO_LOG_INFO, "dir:  %s\n", cheat_path);
 
 	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 0);
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8255,7 +8255,7 @@ static void LoadCheatDatabase()
 		/* Attempt to open cheat.dat */
 		cheat_path[0] = '\0';
 		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
-		DAT_FILE = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
+		DAT_FILE = intfstream_open_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 		if(!DAT_FILE)
 			return;
 log_cb(RETRO_LOG_INFO, "LOG....... dat found\n");

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8261,7 +8261,7 @@ static void LoadCheatDatabase()
 		rzip_file = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_WRITE);
 		if(!rzip_file)
 		{
-			log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to create cheat.rzip  path: %s\n", cheat_path);
+			log_cb(RETRO_LOG_ERROR, LOGPRE "Failed to create cheat.rzip\n");
 			goto bail;
 		}
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -376,10 +376,12 @@ is selected
 #include "artwork.h"
 #include "machine/eeprom.h"
 #include <ctype.h>
+#include <interface_stream.h>
 
 
-#define CHEAT_DATABASE_FILENAME  "cheat.dat"
-#define CHEAT_SAVE_FILENAME      "save_cheat.dat"
+#define CHEAT_DATABASE_RZIP_FILENAME  "cheat.rzip"
+#define CHEAT_DATABASE_FILENAME       "cheat.dat"
+#define CHEAT_SAVE_FILENAME           "save_cheat.dat"
 
 #define OSD_READKEY_KLUDGE	1
 
@@ -8238,13 +8240,20 @@ static void LoadCheatDatabase()
 	cheat_path[0]      = '\0';
 
 	osd_get_path(FILETYPE_CHEAT, cheat_directory);
-	snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
-	log_cb(RETRO_LOG_INFO, "dir:  %s\n", cheat_path);
+	snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_RZIP_FILENAME);
 
 	theFile = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
 
-	if(!theFile)
-		return;
+	if(!theFile) {
+		cheat_path[0] = '\0';
+		snprintf(cheat_path, PATH_MAX_LENGTH, "%s%c%s", cheat_directory, PATH_DEFAULT_SLASH_C(), CHEAT_DATABASE_FILENAME);
+		theFile = intfstream_open_rzip_file(cheat_path, RETRO_VFS_FILE_ACCESS_READ);
+
+		if(!theFile)
+			return;
+
+		//Compression loop
+	}
 
 	foundCheatDatabase = 1;
 

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8232,7 +8232,7 @@ static void LoadCheatDatabase()
 	int			recordNames = 0;
 	char		* directory;
 
-	osd_get_path(FILETYPE_CHEAT, directory);
+	//osd_get_path(FILETYPE_CHEAT, directory);
 	log_cb(RETRO_LOG_INFO, "dir:  %s\n", directory);
 
 	theFile = mame_fopen(NULL, CHEAT_DATABASE_FILENAME, FILETYPE_CHEAT, 0);

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -8403,8 +8403,10 @@ static void SaveCheat(CheatEntry * entry)
 
 	theFile = mame_fopen(NULL, CHEAT_SAVE_FILENAME, FILETYPE_CHEAT, 1);
 
-	if(!theFile)
-		return;
+	if(!theFile) {
+		mame_fopen("save_cheat", 0, FILETYPE_CHEAT, 1);
+		if(!theFile) return;
+	}
 
 	mame_fseek(theFile, 0, SEEK_END);
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -10,6 +10,7 @@
 #include <string/stdstring.h>
 #include <libretro.h>
 #include <file/file_path.h>
+#include <streams/file_stream.h>
 #include <math.h>
 
 #if (HAS_DRZ80 || HAS_CYCLONE)
@@ -211,7 +212,15 @@ static void check_system_specs(void)
 
 void retro_set_environment(retro_environment_t cb)
 {
+  struct retro_vfs_interface_info vfs_iface_info;
+
   environ_cb = cb;
+
+  /* Initialise VFS */
+  vfs_iface_info.required_interface_version = 1;
+  vfs_iface_info.iface                      = NULL;
+  if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
+    filestream_vfs_init(&vfs_iface_info);
 }
 
 


### PR DESCRIPTION
- Uses rzip to compress cheat.dat on first load, sequential loads will benefit from faster loading.
- now saves new / edited codes to new file save_cheat.dat in the system directory.
- use legacy 3ds toolchain to massively boost load times. An apparent issue with the latest chain.
