### PR TITLE
stl force updates

### DIFF
--- a/src/drivers/stlforce.c
+++ b/src/drivers/stlforce.c
@@ -133,7 +133,7 @@ static MEMORY_WRITE16_START( stlforce_writemem )
 	{ 0x400012, 0x400013, oki_bank_w },
 	{ 0x40001E, 0x40001F, sprites_commands_w },
 	{ 0x410000, 0x410001, OKIM6295_data_0_lsb_w },
-	{ 0xff0010, 0xff0011, MWA_RAM }, /* not sure what this is mortalr and stlforce use it*/  
+	{ 0xff0010, 0xff0011, MWA_RAM }, /* not sure what this is mortalr and stlforce use it and its not mapped in mame*/  
 MEMORY_END
 
 INPUT_PORTS_START( stlforce )

--- a/src/drivers/stlforce.c
+++ b/src/drivers/stlforce.c
@@ -133,7 +133,7 @@ static MEMORY_WRITE16_START( stlforce_writemem )
 	{ 0x400012, 0x400013, oki_bank_w },
 	{ 0x40001E, 0x40001F, sprites_commands_w },
 	{ 0x410000, 0x410001, OKIM6295_data_0_lsb_w },
-	{ 0xff0010, 0xff0011, MWA_RAM }, /* not sure what this is mortalr and stlforce use it and its not mapped in mame*/  
+	{ 0xff0010, 0xff0011, MWA16_RAM }, /* not sure what this is mortalr and stlforce use it and its not mapped in mame*/  
 MEMORY_END
 
 INPUT_PORTS_START( stlforce )

--- a/src/drivers/stlforce.c
+++ b/src/drivers/stlforce.c
@@ -91,6 +91,10 @@ static WRITE16_HANDLER( oki_bank_w )
 
 static MEMORY_READ16_START( stlforce_readmem )
 	{ 0x000000, 0x0fffff, MRA16_ROM }, /* rom */
+	{ 0x100000, 0x1007ff, MRA16_RAM }, /* stlforce_bg_videoram } */
+	{ 0x100800, 0x100fff, MRA16_RAM }, /* stlforce_mlow_videoram */
+	{ 0x101000, 0x1017ff, MRA16_RAM }, /* stlforce_mhigh_videoram shared ?*/
+	{ 0x101800, 0x1027ff, MRA16_RAM }, /* stlforce_tx_videoram shared?? */
 	{ 0x102800, 0x103fff, MRA16_RAM }, /* unknown / ram */
 	{ 0x103000, 0x1033ff, MRA16_RAM }, /* bg_scrollram shared? */
 	{ 0x103400, 0x1037ff, MRA16_RAM }, /* stlforce_mlow_scrollram shared? */
@@ -120,14 +124,16 @@ static MEMORY_WRITE16_START( stlforce_writemem )
 	{ 0x103800, 0x103bff, MWA16_RAM, &stlforce_mhigh_scrollram },
 	{ 0x103c00, 0x103fff, MWA16_RAM, &stlforce_vidattrram },
 	{ 0x104000, 0x104fff, paletteram16_xBBBBBGGGGGRRRRR_word_w, &paletteram16 },
-	{ 0x105000, 0x1077ff, MWA16_RAM }, /* unknown / ram */
+	{ 0x105000, 0x107fff, MWA16_RAM }, /* unknown / ram */
 	{ 0x108000, 0x1087ff, MWA16_RAM, &stlforce_spriteram }, /* or is this not sprite ram .. */
 	{ 0x108800, 0x108fff, MWA16_RAM },
 	{ 0x109000, 0x11ffff, MWA16_RAM },
 	{ 0x120000, 0x12ffff, MWA16_RAM }, /*  mortal race has piggybacked RAM chips to double RAM capacity */
-	{ 0x40001E, 0x40001F, sprites_commands_w },
+	{ 0x400010, 0x400011, MWA16_NOP }, /* eprom not added to driver yet */
 	{ 0x400012, 0x400013, oki_bank_w },
+	{ 0x40001E, 0x40001F, sprites_commands_w },
 	{ 0x410000, 0x410001, OKIM6295_data_0_lsb_w },
+	{ 0xff0010, 0xff0011, MWA_RAM }, /* not sure what this is mortalr and stlforce use it*/  
 MEMORY_END
 
 INPUT_PORTS_START( stlforce )

--- a/src/vidhrdw/stlforce_vidhrdw.c
+++ b/src/vidhrdw/stlforce_vidhrdw.c
@@ -262,6 +262,8 @@ VIDEO_UPDATE( stlforce )
 		for (i = 0; i < 256; i++)
 			tilemap_set_scrollx( stlforce_mhigh_tilemap, i, stlforce_mhigh_scrollram[0] + 16);
 	}
+	
+	tilemap_set_scrollx( stlforce_bg_tilemap, 0, stlforce_vidattrram[0] + 15);
 
 	tilemap_set_scrolly( stlforce_bg_tilemap, 0, stlforce_vidattrram[1]+1 );
 	tilemap_set_scrolly( stlforce_mlow_tilemap, 0, stlforce_vidattrram[2] +1 );


### PR DESCRIPTION
0xff0010, 0xff0011 isint mapped in mame at all. I added the reads to ram, as mame had these mapped to write only. I will  will test with shared ram whenIi get the time to see if its makes a difference.
