### PR TITLE
Selectively hide x way joystick menu item

### DIFF
--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -1993,8 +1993,6 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 
 	if (total == 0) return 0;
 
-	// total2 = total * ENTRIES;
-
 	menu_item[total2] = ui_getstring (UI_returntomain);
 	menu_item[total2 + 1] = 0;	/* terminate array */
 	total2++;


### PR DESCRIPTION
As per discussion at the end of this merged PR, [link](https://github.com/libretro/mame2003-plus-libretro/pull/1652), this newly created PR hides the X-Way Joystick option in the Analog Controls menu for types that are not IPT_DIAL and IPT_DIAL_V.  Repasting image of Super Speed Race Jr image that has a Dial control and a Pedal control for reference.  Note the Dial control has a X-Way Joystick option whereas the Pedal control does not.

![image](https://github.com/libretro/mame2003-plus-libretro/assets/5027366/510024fc-ae72-4417-8d60-06b25683633a)

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
