### PR TITLE
Disable gfx speedup for R-Type Leo

### DIFF
--- a/src/drivers/m92.c
+++ b/src/drivers/m92.c
@@ -2421,7 +2421,7 @@ static DRIVER_INIT( rtypeleo )
 	install_mem_read_handler(0, 0xe0032, 0xe0033, rtypeleo_cycle_r);
 	init_m92(rtypeleo_decryption_table);
 	m92_irq_vectorbase=0x20;
-	m92_game_kludge=1;
+	m92_game_kludge=3;
 }
 
 static DRIVER_INIT( rtypelej )
@@ -2429,7 +2429,7 @@ static DRIVER_INIT( rtypelej )
 	install_mem_read_handler(0, 0xe0032, 0xe0033, rtypelej_cycle_r);
 	init_m92(rtypeleo_decryption_table);
 	m92_irq_vectorbase=0x20;
-	m92_game_kludge=1;
+	m92_game_kludge=3;
 }
 
 static DRIVER_INIT( majtitl2 )


### PR DESCRIPTION
Fixes some serious graphical bugs throughout the game

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
