### PR TITLE
model1 running as it should log was spamming the function slowing thi…

### DIFF
--- a/src/mame2003/log.h
+++ b/src/mame2003/log.h
@@ -35,10 +35,12 @@ static INLINE void CLIB_DECL logerror(const char *text,...) __attribute__ ((form
 
 static INLINE void CLIB_DECL logerror(const char *text,...)
 {
+	#if MAMELOGERROR_ENABLE
 	va_list arg;
 	va_start(arg,text);
 	vsprintf(log_buffer,text,arg);
 	va_end(arg);
-   log_cb(RETRO_LOG_DEBUG, "(LOGERROR) %s",log_buffer);
+    log_cb(RETRO_LOG_DEBUG, "(LOGERROR) %s",log_buffer);
+    #endif
 }
 #endif /* LOG_H */


### PR DESCRIPTION
Disable processing of logerror since the model1 is spamming it and it getting processed even if its not printing severely slows down model1 games with the amount of spamming sent. Just jest this define if you need error logs only devs would need access to this anyway.