### PR TITLE
Fix toutrun course map alignment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Try
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Try
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/drivers/outrun.c
+++ b/src/drivers/outrun.c
@@ -835,7 +835,7 @@ static MACHINE_INIT( outrun ){
 	sys16_textlayer_lo_max=0;
 	sys16_textlayer_hi_min=0;
 	sys16_textlayer_hi_max=0xff;
-	sys16_sprxoffset = -0xc0;
+	sys16_sprxoffset = -0xbd;
 	ctrl1 = 0x20;
 
 // *forced sound cmd (eww)


### PR DESCRIPTION
0.148: Shift Turbo Out Run sprites by 1 pixel in the x direction, reference point turbo outrun course map, real hardware isn't glitched like MAME was (video\sega16sp.c) [David Haywood].