### PR TITLE
Test  m92, disable palette banking for R-Type leo - fixes invincibili…

### DIFF
--- a/src/vidhrdw/m92_vidhrdw.c
+++ b/src/vidhrdw/m92_vidhrdw.c
@@ -129,7 +129,7 @@ WRITE_HANDLER( m92_videocontrol_w )
 	if (offset==0)
 	{
 		/* Access to upper palette bank */
-		if ((data & 0x2) == 0x2 && m92_game_kludge!=3) m92_palette_bank = 1;
+    if ((data & 0x2) == 0x2 && (m92_game_kludge!=3 && m92_game_kludge!=1)) m92_palette_bank = 1;
 		else                     m92_palette_bank = 0;
 	}
 /*	log_cb(RETRO_LOG_DEBUG, LOGPRE "%04x: m92_videocontrol_w %d = %02x\n",activecpu_get_pc(),offset,data);*/


### PR DESCRIPTION
…ty flash [Haze]

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
