### PR TITLE
Fixes

### DIFF
--- a/src/drivers/tecmosys.c
+++ b/src/drivers/tecmosys.c
@@ -571,23 +571,25 @@ static WRITE16_HANDLER( unk880000_w )
 
 static READ16_HANDLER( unk880000_r )
 {
-	/* see note above, this seems to have something to do with our missing scroll values.. */
-	UINT16 ret = tecmosys_880000regs[offset];
+	tecmosys_880000regs[offset];
 
 	logerror( "unk880000_r( %06x ) @ %06x = %04x\n", (offset * 2 ) +0x880000, activecpu_get_pc(), tecmosys_880000regs[offset] );
+
 
 	/* this code allows scroll regs to be updated, but tkdensho at least resets perodically */
 
 	switch( offset )
 	{
 		case 0:
-			tecmosys_880000regs[offset] = 0;
-			return ret;
+			tecmosys_880000regs[offset];
+			
+            if ( cpu_getscanline() >= 240) return tecmosys_880000regs[offset] == 0;
 
 		default:
 			return 0;
 	}
 }
+
 
 
 static READ16_HANDLER( eeprom_r )
@@ -1138,6 +1140,56 @@ ROM_START( deroon )
 	ROM_LOAD( "t501.uad1", 0x080000, 0x080000, CRC(2fbcfe27) SHA1(f25c830322423f0959a36955edb563a6150f2142) )
 ROM_END
 
+/*
+About the Deroon DeroDero listed below:
+ This set contains less Japanese text and English translations for some game aspects such as game menus.
+ Coining up displays "TECMO STACKERS" but this set doesn't seem to include a "How to Play" demo like the parent set
+ PCB contained genuine Tecmo development labels, it's unknown which specific region this set was intended for.
+ Still missing the full English version titled Temco Stackers if it exists.
+*/
+
+ROM_START( deroon2 )
+	ROM_REGION( 0x100000, REGION_CPU1, 0 ) /* Main Program */
+	ROM_LOAD16_BYTE( "stk_t01.upau1", 0x00000, 0x80000, CRC(90c794df) SHA1(b6edd62bedf609551f4e1c19ada20bd1373deca2) )
+	ROM_LOAD16_BYTE( "stk_t02.upal1", 0x00001, 0x80000, CRC(cca9f87c) SHA1(0637b0b979f4c6c6b16cf2a21dd193b7d7ec311f) )
+
+	ROM_REGION( 0x048000, REGION_CPU2, 0 ) /* Sound Porgram */
+	ROM_LOAD( "t003.uz1", 0x000000, 0x008000, CRC(8bdfafa0) SHA1(c0cf3eb7a65d967958fe2aace171859b0faf7753) )
+	ROM_CONTINUE(         0x010000, 0x038000 ) /* banked part */
+
+	ROM_REGION( 0x2200, REGION_CPU3, 0 ) /* MCU is a 68HC11A8 with 8k ROM, 512 bytes EEPROM */
+	ROM_LOAD( "deroon_68hc11a8.rom",    0x0000, 0x2000, NO_DUMP )
+	ROM_LOAD( "deroon_68hc11a8.eeprom", 0x2000, 0x0200, NO_DUMP )
+
+	ROM_REGION( 0x2000000, REGION_GFX1, ROMREGION_ERASE00 ) /* Sprites (non-tile based) */
+	/* all these roms need verifying, they could be half size */
+
+	ROM_LOAD16_BYTE( "t101.uah1", 0x0000000, 0x200000, CRC(74baf845) SHA1(935d2954ba227a894542be492654a2750198e1bc) )
+	ROM_LOAD16_BYTE( "t102.ual1", 0x0000001, 0x200000, CRC(1a02c4a3) SHA1(5155eeaef009fc9a9f258e3e54ca2a7f78242df5) )
+	/*                            0x8000000, 0x400000 - no rom loaded here, these gfx are 4bpp */
+	ROM_LOAD16_BYTE( "t103.ubl1", 0x0800001, 0x400000, CRC(84e7da88) SHA1(b5c3234f33bb945cc9762b91db087153a0589cfb) )
+	/*                            0x1000000, 0x400000 - no rom loaded here, these gfx are 4bpp */
+	ROM_LOAD16_BYTE( "t104.ucl1", 0x1000001, 0x200000, CRC(66eb611a) SHA1(64435d35677fea3c06fdb03c670f3f63ee481c02) )
+
+	ROM_REGION( 0x100000, REGION_GFX2, ROMREGION_DISPOSE ) /* 8x8 4bpp tiles */
+	ROM_LOAD( "t301.ubd1", 0x000000, 0x100000, CRC(8b026177) SHA1(3887856bdaec4d9d3669fe3bc958ef186fbe9adb) )
+
+	ROM_REGION( 0x100000, REGION_GFX3, ROMREGION_ERASE00) /* 16x16 4bpp tiles */
+	/* not used? */
+
+	ROM_REGION( 0x100000, REGION_GFX4, ROMREGION_ERASE00 ) /* 16x16 4bpp tiles */
+	ROM_LOAD( "t201.ubb1", 0x000000, 0x100000, CRC(d5a087ac) SHA1(5098160ce7719d93e3edae05f6edd317d4c61f0d) )
+
+	ROM_REGION( 0x100000, REGION_GFX5, ROMREGION_ERASE00 ) /* 16x16 4bpp tiles */
+	ROM_LOAD( "t202.ubc1", 0x000000, 0x100000, CRC(f051dae1) SHA1(f5677c07fe644b3838657370f0309fb09244c619) )
+
+	ROM_REGION( 0x200000, REGION_SOUND1, 0 ) /* YMZ280B Samples */
+	ROM_LOAD( "t401.uya1", 0x000000, 0x200000, CRC(92111992) SHA1(ae27e11ae76dec0b9892ad32e1a8bf6ab11f2e6c) )
+
+	ROM_REGION( 0x100000, REGION_SOUND2, 0 ) /* M6295 Samples */
+	ROM_LOAD( "t501.uad1", 0x080000, 0x080000, CRC(2fbcfe27) SHA1(f25c830322423f0959a36955edb563a6150f2142) )
+ROM_END
+
 ROM_START( tkdensho )
 	ROM_REGION( 0x600000, REGION_CPU1, 0 )
 	ROM_LOAD16_BYTE( "aeprge-2.pal", 0x00000, 0x80000, CRC(25e453d6) SHA1(9c84e2af42eff5cc9b14c1759d5bab42fa7bb663) )
@@ -1226,6 +1278,10 @@ ROM_START( tkdensha )
 	ROM_LOAD( "ae500w07.ad1", 0x080000, 0x080000, CRC(3734f92c) SHA1(048555b5aa89eaf983305c439ba08d32b4a1bb80) )
 ROM_END
 
+static void reset_callback(int param)
+{
+	cpu_set_reset_line(0, PULSE_LINE);
+}
 
 static MACHINE_INIT( deroon )
 {
@@ -1261,21 +1317,25 @@ static DRIVER_INIT( deroon )
 {
 	tecmosys_decramble();
 	device_data = &deroon_data;
+	timer_set(TIME_IN_SEC(2),0,reset_callback);
 }
 
 static DRIVER_INIT( tkdensho )
 {
 	tecmosys_decramble();
 	device_data = &tkdensho_data;
+	timer_set(TIME_IN_SEC(2),0,reset_callback);
 }
 
 static DRIVER_INIT( tkdensha )
 {
 	tecmosys_decramble();
 	device_data = &tkdensha_data;
+	timer_set(TIME_IN_SEC(2),0,reset_callback);
 }
 
 GAME( 1995, deroon,      0,        deroon, deroon, deroon,     ROT0, "Tecmo", "Deroon DeroDero" )
+GAME( 1995, deroon2,     deroon,   deroon, deroon, deroon,     ROT0, "Tecmo", "Deroon DeroDero / Tecmo Stackers" )
 GAME( 1996, tkdensho,    0,        deroon, deroon, tkdensho,   ROT0, "Tecmo", "Touki Denshou -Angel Eyes- (VER. 960614)" )
 GAME( 1996, tkdensha,    tkdensho, deroon, deroon, tkdensha,   ROT0, "Tecmo", "Touki Denshou -Angel Eyes- (VER. 960427)" )
 


### PR DESCRIPTION
Deroon DeroDero now boots
Touki Denshou -Angel Eyes crash problems seem to be fixed Added an English set for Deroon DeroDero

Still to do add back in the gfx improvements for Deroon DeroDero

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
