### PR TITLE
Blktiger

### DIFF
--- a/src/drivers/blktiger.c
+++ b/src/drivers/blktiger.c
@@ -272,7 +272,7 @@ static struct YM2203interface ym2203_interface =
 static MACHINE_DRIVER_START( blktiger )
 
 	/* basic machine hardware */
-	MDRV_CPU_ADD(Z80, 4000000)	/* 4 MHz (?) */
+	MDRV_CPU_ADD(Z80, 6000000)	/* 4 MHz (?) */
 	MDRV_CPU_MEMORY(readmem,writemem)
 	MDRV_CPU_PORTS(readport,writeport)
 	MDRV_CPU_VBLANK_INT(irq0_line_hold,1)

--- a/src/drivers/blktiger.c
+++ b/src/drivers/blktiger.c
@@ -277,7 +277,7 @@ static MACHINE_DRIVER_START( blktiger )
 	MDRV_CPU_PORTS(readport,writeport)
 	MDRV_CPU_VBLANK_INT(irq0_line_hold,1)
 
-	MDRV_CPU_ADD(Z80, 3000000)
+	MDRV_CPU_ADD(Z80, 3579545)
 	MDRV_CPU_FLAGS(CPU_AUDIO_CPU)	/* 3 MHz (?) */
 	MDRV_CPU_MEMORY(sound_readmem,sound_writemem)
 

--- a/src/vidhrdw/blktiger_vidhrdw.c
+++ b/src/vidhrdw/blktiger_vidhrdw.c
@@ -38,8 +38,8 @@ static void get_bg_tile_info(int tile_index)
 	   was not derived from a PROM so it could be wrong. */
 	static int split_table[16] =
 	{
-		3,0,2,2,	/* the fourth could be 1 instead of 2 */
-		0,1,0,0,
+		3,3,2,2,
+		1,1,0,0,
 		0,0,0,0,
 		0,0,0,0
 	};


### PR DESCRIPTION
last update went to mame0122 which fixed my immediate issue. Playing the game through again showed some issues on level 5. So i looked up the history now its updated to mame 0155. plyes through twice didnt notice any glitches was looking hard for them.

0.155: Black Tiger sprite priority fixes [Mamesick].
0.125u1: Corrado Tomaselli changed Black Tiger main Z80 clock to 6MHz and sound Z80 clock to 3.579545MHz as verified on PCB.
0.122u5: Roberto Zandona fixed tile priority table in Black Tiger.
0.122u4: Roberto Zandona fixed sprite priority issues (dragon in intro should appear behind mountains/statue).

