### PR TITLE
Fix video bugs in mk

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/vidhrdw/midtunit_vidhrdw.c
+++ b/src/vidhrdw/midtunit_vidhrdw.c
@@ -739,8 +739,16 @@ WRITE16_HANDLER( midtunit_dma_w )
 	/* clip the clippers */
 	dma_state.topclip = dma_register[DMA_TOPCLIP] & 0x1ff;
 	dma_state.botclip = dma_register[DMA_BOTCLIP] & 0x1ff;
-	dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x1ff;
-	dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x1ff;
+	if(!strcmp(Machine->gamedrv->name, "revx"))
+	{
+		dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x3ff;
+		dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x3ff;
+	}
+	else
+	{
+		dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x1ff;
+		dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x1ff;
+	}
 
 	/* determine the offset */
 	gfxoffset = dma_register[DMA_OFFSETLO] | (dma_register[DMA_OFFSETHI] << 16);

--- a/src/vidhrdw/midtunit_vidhrdw.c
+++ b/src/vidhrdw/midtunit_vidhrdw.c
@@ -739,8 +739,8 @@ WRITE16_HANDLER( midtunit_dma_w )
 	/* clip the clippers */
 	dma_state.topclip = dma_register[DMA_TOPCLIP] & 0x1ff;
 	dma_state.botclip = dma_register[DMA_BOTCLIP] & 0x1ff;
-	dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x3ff;
-	dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x3ff;
+	dma_state.leftclip = dma_register[DMA_LEFTCLIP] & 0x1ff;
+	dma_state.rightclip = dma_register[DMA_RIGHTCLIP] & 0x1ff;
 
 	/* determine the offset */
 	gfxoffset = dma_register[DMA_OFFSETLO] | (dma_register[DMA_OFFSETHI] << 16);


### PR DESCRIPTION
Update seems to have caused issues for mortal Kombat tunit version. Glitching the comic book offer and blitter. This issue #326 offered a fair solution to support the fix for revx without disturbing the other games.