### PR TITLE
New working games Angler Dangler / Fishing

### DIFF
--- a/src/drivers/decocass.c
+++ b/src/drivers/decocass.c
@@ -852,6 +852,27 @@ ROM_END
 
 /* The Following use Dongle Type 3 (unknown part number?)
     (dongle data differs for each game)		 */
+	
+/* Fishing / Angler Dangler */
+ROM_START( cadanglr ) /* version 5-B-0 */
+	DECOCASS_COMMON_ROMS
+
+	ROM_REGION( 0x01000, REGION_USER1, 0 )	  /* dongle data */
+	ROM_LOAD( "dp-1250-a-0.dgl", 0x0000, 0x1000, CRC(92a3b387) SHA1(e17a155d02e9ed806590b23a845dc7806b6720b1) )
+
+	ROM_REGION( 0x10000, REGION_USER2, 0 )	  /* (max) 64k for cassette image */
+	ROM_LOAD( "dt-1255-b-0.cas", 0x0000, 0x7400, CRC(eb985257) SHA1(1285724352a59c96cc4edf4f43e89dd6d8c585b2) )
+ROM_END
+
+ROM_START( cfishing )
+	DECOCASS_COMMON_ROMS
+
+	ROM_REGION( 0x01000, REGION_USER1, 0 )	  /* dongle data */
+	ROM_LOAD( "dp-1250-a-0.dgl", 0x0000, 0x1000, CRC(92a3b387) SHA1(e17a155d02e9ed806590b23a845dc7806b6720b1) )
+
+	ROM_REGION( 0x10000, REGION_USER2, 0 )	  /* (max) 64k for cassette image */
+	ROM_LOAD( "dt-1250-a-0.cas", 0x0000, 0x7500, CRC(d4a16425) SHA1(25afaabdc8b2217d5e73606a36ea9ba408d7bc4b) )
+ROM_END
 
 ROM_START( cburnrub )
 	DECOCASS_COMMON_ROMS
@@ -1104,6 +1125,8 @@ GAME ( 1982, cburnrub, decocass, cburnrub, decocass, decocass, ROT270, "DECO", "
 GAME ( 1982, cburnrb2, cburnrub, cburnrub, decocass, decocass, ROT270, "DECO", "Cassette: Burnin' Rubber (set 2)" )
 GAME ( 1982, cbnj,	   cburnrub, cbnj,	   decocass, decocass, ROT270, "DECO", "Cassette: Bump N Jump" )
 GAME ( 1983, cbtime,   decocass, cbtime,   decocass, decocass, ROT270, "DECO", "Cassette: Burger Time" )
+GAME ( 1982, cadanglr, decocass, cppicf,   decocass, decocass, ROT270, "DECO", "Cassette: Angler Dangler" )
+GAME ( 1982, cfishing, cadanglr, cppicf,   decocass, decocass, ROT270, "DECO", "Cassette: Fishing" )
 GAME ( 1983, cgraplop, decocass, cgraplop, decocass, decocass, ROT270, "DECO", "Cassette: Graplop (aka Cluster Buster) (set 1)" )
 GAMEX( 1983, cgraplp2, cgraplop, cgraplop, decocass, decocass, ROT270, "DECO", "Cassette: Graplop (aka Cluster Buster) (set 2)", GAME_NOT_WORKING ) /* Different Protection / Bitswap? */
 GAME ( 1983, clapapa,  decocass, clapapa,  decocass, decocass, ROT270, "DECO", "Cassette: Rootin' Tootin' (aka La.Pa.Pa)" ) /* Displays 'LaPaPa during attract */


### PR DESCRIPTION
MAME WIP

0.147u2: Tornadoboy added Angler Dangler (DECO Cassette).
0.146u2: SRI, Charles MacDonald and Team Japump added 'Fishing (DECO Cassette)' (Data East 1982).

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
