### PR TITLE
backport mamedev fixes for stlforce, add mortalr

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -5592,6 +5592,7 @@ Other Sun games
 	DRIVER( sprcros2 )	/* (c) 1986 GM Shoji */
 	DRIVER( mugsmash )	/* (c) Electronic Devices (Italy) / 3D Games (England) */
 	DRIVER( stlforce )	/* (c) 1994 Electronic Devices (Italy) / Ecogames S.L. (Spain) */
+	DRIVER( mortalr )	
 	DRIVER( fantland )	/* (c) 1987 Electronic Devices Italy */
 	DRIVER( galaxygn )	/* (c) 1989 Electronic Devices Italy */
 	DRIVER( borntofi )	/* (c) 1987 International Games */

--- a/src/drivers/stlforce.c
+++ b/src/drivers/stlforce.c
@@ -77,10 +77,12 @@ data16_t *stlforce_spriteram;
 
 VIDEO_START( stlforce );
 VIDEO_UPDATE( stlforce );
+
 WRITE16_HANDLER( stlforce_tx_videoram_w );
 WRITE16_HANDLER( stlforce_mhigh_videoram_w );
 WRITE16_HANDLER( stlforce_mlow_videoram_w );
 WRITE16_HANDLER( stlforce_bg_videoram_w );
+WRITE16_HANDLER(sprites_commands_w);
 
 static WRITE16_HANDLER( oki_bank_w )
 {
@@ -88,38 +90,42 @@ static WRITE16_HANDLER( oki_bank_w )
 }
 
 static MEMORY_READ16_START( stlforce_readmem )
-	{ 0x000000, 0x03ffff, MRA16_ROM }, /* rom */
-	{ 0x100000, 0x1007ff, MRA16_RAM }, /* bg ram */
-	{ 0x100800, 0x100fff, MRA16_RAM }, /* mlow ram */
-	{ 0x101000, 0x1017ff, MRA16_RAM }, /* mhigh ram */
-	{ 0x101800, 0x1027ff, MRA16_RAM }, /* tx ram */
+	{ 0x000000, 0x0fffff, MRA16_ROM }, /* rom */
 	{ 0x102800, 0x103fff, MRA16_RAM }, /* unknown / ram */
-	{ 0x104000, 0x104fff, MRA16_RAM }, /* palette */
+	{ 0x103000, 0x1033ff, MRA16_RAM }, //bg_scrollram shared?
+	{ 0x103400, 0x1037ff, MRA16_RAM }, // stlforce_mlow_scrollram shared?
+	{ 0x103800, 0x103bff, MRA16_RAM },// stlforce_mhigh_scrollram shared? 
+	{ 0x103c00, 0x103fff, MRA16_RAM },// stlforce_vidattrram ?
+	{ 0x104000, 0x104fff, MRA16_RAM }, // paletteram16 shared ?
 	{ 0x105000, 0x107fff, MRA16_RAM }, /* unknown / ram */
-	{ 0x108000, 0x108fff, MRA16_RAM }, /* sprite ram? */
+	{ 0x108000, 0x1087ff, MRA16_RAM }, /* sprite ram shared? */
+	{ 0x108800, 0x108fff, MRA16_RAM },
 	{ 0x109000, 0x11ffff, MRA16_RAM }, /* unknown / ram */
+	{ 0x120000, 0x12ffff, MRA16_RAM }, /*  mortal race has piggybacked RAM chips to double RAM capacity */
 	{ 0x400000, 0x400001, input_port_0_word_r },
 	{ 0x400002, 0x400003, input_port_1_word_r },
 	{ 0x410000, 0x410001, OKIM6295_status_0_lsb_r },
 MEMORY_END
 
+
 static MEMORY_WRITE16_START( stlforce_writemem )
-	{ 0x000000, 0x03ffff, MWA16_ROM },
+	{ 0x000000, 0x0fffff, MWA16_ROM },
 	{ 0x100000, 0x1007ff, stlforce_bg_videoram_w, &stlforce_bg_videoram },
 	{ 0x100800, 0x100fff, stlforce_mlow_videoram_w, &stlforce_mlow_videoram },
 	{ 0x101000, 0x1017ff, stlforce_mhigh_videoram_w, &stlforce_mhigh_videoram },
 	{ 0x101800, 0x1027ff, stlforce_tx_videoram_w, &stlforce_tx_videoram },
-	{ 0x102800, 0x102fff, MWA16_RAM }, /* unknown / ram */
-	{ 0x103000, 0x1033ff, MWA16_RAM, &stlforce_bg_scrollram }, /* unknown / ram */
-	{ 0x103400, 0x1037ff, MWA16_RAM, &stlforce_mlow_scrollram }, /* unknown / ram */
-	{ 0x103800, 0x103bff, MWA16_RAM, &stlforce_mhigh_scrollram }, /* unknown / ram */
-	{ 0x103c00, 0x103fff, MWA16_RAM, &stlforce_vidattrram }, /* unknown / ram */
+	{ 0x102800, 0x102fff, MWA16_RAM }, 
+	{ 0x103000, 0x1033ff, MWA16_RAM, &stlforce_bg_scrollram },
+	{ 0x103400, 0x1037ff, MWA16_RAM, &stlforce_mlow_scrollram },
+	{ 0x103800, 0x103bff, MWA16_RAM, &stlforce_mhigh_scrollram },
+	{ 0x103c00, 0x103fff, MWA16_RAM, &stlforce_vidattrram },
 	{ 0x104000, 0x104fff, paletteram16_xBBBBBGGGGGRRRRR_word_w, &paletteram16 },
-	{ 0x105000, 0x107fff, MWA16_RAM }, /* unknown / ram */
-	{ 0x108000, 0x108fff, MWA16_RAM, &stlforce_spriteram }, /* or is this not sprite ram .. */
+	{ 0x105000, 0x1077ff, MWA16_RAM }, /* unknown / ram */
+	{ 0x108000, 0x1087ff, MWA16_RAM, &stlforce_spriteram }, /* or is this not sprite ram .. */
+	{ 0x108800, 0x108fff, MWA16_RAM },
 	{ 0x109000, 0x11ffff, MWA16_RAM },
-/*	{ 0x400010, 0x400013, MWA16_NOP },*/
-/*	{ 0x40001E, 0x40001F, MWA16_NOP },*/
+	{ 0x120000, 0x12ffff, MWA16_RAM }, /*  mortal race has piggybacked RAM chips to double RAM capacity */
+	{ 0x40001E, 0x40001F, sprites_commands_w },
 	{ 0x400012, 0x400013, oki_bank_w },
 	{ 0x410000, 0x410001, OKIM6295_data_0_lsb_w },
 MEMORY_END
@@ -155,6 +161,7 @@ INPUT_PORTS_START( stlforce )
 	PORT_BIT( 0xff00, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
+
 static struct GfxLayout stlforce_bglayout =
 {
 	16,16,
@@ -162,7 +169,7 @@ static struct GfxLayout stlforce_bglayout =
 	4,
 	{0,1,2,3},
 	{12,8,4,0,28,24,20,16,16*32+12,16*32+8,16*32+4,16*32+0,16*32+28,16*32+24,16*32+20,16*32+16},
-	{0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,8*32,9*32,10*32,11*32,12*32,13*32,14*32,15*32},
+	{STEP16(0, 32)},
 	32*32
 };
 
@@ -173,7 +180,7 @@ static struct GfxLayout stlforce_txlayout =
 	4,
 	{0,1,2,3},
 	{12,8,4,0,28,24,20,16},
-	{0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32,},
+	{0*32,1*32,2*32,3*32,4*32,5*32,6*32,7*32 },
 	8*32
 };
 
@@ -182,7 +189,7 @@ static struct GfxLayout stlforce_splayout =
 	16,16,
 	RGN_FRAC(1,4),
 	4,
-	{0x040000*3*8,0x040000*2*8,0x040000*1*8,0x040000*0*8},
+	{RGN_FRAC(3,4),RGN_FRAC(2,4),RGN_FRAC(1,4),RGN_FRAC(0,4)},
 	{16*8+7,16*8+6,16*8+5,16*8+4,16*8+3,16*8+2,16*8+1,16*8+0,7,6,5,4,3,2,1,0},
 	{0*8,1*8,2*8,3*8,4*8,5*8,6*8,7*8,8*8,9*8,10*8,11*8,12*8,13*8,14*8,15*8},
 	32*8
@@ -190,10 +197,12 @@ static struct GfxLayout stlforce_splayout =
 
 static struct GfxDecodeInfo gfxdecodeinfo[] =
 {
-	{ REGION_GFX1, 0, &stlforce_bglayout, 0, 256  },
-	{ REGION_GFX1, 0, &stlforce_txlayout, 0, 256  },
-	{ REGION_GFX2, 0, &stlforce_splayout, 0, 256  },
-	{ -1 } /* end of array */
+	{ REGION_GFX2, 0x000000, &stlforce_splayout, 1024, 16 }, //sprites
+	{ REGION_GFX6, 0x000000, &stlforce_txlayout,  384, 8  }, //txtile
+	{ REGION_GFX5, 0x000000, &stlforce_bglayout,  256, 8  }, //midhightile
+	{ REGION_GFX4, 0x000000, &stlforce_bglayout,  128, 8  }, //midlowtile
+	{ REGION_GFX3, 0x000000, &stlforce_bglayout,    0, 8  }, //bgtile
+	{ -1 }
 };
 
 static struct OKIM6295interface okim6295_interface =
@@ -206,11 +215,11 @@ static struct OKIM6295interface okim6295_interface =
 
 static MACHINE_DRIVER_START( stlforce )
 	/* basic machine hardware */
-	MDRV_CPU_ADD(M68000, 12000000) /* guess ... it might be 15000000 or 12000000/2 ... */
+	MDRV_CPU_ADD(M68000, 15000000) /* guess ... it might be 15000000 or 12000000/2 ... */
 	MDRV_CPU_MEMORY(stlforce_readmem,stlforce_writemem)
 	MDRV_CPU_VBLANK_INT(irq4_line_hold,1)
 
-	MDRV_FRAMES_PER_SECOND(60)
+	MDRV_FRAMES_PER_SECOND(58)
 	MDRV_VBLANK_DURATION(DEFAULT_60HZ_VBLANK_DURATION)
 
 	/* video hardware */
@@ -218,7 +227,7 @@ static MACHINE_DRIVER_START( stlforce )
 	MDRV_GFXDECODE(gfxdecodeinfo)
 	MDRV_VIDEO_ATTRIBUTES(VIDEO_TYPE_RASTER)
 	MDRV_SCREEN_SIZE(64*8, 32*8)
-	MDRV_VISIBLE_AREA(1*8, 47*8-1, 1*8, 30*8-1)
+	MDRV_VISIBLE_AREA(8, 48*8-1-8-2, 0, 30*8-1)
 	MDRV_PALETTE_LENGTH(0x800)
 	MDRV_VIDEO_START(stlforce)
 	MDRV_VIDEO_UPDATE(stlforce)
@@ -228,25 +237,78 @@ static MACHINE_DRIVER_START( stlforce )
 MACHINE_DRIVER_END
 
 ROM_START( stlforce )
-	ROM_REGION( 0x80000, REGION_CPU1, 0 ) /* 68000 code */
+	ROM_REGION( 0x100000, REGION_CPU1, ROMREGION_ERASEFF ) // 68000 code
 	ROM_LOAD16_BYTE( "stlforce.105", 0x00000, 0x20000, CRC(3ec804ca) SHA1(4efcf3321b7111644ac3ee0a83ad95d0571a4021) )
 	ROM_LOAD16_BYTE( "stlforce.104", 0x00001, 0x20000, CRC(69b5f429) SHA1(5bd20fad91a22f4d62f85a5190d72dd824ee26a5) )
 
-	ROM_REGION( 0x200000, REGION_GFX1, 0 ) /* 16x16 bg tiles & 8x8 tx tiles merged */
+	ROM_REGION( 0x200000, REGION_GFX1, 0 ) // 16x16 bg tiles & 8x8 tx tiles merged
 	ROM_LOAD16_BYTE( "stlforce.u27", 0x000001, 0x080000, CRC(c42ef365) SHA1(40e9ee29ea14b3bc2fbfa4e6acb7d680cf72f01a) )
 	ROM_LOAD16_BYTE( "stlforce.u28", 0x000000, 0x080000, CRC(6a4b7c98) SHA1(004d7f3c703c6abc79286fa58a4c6793d66fca39) )
 	ROM_LOAD16_BYTE( "stlforce.u29", 0x100001, 0x080000, CRC(30488f44) SHA1(af0d92d8952ce3cd893ab9569afdda12e17795e7) )
 	ROM_LOAD16_BYTE( "stlforce.u30", 0x100000, 0x080000, CRC(cf19d43a) SHA1(dc04930548ac5b7e2b74c6041325eac06e773ed5) )
 
-	ROM_REGION( 0x100000, REGION_GFX2, 0 ) /* 16x16 sprites */
+	ROM_REGION( 0x080000, REGION_GFX3, 0 )
+	ROM_COPY( REGION_GFX1, 0x000000, 0x000000, 0x080000) //bgtile
+
+	ROM_REGION( 0x080000, REGION_GFX4, 0 )
+	ROM_COPY( REGION_GFX1, 0x080000, 0x000000, 0x080000) //midlowtile
+
+	ROM_REGION( 0x080000, REGION_GFX5, 0 )
+	ROM_COPY( REGION_GFX1, 0x100000, 0x000000, 0x080000) //midhightile
+
+	ROM_REGION( 0x080000, REGION_GFX6, 0 )
+	ROM_COPY( REGION_GFX1, 0x180000, 0x000000, 0x080000) //txtile
+
+	ROM_REGION( 0x100000, REGION_GFX2, 0 ) // 16x16
+	ROM_LOAD( "stlforce.u36", 0x00000, 0x40000, CRC(037dfa9f) SHA1(224f5cd1a95d55b065aef5c0bd03b50cabcb619b) )
 	ROM_LOAD( "stlforce.u31", 0x40000, 0x40000, CRC(305a8eb5) SHA1(3a8d26f8bc4ec2e8246d1c59115e21cad876630d) )
 	ROM_LOAD( "stlforce.u32", 0x80000, 0x40000, CRC(760e8601) SHA1(a61f1d8566e09ce811382c6e23f3881e6c438f15) )
 	ROM_LOAD( "stlforce.u33", 0xc0000, 0x40000, CRC(19415cf3) SHA1(31490a1f3321558f82667b63f3963b2ec3fa0c59) )
-	ROM_LOAD( "stlforce.u36", 0x00000, 0x40000, CRC(037dfa9f) SHA1(224f5cd1a95d55b065aef5c0bd03b50cabcb619b) )
-	
-	/* only one bank */
-	ROM_REGION( 0x80000, REGION_SOUND1, 0 ) /* samples */
+
+	// only one bank
+	ROM_REGION( 0x80000, REGION_SOUND1, 0 ) // samples, second half 0xff filled
 	ROM_LOAD( "stlforce.u1", 0x00000, 0x80000, CRC(0a55edf1) SHA1(091f12e8110c62df22b370a2e710c930ba06e8ca) )
+
+//	ROM_REGION16_BE( 0x80, "eeprom", 0 )
+//	ROM_LOAD( "eeprom-stlforce.bin", 0x0000, 0x0080, CRC(3fb83951) SHA1(0cbf09751e46f100db847cf0594a4440126a7b6e) )
+ROM_END
+
+ROM_START( mortalr )
+	ROM_REGION( 0x100000, REGION_CPU1, 0 ) /* 68000 code */
+	ROM_LOAD16_BYTE( "2.u105", 0x00000, 0x80000, CRC(550c48e3) SHA1(cdd2a00a6377273c73f37944f1ee6acfb4d41e82) )
+	ROM_LOAD16_BYTE( "3.u104", 0x00001, 0x80000, CRC(92fad747) SHA1(0b41f31e2f14607b572ef56751b3cb201cec1bf2) )
+
+	ROM_REGION( 0x400000, REGION_GFX1, ROMREGION_ERASE00 ) /* 16x16 bg tiles */
+	/* 2 pairs of piggyback ROMs to give double usual capacity */
+	ROM_LOAD16_BYTE( "8_bot.u27",  0x000001, 0x080000, CRC(042297f3) SHA1(08640cb7997d10baae776f377a605fa70499f6ef) )
+	ROM_LOAD16_BYTE( "9_bot.u28",  0x000000, 0x080000, CRC(ab330185) SHA1(6403d472499897395e47a05f73e3760ef632ab8a) )
+	ROM_LOAD16_BYTE( "12_top.u27", 0x100001, 0x080000, CRC(fa95773c) SHA1(849f3ab4950b34200e3043d849273622e4bdbfa3) )
+	ROM_LOAD16_BYTE( "13_top.u28", 0x100000, 0x080000, CRC(f2342348) SHA1(0f197e88a1911715d3b98af9e303fd1f137e5fe3) )
+	ROM_LOAD16_BYTE( "10.u29",     0x200001, 0x080000, CRC(fb39b032) SHA1(c2dfb24fccd4b588d92214addee2a9bbb6e45065) )
+	ROM_LOAD16_BYTE( "11.u30",     0x200000, 0x080000, CRC(a82f2421) SHA1(b0787decd1b668af5b2ed032947ca5c0ccc020e8) )
+
+	ROM_REGION( 0x100000, REGION_GFX3, 0 )
+	ROM_COPY( REGION_GFX1, 0x000000, 0x000000, 0x100000)
+
+	ROM_REGION( 0x100000, REGION_GFX4, 0 )
+	ROM_COPY( REGION_GFX1, 0x100000, 0x000000, 0x100000)
+
+	ROM_REGION( 0x100000, REGION_GFX5, 0 )
+	ROM_COPY( REGION_GFX1, 0x200000, 0x000000, 0x100000)
+
+	ROM_REGION( 0x100000, REGION_GFX6, ROMREGION_ERASE00 )
+	// no 8x8 tiles present, but layer gets enabled if you turn on the debug mode
+
+	ROM_REGION( 0x200000, REGION_GFX2, 0 ) /* 16x16 */
+	ROM_LOAD( "4.u36", 0x000000, 0x80000, CRC(6d1e6367) SHA1(4e6d315206b4ebc75abe9cbec1a53a9ca0b29128) )
+	ROM_LOAD( "5.u31", 0x080000, 0x80000, CRC(54b223bf) SHA1(43e2a7f1d56f341f08cb04b979c4d930b58c4587) )
+	ROM_LOAD( "6.u32", 0x100000, 0x80000, CRC(dab08a04) SHA1(68e26cf52ebf86a6b1e96b35fb86fcafc57c9805) )
+	ROM_LOAD( "7.u33", 0x180000, 0x80000, CRC(9a856797) SHA1(265628d3b5c137ae8260ed530b7778496d863fc2) )
+
+	ROM_REGION( 0x80000, REGION_SOUND1, 0 )
+	ROM_LOAD( "1.u1", 0x00000, 0x80000, CRC(e5c730c2) SHA1(a153a204c1452a0c95fe207d750b2df07c5e63f3) )
 ROM_END
 
 GAME(1994, stlforce, 0, stlforce, stlforce, 0, ROT0, "Electronic Devices Italy / Ecogames S.L. Spain", "Steel Force" )
+GAME(1995, mortalr,  0, stlforce,  stlforce, 0, ROT0, "New Dream Games", "Mortal Race" ) /* based on the same rough codebase as Top Driving tch/topdrive.cpp but not the same game, so not a clone */
+

--- a/src/vidhrdw/stlforce_vidhrdw.c
+++ b/src/vidhrdw/stlforce_vidhrdw.c
@@ -2,6 +2,9 @@
 
 #include "driver.h"
 
+int which=0;
+data16_t  sprites_buffer[0x400];
+
 static struct tilemap *stlforce_bg_tilemap, *stlforce_mlow_tilemap, *stlforce_mhigh_tilemap, *stlforce_tx_tilemap;
 
 extern data16_t *stlforce_bg_videoram, *stlforce_mlow_videoram, *stlforce_mhigh_videoram, *stlforce_tx_videoram;
@@ -9,108 +12,193 @@ extern data16_t *stlforce_bg_scrollram, *stlforce_mlow_scrollram, *stlforce_mhig
 
 extern data16_t *stlforce_spriteram;
 
-/* background, appears to be the bottom layer */
+WRITE16_HANDLER(sprites_commands_w)
+{
+	// TODO: I'm not convinced by this, from mwarr.cpp driver
+	if (which)
+	{
+		switch (data & 0xf)
+		{
+		case 0:
+			/* clear sprites on screen */
+			for (int i = 0; i < 0x400; i++)
+			{
+				sprites_buffer[i] = 0;
+			}
+			which = 0;
+			break;
 
+		default:
+			// allow everything else to fall through, other games are writing other values
+		case 0xf: // mwarr
+			/* refresh sprites on screen */
+			for (int i = 0; i < 0x400; i++)
+			{
+				sprites_buffer[i] = stlforce_spriteram[i];
+			}
+			break;
+
+		case 0xd:
+			/* keep sprites on screen */
+			break;
+		}
+	}
+	which ^= 1;
+}
+
+/* background, appears to be the bottom layer */
 static void get_stlforce_bg_tile_info(int tile_index)
 {
 	int tileno,colour;
-
-	tileno = stlforce_bg_videoram[tile_index] & 0x0fff;
-	colour = stlforce_bg_videoram[tile_index] & 0xe000;
-	colour = colour >> 13;
-	SET_TILE_INFO(0,tileno,colour,0)
+	tileno = stlforce_bg_videoram[tile_index] & 0x1fff;
+	colour = (stlforce_bg_videoram[tile_index] & 0xe000) >> 13;
+	SET_TILE_INFO(4,tileno,colour,0)
 }
 
 WRITE16_HANDLER( stlforce_bg_videoram_w )
 {
-	if (stlforce_bg_videoram[offset] != data)
-	{
-		stlforce_bg_videoram[offset] = data;
+		COMBINE_DATA(&stlforce_bg_videoram[offset]);
 		tilemap_mark_tile_dirty(stlforce_bg_tilemap,offset);
-	}
-}
-
-/* middle layer, low */
-
-static void get_stlforce_mlow_tile_info(int tile_index)
-{
-	int tileno,colour;
-
-	tileno = stlforce_mlow_videoram[tile_index] & 0x0fff;
-	colour = stlforce_mlow_videoram[tile_index] & 0xe000;
-	colour = colour >> 13;
-	colour += 8;
-	tileno += 0x1000;
-
-	SET_TILE_INFO(0,tileno,colour,0)
 }
 
 WRITE16_HANDLER( stlforce_mlow_videoram_w )
 {
-	if (stlforce_mlow_videoram[offset] != data)
-	{
-		stlforce_mlow_videoram[offset] = data;
+		COMBINE_DATA(&stlforce_mlow_videoram[offset]);
 		tilemap_mark_tile_dirty(stlforce_mlow_tilemap,offset);
-	}
+
 }
-
-/* middle layer, high */
-
-static void get_stlforce_mhigh_tile_info(int tile_index)
-{
-	int tileno,colour;
-
-	tileno = stlforce_mhigh_videoram[tile_index] & 0x0fff;
-	colour = stlforce_mhigh_videoram[tile_index] & 0xe000;
-	colour = colour >> 13;
-	colour += 16;
-	tileno += 0x2000;
-
-	SET_TILE_INFO(0,tileno,colour,0)
-}
-
 WRITE16_HANDLER( stlforce_mhigh_videoram_w )
 {
-	if (stlforce_mhigh_videoram[offset] != data)
-	{
-		stlforce_mhigh_videoram[offset] = data;
+		COMBINE_DATA(&stlforce_mhigh_videoram[offset]);
 		tilemap_mark_tile_dirty(stlforce_mhigh_tilemap,offset);
-	}
-}
-
-/* text layer, appears to be the top layer */
-
-static void get_stlforce_tx_tile_info(int tile_index)
-{
-	int tileno,colour;
-
-	tileno = stlforce_tx_videoram[tile_index] & 0x0fff;
-	colour = stlforce_tx_videoram[tile_index] & 0xe000;
-	colour = colour >> 13;
-
-	tileno += 0xc000;
-
-	colour += 24;
-	SET_TILE_INFO(1,tileno,colour,0)
 }
 
 WRITE16_HANDLER( stlforce_tx_videoram_w )
 {
-	if (stlforce_tx_videoram[offset] != data)
-	{
-		stlforce_tx_videoram[offset] = data;
+		COMBINE_DATA(&stlforce_tx_videoram[offset]);
 		tilemap_mark_tile_dirty(stlforce_tx_tilemap,offset);
+}
+/* middle layer, low */
+static void get_stlforce_mlow_tile_info(int tile_index)
+{
+	int tileno,colour;
+	tileno =  stlforce_mlow_videoram[tile_index] & 0x1fff;
+	colour = (stlforce_mlow_videoram[tile_index] & 0xe000) >> 13;
+	SET_TILE_INFO(3,tileno,colour,0)
+}
+
+/* middle layer, high */
+static void get_stlforce_mhigh_tile_info(int tile_index)
+{
+	int tileno =  stlforce_mhigh_videoram[tile_index] & 0x1fff;
+	int colour = (stlforce_mhigh_videoram[tile_index] & 0xe000) >> 13;
+	SET_TILE_INFO(2,tileno,colour,0)
+}
+
+/* text layer, appears to be the top layer */
+static void get_stlforce_tx_tile_info(int tile_index)
+{
+	int tileno =  stlforce_tx_videoram[tile_index] & 0x1fff;
+	int colour = (stlforce_tx_videoram[tile_index] & 0xe000) >> 13;
+	SET_TILE_INFO(1,tileno,colour,0)
+}
+
+
+int get_priority(const data16_t *source)
+{
+	return ((source[1] & 0x3c00) >> 10); // Priority (1 = Low)
+}
+
+// the Steel Force type hardware uses an entirely different bit for priority and only appears to have 2 levels
+// Mortal Race uses additional priorities
+int sforce_get_priority(const data16_t *source)
+{
+	switch (source[1] & 0x0030)
+	{
+	case 0x00:
+		return 0x02;
+	case 0x10:
+		return 0x04;
+	case 0x20:
+		return 0x0c;
+	case 0x30:
+		return 0x0e;
+	}
+
+	return 0x00;
+}
+
+int spritexoffs=7;
+static void draw_sprites( struct mame_bitmap *bitmap, const struct rectangle *cliprect )
+{
+	const data16_t *source = sprites_buffer + 0x400 - 4;
+	const data16_t *finish = sprites_buffer;
+	const struct GfxElement *gfx = Machine->gfx[0];
+	int x, y, color, flipx, dy, pri, pri_mask, i;
+
+	while (source >= finish)
+	{
+		/* draw sprite */
+		if (source[0] & 0x0800)
+		{
+			y = 0x1ff - (source[0] & 0x01ff);
+			x = (source[3] & 0x3ff) - spritexoffs;
+
+			color = source[1] & 0x000f;
+			flipx = source[1] & 0x0200;
+
+			dy = (source[0] & 0xf000) >> 12;
+
+			pri = sforce_get_priority(source); 
+			pri_mask = ~((1 << (pri + 1)) - 1);     // Above the first "pri" levels
+
+			for (i = 0; i <= dy; i++)
+			{
+				pdrawgfx(bitmap,gfx,
+					source[2] + i,
+					color,
+					flipx, 0,
+					x, y + i * 16,
+					cliprect,TRANSPARENCY_PEN,0,
+					pri_mask);
+
+				// wrap around x 
+				pdrawgfx(bitmap,gfx,
+					source[2] + i,
+					color,
+					flipx, 0,
+					x - 1024, y + i * 16,
+					cliprect,TRANSPARENCY_PEN,0,
+					pri_mask);
+				// wrap around y 
+				pdrawgfx(bitmap,gfx,
+					source[2] + i,
+					color,
+					flipx, 0,
+					x, y - 512 + i * 16,
+					cliprect,TRANSPARENCY_PEN,0,
+					pri_mask);
+
+					// wrap around x & y 
+				pdrawgfx(bitmap,gfx,
+					source[2] + i,
+					color,
+					flipx, 0,
+					x - 1024, y - 512 + i * 16,
+					cliprect,TRANSPARENCY_PEN,0,
+					pri_mask);
+			}
+		}
+		source -= 0x4;
 	}
 }
 
-/* sprites - quite a bit still needs doing .. */
-
-static void draw_sprites( struct mame_bitmap *bitmap, const struct rectangle *cliprect )
+static void draw_sprites_old( struct mame_bitmap *bitmap, const struct rectangle *cliprect )
 {
 
 	const UINT16 *source = stlforce_spriteram+0x0;
 	const UINT16 *finish = stlforce_spriteram+0x800;
-	const struct GfxElement *gfx = Machine->gfx[2];
+	const struct GfxElement *gfx = Machine->gfx[0];
 
 	while( source<finish )
 	{
@@ -137,24 +225,64 @@ static void draw_sprites( struct mame_bitmap *bitmap, const struct rectangle *cl
 
 VIDEO_UPDATE( stlforce )
 {
+	int i;
+	fillbitmap(priority_bitmap, 0, cliprect);
+	fillbitmap(bitmap, get_black_pen(), cliprect);
+	/* xscrolls - Steel Force clearly shows that each layer needs -1 scroll compared to the previous, do enable flags change this?  */
 
-	tilemap_set_scrollx( stlforce_bg_tilemap, 0, stlforce_bg_scrollram[0]+8);
-	tilemap_set_scrolly( stlforce_bg_tilemap, 0, stlforce_vidattrram[1] );
+	if (BIT(stlforce_vidattrram[6], 0))
+	{
+		for (i = 0; i < 256; i++)
+			tilemap_set_scrollx( stlforce_bg_tilemap, i, stlforce_bg_scrollram[i] + 18);
+	}
 
-	tilemap_set_scrollx( stlforce_mlow_tilemap, 0, stlforce_mlow_scrollram[0]+8 );
-	tilemap_set_scrolly( stlforce_mlow_tilemap, 0, stlforce_vidattrram[2] );
+	else
+	{
+		for (i = 0; i < 256; i++)
+			tilemap_set_scrollx( stlforce_bg_tilemap, i, stlforce_bg_scrollram[0] + 18);
+	}
 
-	tilemap_set_scrollx( stlforce_mhigh_tilemap, 0, stlforce_mhigh_scrollram[0]+8);
-	tilemap_set_scrolly( stlforce_mhigh_tilemap, 0, stlforce_vidattrram[3] );
+	if (BIT(stlforce_vidattrram[6], 2))
+	{
+		for (i = 0; i < 256; i++)
+			tilemap_set_scrollx( stlforce_mlow_tilemap, i, stlforce_mlow_scrollram[i] + 17 );
+	}
+	else
+	{
+		for (i = 0; i < 256; i++)
+			tilemap_set_scrollx( stlforce_mlow_tilemap, i, stlforce_mlow_scrollram[0] + 17 );
+	}
 
+	if (BIT(stlforce_vidattrram[6], 4))
+	{
+		for (i = 0; i < 256; i++)
+			tilemap_set_scrollx( stlforce_mhigh_tilemap, i, stlforce_mhigh_scrollram[i] + 16);
+	}
+	else
+	{
+		for (i = 0; i < 256; i++)
+			tilemap_set_scrollx( stlforce_mhigh_tilemap, i, stlforce_mhigh_scrollram[0] + 16);
+	}
 
-	tilemap_draw(bitmap,cliprect,stlforce_bg_tilemap,0,0);
-	tilemap_draw(bitmap,cliprect,stlforce_mlow_tilemap,0,0);
-	tilemap_draw(bitmap,cliprect,stlforce_mhigh_tilemap,0,0);
-	draw_sprites(bitmap, cliprect);
-	tilemap_draw(bitmap,cliprect,stlforce_tx_tilemap,0,0);
+	tilemap_set_scrolly( stlforce_bg_tilemap, 0, stlforce_vidattrram[1]+1 );
+	tilemap_set_scrolly( stlforce_mlow_tilemap, 0, stlforce_vidattrram[2] +1 );
+	tilemap_set_scrolly( stlforce_mhigh_tilemap, 0, stlforce_vidattrram[3] +1 );
+	tilemap_set_scrolly( stlforce_tx_tilemap, 0, stlforce_vidattrram[4] +1 );
 
-/*usrintf_showmessage	("Regs %04x, %04x, %04x, %04x, %04", stlforce_vidattrram[0tlforce_tx_scrollram], stlforce_vidattrram[4],stlforce_vidattrram[5],stlforce_vidattrram[6],stlforce_vidattrram[7] );*/
+	if (BIT(stlforce_vidattrram[5], 0))
+		tilemap_draw(bitmap,cliprect,stlforce_bg_tilemap,0,0x01);
+
+	if (BIT(stlforce_vidattrram[5], 1))
+		tilemap_draw(bitmap,cliprect,stlforce_mlow_tilemap,0,0x02);
+
+	if (BIT(stlforce_vidattrram[5], 2))
+		tilemap_draw(bitmap,cliprect,stlforce_mhigh_tilemap,0,0x04);
+
+	if (BIT(stlforce_vidattrram[5], 3))
+			tilemap_draw(bitmap,cliprect,stlforce_tx_tilemap,0,0x10);
+
+	if (BIT(stlforce_vidattrram[5], 4))
+		draw_sprites(bitmap, cliprect);
 }
 
 VIDEO_START( stlforce )
@@ -170,5 +298,8 @@ VIDEO_START( stlforce )
 	stlforce_tx_tilemap = tilemap_create(get_stlforce_tx_tile_info,tilemap_scan_rows,TILEMAP_TRANSPARENT, 8, 8,64,32);
 	tilemap_set_transparent_pen(stlforce_tx_tilemap,0);
 
+	tilemap_set_scroll_rows(stlforce_bg_tilemap, 256);
+	tilemap_set_scroll_rows(stlforce_mlow_tilemap, 256);
+	tilemap_set_scroll_rows(stlforce_mhigh_tilemap, 256);
 	return 0;
 }


### PR DESCRIPTION
@arcadez2003 I left the old sprite draw in just in case there is speed issues you can just change to the quicker sprites.  Stlforce will need a few tweaks the priorities are wrong in the old code but can get it looking the same as it did with the old code and both games are playable enough just a few niggles with priorities with the older code. 