### PR TITLE
Finish off backporting the djboy driver

### DIFF
--- a/src/drivers/djboy.c
+++ b/src/drivers/djboy.c
@@ -647,6 +647,11 @@ static DRIVER_INIT( djboy )
 	bankxor = 0x00;
 }
 
+static DRIVER_INIT( djboyj )
+{
+	bankxor = 0x1f;
+}
+
 static WRITE_HANDLER( cpu1_cause_nmi_w )
 {
 	cpu_set_irq_line(0, IRQ_LINE_NMI, PULSE_LINE);
@@ -1043,5 +1048,39 @@ ROM_START( djboy )
 	ROM_LOAD( "bs203.5j", 0x000000, 0x40000, CRC(805341fb) SHA1(fb94e400e2283aaa806814d5a39d6196457dc822) )
 ROM_END
 
-/*    YEAR, NAME,   PARENT, MACHINE, INPUT, INIT,  MNTR, COMPANY,  FULLNAME, FLAGS */
-GAME( 1989, djboy,  0,      djboy,   djboy, djboy, ROT0, "Kaneko", "DJ Boy" ) /* Sammy & Williams logos in FG ROM*/
+ROM_START( djboyj )
+	ROM_REGION( 0x48000, REGION_CPU1, 0 )
+	ROM_LOAD( "bs12.4b",  0x00000, 0x08000, CRC(0971523e) SHA1(f90cd02cedf8632f4b651de7ea75dc8c0e682f6e) )
+	ROM_CONTINUE( 0x10000, 0x18000 )
+	ROM_LOAD( "bs100.4d", 0x28000, 0x20000, CRC(081e8af8) SHA1(3589dab1cf31b109a40370b4db1f31785023e2ed) )
+
+	ROM_REGION( 0x38000, REGION_CPU2, 0 )
+	ROM_LOAD( "bs13.5y",  0x00000, 0x08000, CRC(5c3f2f96) SHA1(bb7ee028a2d8d3c76a78a29fba60bcc36e9399f5) )
+	ROM_CONTINUE( 0x10000, 0x08000 )
+	ROM_LOAD( "bs101.6w", 0x18000, 0x20000, CRC(a7c85577) SHA1(8296b96d5f69f6c730b7ed77fa8c93496b33529c) )
+
+	ROM_REGION( 0x24000, REGION_CPU3, 0 ) /* sound */
+	ROM_LOAD( "bs200.8c", 0x00000, 0x0c000, CRC(f6c19e51) SHA1(82193f71122df07cce0a7f057a87b89eb2d587a1) )
+	ROM_CONTINUE( 0x10000, 0x14000 )
+
+	ROM_REGION( 0x200000, REGION_GFX1, 0 ) /* sprites */
+	ROM_LOAD( "bs000.1h", 0x000000, 0x80000, CRC(be4bf805) SHA1(a73c564575fe89d26225ca8ec2d98b6ac319ac18) )
+	ROM_LOAD( "bs001.1f", 0x080000, 0x80000, CRC(fdf36e6b) SHA1(a8762458dfd5201304247c113ceb85e96e33d423) )
+	ROM_LOAD( "bs002.1d", 0x100000, 0x80000, CRC(c52fee7f) SHA1(bd33117f7a57899fd4ec0a77413107edd9c44629) )
+	ROM_LOAD( "bs003.1k", 0x180000, 0x80000, CRC(ed89acb4) SHA1(611af362606b73cd2cf501678b463db52dcf69c4) )
+	ROM_LOAD( "bsxx.1b",  0x1f0000, 0x10000, CRC(22c8aa08) SHA1(5521c9d73b4ee82a2de1992d6edc7ef62788ad72) ) // replaces last 0x200 tiles
+
+	ROM_REGION( 0x100000, REGION_GFX2, 0 ) /* background */
+	ROM_LOAD( "bs004.1s", 0x000000, 0x80000, CRC(2f1392c3) SHA1(1bc3030b3612766a02133eef0b4d20013c0495a4) )
+	ROM_LOAD( "bs005.1u", 0x080000, 0x80000, CRC(46b400c4) SHA1(35f4823364bbff1fc935994498d462bbd3bc6044) )
+
+	ROM_REGION( 0x40000, REGION_SOUND1, 0 ) /* OKI-M6295 samples */
+	ROM_LOAD( "bs-204.5j", 0x000000, 0x40000, CRC(510244f0) SHA1(afb502d46d268ad9cd209ae1da72c50e4e785626) )
+
+	ROM_REGION( 0x40000, REGION_SOUND2, 0 ) /* OKI-M6295 samples */
+	ROM_LOAD( "bs-204.5j", 0x000000, 0x40000, CRC(510244f0) SHA1(afb502d46d268ad9cd209ae1da72c50e4e785626) )
+ROM_END
+
+
+GAME( 1989, djboy,  0,      djboy,  djboy,  djboy,   ROT0, "Kaneko", "DJ Boy" ) /* Sammy & Williams logos in FG ROM */
+GAME( 1989, djboyj, djboy,  djboy,  djboy,  djboyj,  ROT0, "Kaneko", "DJ Boy (Japan)" ) /* Sega logo in FG ROM */


### PR DESCRIPTION
Add support for the Japanese version which has a different DJ over the World set not sure if there are more diffs

MAME WIP

0.116u4: Phil Stroffolino Updated djboy driver [Phil Stroffolino]: Support for DJ Boy (Japan); same MCU, but ROM banking bits need to be XOR'd. 
0.105u2: Added clone DJ Boy (Japan).

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
