### PR TITLE
dkong3 propper corret resnet colors

### DIFF
--- a/src/drivers/dkong.c
+++ b/src/drivers/dkong.c
@@ -1969,8 +1969,8 @@ static MACHINE_DRIVER_START( dkong3 )
 	MDRV_SCREEN_SIZE(32*8, 32*8)
 	MDRV_VISIBLE_AREA(0*8, 32*8-1, 2*8, 30*8-1)
 	MDRV_GFXDECODE(gfxdecodeinfo)
-	MDRV_PALETTE_LENGTH(256)
-	MDRV_COLORTABLE_LENGTH(64*4)
+	MDRV_PALETTE_LENGTH(512)
+	MDRV_COLORTABLE_LENGTH(512)
 
 	MDRV_PALETTE_INIT(dkong3)
 	MDRV_VIDEO_START(dkong)
@@ -2505,10 +2505,10 @@ ROM_START( dkong3 )
 	ROM_LOAD( "dk3v.7e",      0x2000, 0x1000, CRC(0c0af3fb) SHA1(03e0c3f51bc3c20f95cb02f76f2d80188d5dbe36) )
 	ROM_LOAD( "dk3v.7f",      0x3000, 0x1000, CRC(55c58662) SHA1(7f3d5a1b386cc37d466e42392ffefc928666a8dc) )
 
-	ROM_REGION( 0x0300, REGION_PROMS, 0 )
+	ROM_REGION( 0x0500, REGION_PROMS, 0 )
 	ROM_LOAD( "dkc1-c.1d",    0x0000, 0x0200, CRC(df54befc) SHA1(7912dbf0a0c8ef68f4ae0f95e55ab164da80e4a1) ) /* palette red & green component */
-	ROM_LOAD( "dkc1-c.1c",    0x0100, 0x0200, CRC(66a77f40) SHA1(c408d65990f0edd78c4590c447426f383fcd2d88) ) /* palette blue component */
-	ROM_LOAD( "dkc1-v.2n",    0x0200, 0x0100, CRC(50e33434) SHA1(b63da9bed9dc4c7da78e4c26d4ba14b65f2b7e72) )	/* character color codes on a per-column basis */
+	ROM_LOAD( "dkc1-c.1c",    0x0200, 0x0200, CRC(66a77f40) SHA1(c408d65990f0edd78c4590c447426f383fcd2d88) ) /* palette blue component */
+	ROM_LOAD( "dkc1-v.2n",    0x0400, 0x0100, CRC(50e33434) SHA1(b63da9bed9dc4c7da78e4c26d4ba14b65f2b7e72) )	/* character color codes on a per-column basis */
 ROM_END
 
 ROM_START( dkong3j )

--- a/src/vidhrdw/dkong_vidhrdw.c
+++ b/src/vidhrdw/dkong_vidhrdw.c
@@ -84,6 +84,27 @@ static const res_net_info dkong_net_bck_info =
 	}
 };
 
+static const res_net_decode_info dkong3_decode_info =
+{
+	1,		/*  one prom needed to contruct color */
+	0,		/*  start at 0 */
+	255,	/*  end at 255 */
+	/*   R,   G,   B */
+	{   0,   0, 512 },		/*  offsets */
+	{   4,   0,   0 },		/*  shifts */
+	{0x0F,0x0F,0x0F }		    /*  masks */
+};
+
+static const res_net_info dkong3_net_info =
+{
+	RES_NET_VCC_5V | RES_NET_VBIAS_5V | RES_NET_VIN_MB7052 |  RES_NET_MONITOR_SANYO_EZV20,
+	{
+		{ RES_NET_AMP_DARLINGTON, 470,      0, 4, { 2200, 1000, 470, 220 } },
+		{ RES_NET_AMP_DARLINGTON, 470,      0, 4, { 2200, 1000, 470, 220 } },
+		{ RES_NET_AMP_DARLINGTON, 470,      0, 4, { 2200, 1000, 470, 220 } }
+	}
+};
+
 PALETTE_INIT( dkong)
 {
 
@@ -178,40 +199,14 @@ PALETTE_INIT( dkong_old )
 ***************************************************************************/
 PALETTE_INIT( dkong3 )
 {
-	int i;
-	#define TOTAL_COLORS(gfxn) (Machine->gfx[gfxn]->total_colors * Machine->gfx[gfxn]->color_granularity)
-	#define COLOR(gfxn,offs) (colortable[Machine->drv->gfxdecodeinfo[gfxn].color_codes_start + offs])
+	rgb_t	*rgb;
 
+	rgb = compute_res_net_all(color_prom, &dkong3_decode_info, &dkong3_net_info);
+	res_palette_set_colors(0, rgb, 256);
+	palette_normalize_range(0, 255, 0, 255);
+	free(rgb);
 
-	for (i = 0;i < 256;i++)
-	{
-		int bit0,bit1,bit2,bit3,r,g,b;
-
-
-		/* red component */
-		bit0 = (color_prom[0] >> 4) & 0x01;
-		bit1 = (color_prom[0] >> 5) & 0x01;
-		bit2 = (color_prom[0] >> 6) & 0x01;
-		bit3 = (color_prom[0] >> 7) & 0x01;
-		r = 255 - (0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3);
-		/* green component */
-		bit0 = (color_prom[0] >> 0) & 0x01;
-		bit1 = (color_prom[0] >> 1) & 0x01;
-		bit2 = (color_prom[0] >> 2) & 0x01;
-		bit3 = (color_prom[0] >> 3) & 0x01;
-		g = 255 - (0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3);
-		/* blue component */
-		bit0 = (color_prom[256] >> 0) & 0x01;
-		bit1 = (color_prom[256] >> 1) & 0x01;
-		bit2 = (color_prom[256] >> 2) & 0x01;
-		bit3 = (color_prom[256] >> 3) & 0x01;
-		b = 255 - (0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3);
-
-		palette_set_color(i,r,g,b);
-		color_prom++;
-	}
-
-	color_prom += 256;
+	color_prom += 1024;
 	/* color_prom now points to the beginning of the character color codes */
 	color_codes = color_prom;	/* we'll need it later */
 }


### PR DESCRIPTION
fbneo still doesnt use the resnet for this one maybe someone should let the "correct and propper" guy to mark its as such :). If you want the old red in dkong set the gamma correction to 0.5 no need for any core options.