### PR TITLE
init fix

### DIFF
--- a/src/mame.c
+++ b/src/mame.c
@@ -447,7 +447,7 @@ static int run_machine(void)
 					}
 
 				ui_copyright_and_warnings();
-        pause_action = pause_action_start_emulator;
+				pause_action_start_emulator(); // this needs call before retrorun else serialization can fail on different sizes
 				return 0;
 			}
 


### PR DESCRIPTION
This fixes the init so i calls before retrorun this should have happened anyway probably an oversight.  

Rewind is disabled in this core anyway. Neogeo and rtypeleo work well. Work on drives and soundcores would need to be done to get it working. It too much work for me but might as well get it in a stated that someone can work on it if they choose too. 