### PR TITLE
Fix ikari ost

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Start
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Start
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -904,10 +904,10 @@ bool generate_ost_sound_ikari(int data)
 			break;
 
 		// Credit
-		case 0x90:
+		/*case 0x90:
 			ikari_glory = false;
 			ost_start_samples(2, 3, 1);
-			break;
+			break;*/
 
 		// Force landing
 		case 0xA5:
@@ -935,7 +935,7 @@ bool generate_ost_sound_ikari(int data)
 
 		// Game Over and Glory
 		case 0x60:
-			if(ikari_glory == false) {
+			if(/*ikari_glory == false*/1) {
 				ikari_glory = true;
 				ost_start_samples(12, 13, 1);
 			}

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -573,8 +573,6 @@ static void ost_start_samples(int sa_left, int sa_right, int sa_loop)
 {
   ost_stop_samples();
 
-  usrintf_showmessage("start samples %i - %i", sa_left, sa_right);
-
   sample_start(0, sa_left, sa_loop);
   sample_start(1, sa_right, sa_loop);
 }

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -578,6 +578,8 @@ static void ost_start_samples(int sa_left, int sa_right, int sa_loop)
 {
   ost_stop_samples();
 
+  usrintf_showmessage("start samples %i - %i", sa_left, sa_right);
+
   sample_start(0, sa_left, sa_loop);
   sample_start(1, sa_right, sa_loop);
 }

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -23,7 +23,6 @@ int      d_title_counter;
 bool     ff_alternate_song_1;
 bool     ff_alternate_song_2;
 
-bool     ikari_start;
 bool     ikari_glory;
 
 bool     moon_diddy;
@@ -519,7 +518,6 @@ void install_ost_support(struct InternalMachineDriver *machine, int ost)
 
     case OST_SUPPORT_IKARI:
       MDRV_SOUND_ADD_TAG("OST Samples", SAMPLES, ost_ikari)
-      ikari_start = true;
       ikari_glory = false;
       break;
 
@@ -897,12 +895,6 @@ bool generate_ost_sound_ikari(int data)
 	/* initialize game config */
 	schedule_default_sound = false;
 	sa_volume = 100;
-
-	if(ikari_start == true) {
-		ikari_start = false;
-		ikari_glory = false;
-		ost_start_samples(0, 1, 1);
-	}
 
 	switch (data) {
 		// Title Demo

--- a/src/ost_samples.c
+++ b/src/ost_samples.c
@@ -23,8 +23,6 @@ int      d_title_counter;
 bool     ff_alternate_song_1;
 bool     ff_alternate_song_2;
 
-bool     ikari_glory;
-
 bool     moon_diddy;
 int      mj_current_music;
 
@@ -518,7 +516,6 @@ void install_ost_support(struct InternalMachineDriver *machine, int ost)
 
     case OST_SUPPORT_IKARI:
       MDRV_SOUND_ADD_TAG("OST Samples", SAMPLES, ost_ikari)
-      ikari_glory = false;
       break;
 
     case OST_SUPPORT_MK:
@@ -899,48 +896,37 @@ bool generate_ost_sound_ikari(int data)
 	switch (data) {
 		// Title Demo
 		case 0x70:
-			ikari_glory = false;
 			ost_start_samples(0, 1, 1);
 			break;
 
 		// Credit
 		/*case 0x90:
-			ikari_glory = false;
 			ost_start_samples(2, 3, 1);
 			break;*/
 
 		// Force landing
 		case 0xA5:
-			ikari_glory = false;
 			ost_start_samples(4, 5, 1);
 			break;
 
 		// Theme of Ikari
 		case 0x41:
-			ikari_glory = false;
 			ost_start_samples(6, 7, 1);
 			break;
 
 		// Gate
 		case 0x48:
-			ikari_glory = false;
 			ost_start_samples(8, 9, 1);
 			break;
 
 		// Victory
 		case 0x68:
-			ikari_glory = false;
 			ost_start_samples(10, 11, 1);
 			break;
 
 		// Game Over and Glory
 		case 0x60:
-			if(/*ikari_glory == false*/1) {
-				ikari_glory = true;
-				ost_start_samples(12, 13, 1);
-			}
-			else
-				return 0; /* do nothing */
+			ost_start_samples(12, 13, 1);
 			break;
 
 		default:


### PR DESCRIPTION
- remove duplicate start, both trigger on top of each other.
- remove unneeded variables
- temporary removal of credit trigger samples (2/3). It's trigging on every large explosion making it restart constantly throughout the game play.