### PR TITLE
Add a core option 'analog_sensitivity'.

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -873,7 +873,7 @@ void update_analog_port(int port)
 	}
 
 
-	sensitivity = IP_GET_SENSITIVITY(in);
+	sensitivity = options.analog_sensitivity ? (int)(options.analog_sensitivity * 100) : IP_GET_SENSITIVITY(in);
 	min = IP_GET_MIN(in);
 	max = IP_GET_MAX(in);
 	default_value = in->default_value * 100 / sensitivity;
@@ -1074,7 +1074,7 @@ static void scale_analog_port(int port)
 
 profiler_mark(PROFILER_INPUT);
 	in = input_analog[port];
-	sensitivity = IP_GET_SENSITIVITY(in);
+	sensitivity = options.analog_sensitivity ? (int)(options.analog_sensitivity * 100) : IP_GET_SENSITIVITY(in);
 
 	/* apply scaling fairly in both positive and negative directions */
 	delta = input_analog_current_value[port] - input_analog_previous_value[port];
@@ -1329,7 +1329,7 @@ profiler_mark(PROFILER_INPUT);
 						input_analog_init[port] = 0;
 						input_analog_scale[port] = 1;
 						input_analog_current_value[port] = input_analog_previous_value[port]
-							= in->default_value * 100 / IP_GET_SENSITIVITY(in);
+							= in->default_value * 100 / (options.analog_sensitivity ? (int)(options.analog_sensitivity * 100) : IP_GET_SENSITIVITY(in));
 					}
 				}
 				else

--- a/src/mame.h
+++ b/src/mame.h
@@ -203,6 +203,7 @@ struct GameOptions
   unsigned dial_share_xy;
   bool     dial_swap_xy;
   unsigned xy_device;
+  float    analog_sensitivity;   /* if nonzero, override sensitivity value from the OSD menu */
   bool     use_lightgun_with_pad;
   unsigned input_interface;                         /* can be set to RETRO_DEVICE_JOYPAD, RETRO_DEVICE_KEYBOARD, or 0 (both simultaneously) */
   unsigned active_control_type[MAX_PLAYER_COUNT];   /* register to indicate the default control layout for each player as currently set in the frontend */

--- a/src/mame2003/core_options.c
+++ b/src/mame2003/core_options.c
@@ -801,6 +801,63 @@ static struct retro_core_option_v2_definition option_def_input_toggle = {
    "enabled"
 };
 
+static struct retro_core_option_v2_definition option_def_analog_sensitivity = {
+   APPNAME"_analog_sensitivity",
+   "Analog Sensitivity",
+   NULL,
+   "Used to adjust analog input sensitivity.",
+   NULL,
+   "cat_key_input",
+   {
+      { "default", NULL },
+      { "5",       "5%" },
+      { "10",     "10%" },
+      { "15",     "15%" },
+      { "20",     "20%" },
+      { "25",     "25%" },
+      { "30",     "30%" },
+      { "35",     "35%" },
+      { "40",     "40%" },
+      { "45",     "45%" },
+      { "50",     "50%" },
+      { "55",     "55%" },
+      { "60",     "60%" },
+      { "65",     "65%" },
+      { "70",     "70%" },
+      { "75",     "75%" },
+      { "80",     "80%" },
+      { "85",     "85%" },
+      { "90",     "90%" },
+      { "95",     "95%" },
+      { "100",   "100%" },
+      { "105",   "105%" },
+      { "110",   "110%" },
+      { "115",   "115%" },
+      { "120",   "120%" },
+      { "125",   "125%" },
+      { "150",   "150%" },
+      { "200",   "200%" },
+      { "250",   "250%" },
+      { "300",   "300%" },
+      { "350",   "350%" },
+      { "400",   "400%" },
+      { "450",   "450%" },
+      { "500",   "500%" },
+      { "550",   "550%" },
+      { "600",   "600%" },
+      { "650",   "650%" },
+      { "700",   "700%" },
+      { "750",   "750%" },
+      { "800",   "800%" },
+      { "850",   "850%" },
+      { "900",   "900%" },
+      { "950",   "950%" },
+      { "1000", "1000%" },
+      { NULL, NULL },
+   },
+   "default"
+};
+
 static struct retro_core_option_v2_definition option_def_null = {
    NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL
 };
@@ -887,6 +944,7 @@ void init_core_options(void)
   default_options[OPT_CPU_CLOCK_SCALE]           = option_def_cpu_clock_scale;
   default_options[OPT_OVERRIDE_AD_STICK]         = option_def_override_ad_stick;
   default_options[OPT_INPUT_TOGGLE]              = option_def_input_toggle;
+  default_options[OPT_ANALOG_SENSITIVITY]        = option_def_analog_sensitivity;
 #if (HAS_CYCLONE || HAS_DRZ80)
   default_options[OPT_CYCLONE_MODE]              = option_def_cyclone_mode;
 #endif
@@ -1266,6 +1324,13 @@ void update_variables(bool first_time)
             options.input_toggle = true;
           else
             options.input_toggle = false;
+          break;
+
+        case OPT_ANALOG_SENSITIVITY:
+          if(strcmp(var.value, "default") == 0)
+            options.analog_sensitivity = 0;
+          else
+            options.analog_sensitivity = (float)atoi(var.value) / 100;
           break;
 
 #if (HAS_CYCLONE || HAS_DRZ80)

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -226,6 +226,7 @@ enum CORE_OPTIONS  /* controls the order in which core options appear. common, i
   OPT_NEOGEO_BIOS,
   OPT_STV_BIOS,
   OPT_CPU_CLOCK_SCALE,
+  OPT_ANALOG_SENSITIVITY,
 #if (HAS_CYCLONE || HAS_DRZ80)
   OPT_CYCLONE_MODE,
 #endif


### PR DESCRIPTION
The OSD menu allows changing analog sensitivity up to 255%. Sometimes this is not quite enough (tested on Arkanoid). So adding a core option with a larger range. The "default" value means to use the OSD menu setting. Any non-default value overrides the OSD menu. A core option is also easier to access than the OSD menu.