### PR TITLE
decouple fast dma from dcs speed hack since we cant toggle options an…

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -595,6 +595,4 @@ extern const struct GameDriver *test_drivers[];
 
 extern const int total_drivers;
 
-extern unsigned activate_dcs_speedhack;
-
 #endif

--- a/src/mame.h
+++ b/src/mame.h
@@ -212,8 +212,7 @@ struct GameOptions
 
   int      crosshair_enable;
   int      crosshair_appearance;
-  bool     activate_dcs_speedhack;
-
+  
   bool     mame_remapping;       /* display MAME input remapping menu */
 
   int      samplerate;		       /* sound sample playback rate, in KHz */

--- a/src/mame2003/core_options.c
+++ b/src/mame2003/core_options.c
@@ -1300,8 +1300,6 @@ void update_variables(bool first_time)
     }
   }
 
-  options.activate_dcs_speedhack = true; /* formerly a core option, now always on. */
-
   ledintf.set_led_state = NULL;
   environ_cb(RETRO_ENVIRONMENT_GET_LED_INTERFACE, &ledintf);
   led_state_cb = ledintf.set_led_state;

--- a/src/sndhrdw/dcs.c
+++ b/src/sndhrdw/dcs.c
@@ -15,6 +15,8 @@
 #define LOG_BUFFER_FILLING			(0)
 
 
+bool activate_dcs_speedhack = 1; // this is core maintaniers choice to always be active dont change
+
 /***************************************************************************
 	CONSTANTS
 ****************************************************************************/
@@ -413,7 +415,7 @@ void dcs_init(void)
 
 
 	/* install the speedup handler */
-   if (options.activate_dcs_speedhack)
+   if (activate_dcs_speedhack)
    {
       dcs_speedup1 = install_mem_write16_handler(dcs_cpunum, ADSP_DATA_ADDR_RANGE(0x04f8, 0x04f8), dcs_speedup1_w);
       dcs_speedup2 = install_mem_write16_handler(dcs_cpunum, ADSP_DATA_ADDR_RANGE(0x063d, 0x063d), dcs_speedup2_w);
@@ -456,7 +458,7 @@ void dcs2_init(offs_t polling_offset)
 			dcs_expanded_rom[0x400 * page + i] = romsrc[BYTE_XOR_LE(0x1000 * page + i)];
 	
     /* install the speedup handler */
-    if (options.activate_dcs_speedhack)
+    if (activate_dcs_speedhack)
     {
       dcs_speedup1 = install_mem_write16_handler(dcs_cpunum, ADSP_DATA_ADDR_RANGE(0x04f8, 0x04f8), dcs_speedup1_w);
       dcs_speedup2 = install_mem_write16_handler(dcs_cpunum, ADSP_DATA_ADDR_RANGE(0x063d, 0x063d), dcs_speedup2_w);
@@ -553,7 +555,7 @@ static WRITE16_HANDLER( dcs_rombank_select_w )
 	set_led_status(2, data & 0x800);
 #endif
 
-   if (options.activate_dcs_speedhack)
+   if (activate_dcs_speedhack)
    {
       /* they write 0x800 here just before entering the stall loop */
       if (data == 0x800)
@@ -1081,7 +1083,7 @@ static void dcs_irq(int state)
 	/* store it */
 	cpunum_set_reg(dcs_cpunum, ADSP2100_I0 + dcs.ireg, reg);
    
-   if (options.activate_dcs_speedhack)
+   if (activate_dcs_speedhack)
 	/* this is the same trigger as an interrupt */
       cpu_triggerint(dcs_cpunum);
 }

--- a/src/vidhrdw/midtunit_vidhrdw.c
+++ b/src/vidhrdw/midtunit_vidhrdw.c
@@ -826,21 +826,21 @@ skipdma:
 	/* used to initiate the DMA. What they do is start the DMA, *then* set */
 	/* up the memory for it, which means that there must be some non-zero  */
 	/* delay that gives them enough time to build up the DMA command list  */
-   if (options.activate_dcs_speedhack)
-   {
-      if (command != 0x8000)
-         dma_callback(1);
-      else
-      {
-        TMS_SET_IRQ_LINE(CLEAR_LINE);
-        timer_set(TIME_IN_NSEC(41 * pixels), 0, dma_callback);
-      }
-   }
-   else
-   {
-      TMS_SET_IRQ_LINE(CLEAR_LINE);
-      timer_set(TIME_IN_NSEC(41 * pixels), 0, dma_callback);
-   }
+	if (FAST_DMA)
+	{
+		if (command != 0x8000)
+			dma_callback(1);
+		else
+		{
+			TMS_SET_IRQ_LINE(CLEAR_LINE);
+			timer_set(TIME_IN_NSEC(41 * pixels), 0, dma_callback);
+		}
+	}
+	else
+	{
+		TMS_SET_IRQ_LINE(CLEAR_LINE);
+		timer_set(TIME_IN_NSEC(41 * pixels), 0, dma_callback);
+	}
 
 	profiler_mark(PROFILER_END);
 }

--- a/src/vidhrdw/midyunit_vidhrdw.c
+++ b/src/vidhrdw/midyunit_vidhrdw.c
@@ -484,12 +484,11 @@ READ16_HANDLER( midyunit_dma_r )
 {
 	int result = dma_register[offset];
 
-    if(!options.activate_dcs_speedhack)
-	{
-	   /* see if we're done */
-	   if (offset == DMA_COMMAND && (result & 0x8000))
-         switch (activecpu_get_pc())
-		 {
+#if !FAST_DMA
+	/* see if we're done */
+	if (offset == DMA_COMMAND && (result & 0x8000))
+		switch (activecpu_get_pc())
+		{
 			case 0xfff7aa20: /* narc */
 			case 0xffe1c970: /* trog */
 			case 0xffe1c9a0: /* trog3 */
@@ -508,8 +507,8 @@ READ16_HANDLER( midyunit_dma_r )
 			case 0xff82e200: /* nbajam */
 				cpu_spinuntil_int();
 				break;
-		 }
-   }
+		}
+#endif
 
 	return result;
 }
@@ -653,11 +652,10 @@ WRITE16_HANDLER( midyunit_dma_w )
 	}
 
 	/* signal we're done */
-    if(options.activate_dcs_speedhack)
-	   dma_callback(1);
+	if (FAST_DMA)
+		dma_callback(1);
 	else
-	   timer_set(TIME_IN_NSEC(41 * dma_state.width * dma_state.height), 0, dma_callback);
-
+		timer_set(TIME_IN_NSEC(41 * dma_state.width * dma_state.height), 0, dma_callback);
 
 	profiler_mark(PROFILER_END);
 }


### PR DESCRIPTION
fast dma was included in the dcs hack when the option was able to be toggled that made sense in the optional hack context. We need to put it back to its original define state and decouple it from the dcs sound hack now so we don't get gfx glitches when using the sound hack. 