### PR TITLE
update audio

### DIFF
--- a/src/mame.c
+++ b/src/mame.c
@@ -820,39 +820,8 @@ static void init_game_options(void)
   Machine->orientation    = ROT0;
   Machine->ui_orientation = options.ui_orientation;
 
-
-// set sample rate here as osd_start_audio_stream the logic must be the same in both some soundcores require setting here as well
-// ie ymf271 will segfault without this.
- if (options.machine_timing)
-  {
-    if ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) )
-      Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-
-    else Machine->sample_rate = options.samplerate;
-  }
-
-  else
-  {
-    if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
-    {
-      if ( Machine->drv->frames_per_second * 1000 > 44100)
-        Machine->sample_rate = 44100;
-      else if ( Machine->drv->frames_per_second * 1000 > 30000)
-        Machine->sample_rate = 30000;
-      else if ( Machine->drv->frames_per_second * 1000 > 22050)
-        Machine->sample_rate = 22050;
-      else if ( Machine->drv->frames_per_second * 1000 > 11025)
-        Machine->sample_rate = 11025;
-      else if ( Machine->drv->frames_per_second * 1000 > 8000)
-        Machine->sample_rate = 8000;
-      else
-        Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-    }
-
-    else
-      Machine->sample_rate = options.samplerate;
-  }
-
+  Machine->sample_rate = options.samplerate;
+ 
 }
 
 

--- a/src/mame.h
+++ b/src/mame.h
@@ -254,7 +254,6 @@ struct GameOptions
   int      debug_height;	       /* requested height of debugger bitmap */
   int      debug_depth;	         /* requested depth of debugger bitmap */
   bool     cheat_input_ports;     /*cheat input ports enable/disable */
-  bool     machine_timing;
   int      override_ad_stick;
   bool     digital_joy_centering; /* center digital joysticks enable/disable */
   double   cpu_clock_scale;

--- a/src/mame2003/core_options.c
+++ b/src/mame2003/core_options.c
@@ -732,21 +732,6 @@ static struct retro_core_option_v2_definition option_def_cheat_input_ports = {
    "disabled"
 };
 
-static struct retro_core_option_v2_definition option_def_machine_timing = {
-   APPNAME"_machine_timing",
-   "Bypass Audio Skew",
-   NULL,
-   "Restart core required.",
-   NULL,
-   "cat_key_audio",
-   {
-      { "disabled", NULL },
-      { "enabled",  NULL },
-      { NULL, NULL },
-   },
-   "disabled"
-};
-
 static struct retro_core_option_v2_definition option_def_digital_joy_centering = {
    APPNAME"_digital_joy_centering",
    "Center Joystick Axis for Digital Controls",
@@ -914,7 +899,6 @@ void init_core_options(void)
   default_options[OPT_CORE_SAVE_SUBFOLDER]       = option_def_core_save_subfolder;
   default_options[OPT_AUTOSAVE_HISCORE]          = option_def_autosave_hiscore;
   default_options[OPT_CHEAT_INPUT_PORTS]         = option_def_cheat_input_ports;
-  default_options[OPT_MACHINE_TIMING]            = option_def_machine_timing;
   default_options[OPT_DIGITAL_JOY_CENTERING]     = option_def_digital_joy_centering;
   default_options[OPT_CPU_CLOCK_SCALE]           = option_def_cpu_clock_scale;
   default_options[OPT_OVERRIDE_AD_STICK]         = option_def_override_ad_stick;
@@ -1285,13 +1269,6 @@ void update_variables(bool first_time)
             options.cheat_input_ports = true;
           else
             options.cheat_input_ports = false;
-          break;
-
-        case OPT_MACHINE_TIMING:
-          if(strcmp(var.value, "enabled") == 0)
-            options.machine_timing = true;
-          else
-            options.machine_timing = false;
           break;
 
         case OPT_OVERRIDE_AD_STICK:

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -228,50 +228,9 @@ void retro_set_environment(retro_environment_t cb)
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
   mame2003_video_get_geometry(&info->geometry);
-  if(options.machine_timing)
-  {
-    if (Machine->drv->frames_per_second < 60.0 )
-      info->timing.fps = 60.0;
-    else
-      info->timing.fps = Machine->drv->frames_per_second; /* qbert is 61 fps */
-
-    if ( (Machine->drv->frames_per_second * 1000 < options.samplerate) || ( Machine->drv->frames_per_second < 60) )
-    {
-      info->timing.sample_rate = Machine->drv->frames_per_second * 1000;
-      log_cb(RETRO_LOG_INFO, LOGPRE "Sample timing rate too high for framerate required dropping to %f\n",  Machine->drv->frames_per_second * 1000);
-    }
-
-    else
-    {
-      info->timing.sample_rate = options.samplerate;
-      log_cb(RETRO_LOG_INFO, LOGPRE "Sample rate set to %d\n",options.samplerate);
-    }
-  }
-
-  else
-  {
-    info->timing.fps = Machine->drv->frames_per_second;
-
-    if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
-    {
-      if ( Machine->drv->frames_per_second * 1000 > 44100)
-        info->timing.sample_rate = 44100;
-      else if ( Machine->drv->frames_per_second * 1000 > 30000)
-        info->timing.sample_rate = 30000;
-      else if ( Machine->drv->frames_per_second * 1000 > 22050)
-        info->timing.sample_rate = 22050;
-      else if ( Machine->drv->frames_per_second * 1000 > 11025)
-        info->timing.sample_rate = 11025;
-      else if ( Machine->drv->frames_per_second * 1000 > 8000)
-        info->timing.sample_rate = 8000;
-      else
-        info->timing.sample_rate = Machine->drv->frames_per_second * 1000;
-    }
-
-    else
-     info->timing.sample_rate = options.samplerate;
-  }
-
+  
+  info->timing.fps = Machine->drv->frames_per_second;
+  info->timing.sample_rate = options.samplerate ;
 }
 
 
@@ -557,35 +516,8 @@ bool retro_unserialize(const void * data, size_t size)
 
 int osd_start_audio_stream(int stereo)
 {
-  if (options.machine_timing)
-  {
-    if ( ( Machine->drv->frames_per_second * 1000 < options.samplerate) || (Machine->drv->frames_per_second < 60) )
-      Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-
-    else Machine->sample_rate = options.samplerate;
-  }
-
-  else
-  {
-    if ( Machine->drv->frames_per_second * 1000 < options.samplerate)
-    {
-      if ( Machine->drv->frames_per_second * 1000 > 44100)
-        Machine->sample_rate = 44100;
-      else if ( Machine->drv->frames_per_second * 1000 > 30000)
-        Machine->sample_rate = 30000;
-      else if ( Machine->drv->frames_per_second * 1000 > 22050)
-        Machine->sample_rate = 22050;
-      else if ( Machine->drv->frames_per_second * 1000 > 11025)
-        Machine->sample_rate = 11025;
-      else if ( Machine->drv->frames_per_second * 1000 > 8000)
-        Machine->sample_rate = 8000;
-      else
-        Machine->sample_rate = Machine->drv->frames_per_second * 1000;
-    }
-
-    else
-      Machine->sample_rate = options.samplerate;
-  }
+ 
+  Machine->sample_rate = options.samplerate;
 
   delta_samples = 0.0f;
   usestereo = stereo ? 1 : 0;

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -210,7 +210,6 @@ enum CORE_OPTIONS  /* controls the order in which core options appear. common, i
   OPT_USE_SAMPLES,
   OPT_USE_ALT_SOUND,
   OPT_SAMPLE_RATE,
-  OPT_MACHINE_TIMING,
   OPT_BRIGHTNESS,
   OPT_GAMMA,
   OPT_TATE_MODE,


### PR DESCRIPTION
Retroarch does not pull up the fps rate like it used too when the audio rate is higher than the fps.  The checks are un-needed now. Removed machine timing even though it serves it purpose, since its disabled by default users can just fix there audio skew manually as it purpose of the games playing the right speed for users transparently isint achieved by being disabled.

relevant ra fixes

https://github.com/libretro/RetroArch/pull/12987
https://github.com/libretro/RetroArch/pull/13300
