### PR TITLE
Fix sprite priority for bodyslam

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/drivers/system16.c
+++ b/src/drivers/system16.c
@@ -2051,7 +2051,7 @@ MEMORY_END
 static MACHINE_INIT( bodyslam ){
 	sys16_textmode=1;
 	sys16_spritesystem = sys16_sprite_quartet2;
-	sys16_sprxoffset = -0xbc;
+	sys16_sprxoffset = -0xbd;
 	sys16_fgxoffset = sys16_bgxoffset = 7;
 	sys16_bg_priority_mode = 2;
 	sys16_bg_priority_value=0x0e00;

--- a/src/vidhrdw/sys16spr.c
+++ b/src/vidhrdw/sys16spr.c
@@ -225,7 +225,7 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 			//bottom++;
 			sprite->x = source[1] + sys16_sprxoffset;
 			if(sprite->x > 0x140) sprite->x-=0x200;
-			sprite->y = top;
+			sprite->y = top - 1;
 			sprite->priority = spr_pri;
 			sprite->color = 1024/16 + pal;
 			sprite->screen_height = bottom-top;

--- a/src/vidhrdw/sys16spr.c
+++ b/src/vidhrdw/sys16spr.c
@@ -291,7 +291,7 @@ int sys16_sprite_hangon( struct sys16_sprite_attributes *sprite, const UINT16 *s
 //			sprite->shadow_pen=10;
 		sprite->zoomx = zoomx;
 		sprite->zoomy = zoomy;
-		sprite->gfx = ((gfx &0x3ffff) + (sys16_obj_bank[bank] << 17))/2;
+		sprite->gfx = (gfx &0x3ffff) + ((sys16_obj_bank[bank] << 17)/2);
 	}
 	return 0;
 }

--- a/src/vidhrdw/sys16spr.c
+++ b/src/vidhrdw/sys16spr.c
@@ -226,7 +226,7 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 			sprite->x = source[1] + sys16_sprxoffset;
 			if(sprite->x > 0x140) sprite->x-=0x200;
 			sprite->y = top;
-			sprite->priority = 3 - spr_pri;
+			sprite->priority = spr_pri;
 			sprite->color = 1024/16 + pal;
 			sprite->screen_height = bottom-top;
 			sprite->pitch = width&0xff;

--- a/src/vidhrdw/sys16spr.c
+++ b/src/vidhrdw/sys16spr.c
@@ -194,8 +194,8 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 	7	-------- --------
 */
 	UINT16 ypos = source[0];
-	int top = ypos&0xff;
-	int bottom = ypos>>8;
+	int top = (ypos&0xff) + 1;
+	int bottom = (ypos>>8) + 1;
 	if( bottom == 0xff ) return 1;
 	if(bottom !=0 && bottom > top){
 		UINT16 spr_pri=(source[4])&0xf; /* ?? */
@@ -225,7 +225,7 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 			//bottom++;
 			sprite->x = source[1] + sys16_sprxoffset;
 			if(sprite->x > 0x140) sprite->x-=0x200;
-			sprite->y = top + 1;
+			sprite->y = top;
 			sprite->priority = spr_pri;
 			sprite->color = 1024/16 + pal;
 			sprite->screen_height = bottom-top;

--- a/src/vidhrdw/sys16spr.c
+++ b/src/vidhrdw/sys16spr.c
@@ -205,7 +205,6 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 		UINT16 width;
 		int gfx;
 
-		if (spr_pri) { /* MASH - ?? */
 			tsource[2]=source[2];
 			tsource[3]=source[3];
 #ifndef TRANSPARENT_SHADOWS
@@ -227,7 +226,7 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 			sprite->x = source[1] + sys16_sprxoffset;
 			if(sprite->x > 0x140) sprite->x-=0x200;
 			sprite->y = top;
-			sprite->priority = spr_pri;
+			sprite->priority = 3 - spr_pri;
 			sprite->color = 1024/16 + pal;
 			sprite->screen_height = bottom-top;
 			sprite->pitch = width&0xff;
@@ -237,7 +236,6 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 			if( pal==0x3f ) sprite->flags|= SYS16_SPR_SHADOW; // shadow sprite
 #endif
 			sprite->gfx = ((gfx &0x3ffff) + (sys16_obj_bank[bank] << 17))/2;
-		}
 	}
 	return 0;
 }
@@ -291,7 +289,7 @@ int sys16_sprite_hangon( struct sys16_sprite_attributes *sprite, const UINT16 *s
 //			sprite->shadow_pen=10;
 		sprite->zoomx = zoomx;
 		sprite->zoomy = zoomy;
-		sprite->gfx = (gfx &0x3ffff) + ((sys16_obj_bank[bank] << 17)/2);
+		sprite->gfx = ((gfx &0x3ffff) + (sys16_obj_bank[bank] << 17))/2;
 	}
 	return 0;
 }

--- a/src/vidhrdw/sys16spr.c
+++ b/src/vidhrdw/sys16spr.c
@@ -225,7 +225,7 @@ int sys16_sprite_quartet2( struct sys16_sprite_attributes *sprite, const UINT16 
 			//bottom++;
 			sprite->x = source[1] + sys16_sprxoffset;
 			if(sprite->x > 0x140) sprite->x-=0x200;
-			sprite->y = top - 1;
+			sprite->y = top + 1;
 			sprite->priority = spr_pri;
 			sprite->color = 1024/16 + pal;
 			sprite->screen_height = bottom-top;


### PR DESCRIPTION
Removing this fixes the missing sprites for bodyslam, haven't found any regressions for other games using this but there could be. Needs more testing.