### PR TITLE
Update XML schema for driver status

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -870,7 +870,7 @@ void print_mame_xml()
 		"\t\t\t\t<!ATTLIST dipvalue name CDATA #REQUIRED>\n"
 		"\t\t\t\t<!ATTLIST dipvalue default (yes|no) \"no\">\n"
 		"\t\t<!ELEMENT driver EMPTY>\n"
-		"\t\t\t<!ATTLIST driver status (good|preliminary|test) #REQUIRED>\n"
+		"\t\t\t<!ATTLIST driver status (good|preliminary|protection) #REQUIRED>\n"
 		"\t\t\t<!ATTLIST driver color (good|imperfect|preliminary) #REQUIRED>\n"
 		"\t\t\t<!ATTLIST driver sound (good|imperfect|preliminary) #REQUIRED>\n"
 		"\t\t\t<!ATTLIST driver graphic (good|imperfect) #REQUIRED>\n"


### PR DESCRIPTION
(Very minor fix.)

The XML schema indicates that `test` is a valid value for the driver status, but `print_game_driver` isn't capable of generating such a value.  It is capable of outputting `protection` which isn't documented in the schema.