### PR TITLE
fix frameskip take two

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -388,6 +388,8 @@ void cpu_pause(bool pause)
     cpu_pause_state = false;
 }
 
+extern UINT8 frameskip_counter;
+
 void retro_run (void)
 {
   bool updated = false;
@@ -410,8 +412,17 @@ void retro_run (void)
       cpunum_set_clockscale(0, options.cpu_clock_scale);
     }
   }
-
   mame_frame();
+  if(frameskip_counter <= 11)
+    frameskip_counter++;
+
+  else
+    frameskip_counter = 0;
+
+ frameskip_counter = (frameskip_counter ) % 12;
+  
+ /*log_cb(RETRO_LOG_DEBUG, LOGPRE "frameskip_counter %d\n",frameskip_counter);*/
+ 
 }
 
 void retro_unload_game(void)
@@ -1182,6 +1193,7 @@ int osd_is_joy_pressed(int joycode)
   unsigned retro_code    = INT_MAX;
 
   if (!retro_running)                                   return 0; /* input callback has not yet been polled */
+
   if (options.input_interface == RETRO_DEVICE_KEYBOARD) return 0; /* disregard joystick input */
 
   /*log_cb(RETRO_LOG_DEBUG, "MAME is polling joysticks -- joycode: %i      player_number: %i      osd_code: %i\n", joycode, player_number, osd_code);*/

--- a/src/mame2003/video.c
+++ b/src/mame2003/video.c
@@ -385,11 +385,10 @@ const int frameskip_table[12][12] =
      { 0,1,1,1,1,1,0,1,1,1,1,1 },
      { 0,1,1,1,1,1,1,1,1,1,1,1 } };
 
- unsigned frameskip_counter = 0;
+UINT8 frameskip_counter = 0;
+
 int osd_skip_this_frame(void)
 {
-	static unsigned auto_frameskip_counter = 0;
-
 	bool skip_frame = 0;
 
 	if (pause_action)  return 0;  /* dont skip pause action hack (rendering mame info screens or you wont see them and not know to press a key) */
@@ -414,25 +413,11 @@ int osd_skip_this_frame(void)
 					skip_frame = options.frameskip;
 				break;
 			}
-
 		}
 	}
-	else /*manual frameskip includes disabled check */
-	{
-			if (skip_frame)
-			{
-				if(auto_frameskip_counter <= 40)
-				{
-					auto_frameskip_counter++;;
-				}
-				else
-				{
-					auto_frameskip_counter = 0;
-					skip_frame=0;
-				}
-			}
-		skip_frame = frameskip_table[options.frameskip][frameskip_counter];
-	}
+	else /*manual frameskip */
+	 skip_frame = frameskip_table[options.frameskip][frameskip_counter];
+
 	return skip_frame;
 }
 
@@ -505,7 +490,7 @@ void osd_update_video_and_audio(struct mame_display *display)
 
    gotFrame = 1;
 
-   frameskip_counter = (frameskip_counter + 1) % 12;
+  
    RETRO_PERFORMANCE_STOP(perf_cb, update_video_and_audio);
 }
 


### PR DESCRIPTION
The variables need set in retro run and there was an if statement I removed but I didnt do a git pull. the frameskip call is requested at least two times a frame so its set in retro run now(some drivers call it as well. The manual frame skips working a lot better now. Ill leave any updates to weekend when I have time to test properly in future.

dont pull this yet I want to test some more things. Ill drop you a wee note here when im done.