### PR TITLE
Bios fallback support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios %i\n", romp); romp=0; system_bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios %i\n", romp_name); romp_name="default"; system_bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(&romdata, romp--); continue;}
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; return process_rom_entries(&romdata, romp--);}
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1736,7 +1736,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
 						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						if (!open_rom_file(fallback_romdata, &fallback_romp[3])) { romp++; continue; }
+						if (!open_rom_file(romdata, &romp[0])) { romp++; continue; }
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1736,8 +1736,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
 						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						system_bios=1;
-						if (!open_rom_file(fallback_romdata, fallback_romp)) continue;
+						if (!open_rom_file(fallback_romdata, fallback_romp++)) continue;
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1736,7 +1736,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
 						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						if (!open_rom_file(fallback_romdata, fallback_romp++)) continue;
+						if (!open_rom_file(fallback_romdata, fallback_romp[3])) { romp++; continue; }
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1733,7 +1733,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
-						handle_missing_file(romdata, romp);//log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
+						log_cb(RETRO_LOG_WARN, LOGPRE "%s NOT FOUND! fallback to default bios.\n", ROM_GETNAME(romp));
 						if (!open_rom_file(romdata, &fallback_romp[0])) /* try default bios instead */
 							handle_missing_file(romdata, romp);
 					}

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(romdata, romp); continue;}
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(&romdata, romp--); continue;}
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios fallback.\n"); romp=NULL; system_bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; romp--; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; romp-=2; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1686,8 +1686,9 @@ static int copy_rom_data(struct rom_load_data *romdata, const struct RomModule *
 static int process_rom_entries(struct rom_load_data *romdata, const struct RomModule *romp)
 {
 	UINT32 lastflags = 0;
-struct rom_load_data *romdata2 = romdata;
-const struct RomModule *romp2 = romp;
+
+	struct rom_load_data *fallback_romdata = romdata;
+	const struct RomModule *fallback_romp = romp;
 
 	/* loop until we hit the end of this region */
 	while (!ROMENTRY_ISREGIONEND(romp))
@@ -1733,8 +1734,11 @@ const struct RomModule *romp2 = romp;
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; open_rom_file(romdata2, romp2);}
-			
+					{
+						log_cb(RETRO_LOG_ERROR, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
+						system_bios=0;
+						open_rom_file(fallback_romdata, fallback_romp);
+					}
 					else
 						handle_missing_file(romdata, romp);
 				}

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; romp--; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1730,8 +1730,8 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				log_cb(RETRO_LOG_INFO, LOGPRE "Opening ROM file: %s\n", ROM_GETNAME(romp));
 				if (!open_rom_file(romdata, romp))
 				{
-					if ((ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						open_rom_file(romdata, 1); /*fallback to default bios*/
+					if (ROM_GETBIOSFLAGS(romp) == system_bios+1)
+						open_rom_file(romdata, 1); /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1736,7 +1736,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
 						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						if (!open_rom_file(romdata, &romp[0])) { romp++; continue; }
+						if (!open_rom_file(romdata, &fallback_romp[0])) { romp++; continue; }
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1733,7 +1733,7 @@ const struct RomModule *romp2 = romp;
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(&romdata2, romp2); romp++; continue;}
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; open_rom_file(romdata2, romp2);}
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"skippy\n"); romp++; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios\n"); romp--; Machine->gamedrv->bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios fallback.\n"); system_bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios fallback.\n"); system_bios=0; break;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1686,8 +1686,6 @@ static int copy_rom_data(struct rom_load_data *romdata, const struct RomModule *
 static int process_rom_entries(struct rom_load_data *romdata, const struct RomModule *romp)
 {
 	UINT32 lastflags = 0;
-
-	struct rom_load_data *fallback_romdata = romdata;
 	const struct RomModule *fallback_romp = romp;
 
 	/* loop until we hit the end of this region */
@@ -1736,7 +1734,8 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
 						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						if (!open_rom_file(romdata, &fallback_romp[0])) { romp++; continue; }
+						if (!open_rom_file(romdata, &fallback_romp[0])) /* try default bios instead */
+							handle_missing_file(romdata, romp);
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1733,7 +1733,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
-						log_cb(RETRO_LOG_WARN, LOGPRE "%s NOT FOUND! fallback to default bios.\n", ROM_GETNAME(romp));
+						log_cb(RETRO_LOG_WARN, LOGPRE "%s NOT FOUND! Attempt fallback to default bios.\n", ROM_GETNAME(romp));
 						if (!open_rom_file(romdata, &fallback_romp[0])) /* try default bios instead */
 							handle_missing_file(romdata, romp);
 					}

--- a/src/common.c
+++ b/src/common.c
@@ -1730,8 +1730,8 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				log_cb(RETRO_LOG_INFO, LOGPRE "Opening ROM file: %s\n", ROM_GETNAME(romp));
 				if (!open_rom_file(romdata, romp))
 				{
-					if (ROM_GETBIOSFLAGS(romp) == system_bios+1)
-						open_rom_file(romdata, 1); /*fallback to default bios.*/
+					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
+						{ log_cb(RETRO_LOG_INFO,"skippy\n"); romp++; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1729,7 +1729,13 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				/* open the file */
 				log_cb(RETRO_LOG_INFO, LOGPRE "Opening ROM file: %s\n", ROM_GETNAME(romp));
 				if (!open_rom_file(romdata, romp))
-					handle_missing_file(romdata, romp);
+				{
+					if ((ROM_GETBIOSFLAGS(romp) == (system_bios+1))
+						open_rom_file(romdata, 1); /*fallback to default bios*/
+			
+					else
+						handle_missing_file(romdata, romp);
+				}
 
 				/* loop until we run out of reloads */
 				do

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios %i\n", romp_name); romp_name="default"; system_bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios %s\n", romp); romp="default"; system_bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1686,8 +1686,8 @@ static int copy_rom_data(struct rom_load_data *romdata, const struct RomModule *
 static int process_rom_entries(struct rom_load_data *romdata, const struct RomModule *romp)
 {
 	UINT32 lastflags = 0;
-struct rom_load_data *romdata2 = *romdata;
-const struct RomModule *romp2 = *romp;
+struct rom_load_data *romdata2 = romdata;
+const struct RomModule *romp2 = romp;
 
 	/* loop until we hit the end of this region */
 	while (!ROMENTRY_ISREGIONEND(romp))

--- a/src/common.c
+++ b/src/common.c
@@ -1736,7 +1736,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
 						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						if (!open_rom_file(fallback_romdata, fallback_romp[3])) { romp++; continue; }
+						if (!open_rom_file(fallback_romdata, &fallback_romp[3])) { romp++; continue; }
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; romp-=2; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; romp-=4; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios fallback.\n"); system_bios=0; break;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios fallback.\n"); romp=NULL; system_bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1733,7 +1733,7 @@ const struct RomModule *romp2 = romp;
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; return process_rom_entries(&romdata2, romp2);}
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(&romdata2, romp2); continue;}
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios\n"); romp--; Machine->gamedrv->bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios %i\n", romp); romp=0; system_bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1735,9 +1735,9 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
-						log_cb(RETRO_LOG_ERROR, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
-						system_bios=0;
-						open_rom_file(fallback_romdata, fallback_romp);
+						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
+						system_bios=1;
+						if (!open_rom_file(fallback_romdata, fallback_romp)) continue;
 					}
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1733,7 +1733,7 @@ const struct RomModule *romp2 = romp;
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(&romdata2, romp2); continue;}
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(&romdata2, romp2); romp++; continue;}
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1733,7 +1733,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
 					{
-						log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
+						handle_missing_file(romdata, romp);//log_cb(RETRO_LOG_WARN, LOGPRE "%s not found! fallback to default bios.\n", ROM_GETNAME(romp));
 						if (!open_rom_file(romdata, &fallback_romp[0])) /* try default bios instead */
 							handle_missing_file(romdata, romp);
 					}

--- a/src/common.c
+++ b/src/common.c
@@ -1686,6 +1686,8 @@ static int copy_rom_data(struct rom_load_data *romdata, const struct RomModule *
 static int process_rom_entries(struct rom_load_data *romdata, const struct RomModule *romp)
 {
 	UINT32 lastflags = 0;
+struct rom_load_data *romdata2 = *romdata;
+const struct RomModule *romp2 = *romp;
 
 	/* loop until we hit the end of this region */
 	while (!ROMENTRY_ISREGIONEND(romp))
@@ -1731,7 +1733,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; return process_rom_entries(&romdata, romp--);}
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; return process_rom_entries(&romdata2, romp2);}
 			
 					else
 						handle_missing_file(romdata, romp);

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_INFO,"default bios %s\n", romp); romp="default"; system_bios=0; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_INFO,"default bios fallback.\n"); system_bios=0; continue;} /*fallback to default bios.*/
 			
 					else
 						handle_missing_file(romdata, romp);
@@ -1765,7 +1765,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 					if (baserom)
 					{
 						log_cb(RETRO_LOG_DEBUG, LOGPRE "Verifying length (%X) and checksums\n", explength);
-            verify_length_and_hash(romdata, ROM_GETNAME(baserom), explength, ROM_GETHASHDATA(baserom));
+						verify_length_and_hash(romdata, ROM_GETNAME(baserom), explength, ROM_GETHASHDATA(baserom));
 						log_cb(RETRO_LOG_DEBUG, LOGPRE "Length and checksum verify finished\n");
 					}
 

--- a/src/common.c
+++ b/src/common.c
@@ -1731,7 +1731,7 @@ static int process_rom_entries(struct rom_load_data *romdata, const struct RomMo
 				if (!open_rom_file(romdata, romp))
 				{
 					if (ROM_GETBIOSFLAGS(romp) == (system_bios+1))
-						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; romp-=4; continue;} /*fallback to default bios.*/
+						{ log_cb(RETRO_LOG_WARN, LOGPRE "default bios fallback.\n"); system_bios=0; process_rom_entries(romdata, romp); continue;}
 			
 					else
 						handle_missing_file(romdata, romp);


### PR DESCRIPTION
If the user selected bios cannot be loaded, try to load the default bios before failing.