### PR TITLE
Fix time soldiers character init direction and precession

### DIFF
--- a/src/drivers/alpha68k.c
+++ b/src/drivers/alpha68k.c
@@ -243,18 +243,33 @@ static READ16_HANDLER( kyros_dip_r )
 static READ16_HANDLER( control_1_r )
 {
 	if (invert_controls)
+  {
 		return ~(readinputport(0) + (readinputport(1) << 8));
+  }
 
 	return (readinputport(0) + (readinputport(1) << 8));
 }
 
 static READ16_HANDLER( control_2_r )
 {
+  int portout5;
 	if (invert_controls)
-		return ~(readinputport(3) + ((~(1 << (readinputport(5) * 12 / 256))) << 8));
+  {
+    /* With initial port value of 0, this -10 keeps the 1st player correctly pointing */
+    /* straight up initially, and puts the value in the middle of one rotary step range */
+    /* to minimize slightly off key / joy step sizes mismatch from adding up too much */
+    /* too soon to cause a missed or no step event. */
+    portout5 = readinputport(5) - 10;
+    if (portout5 < 0)
+      portout5 = portout5 + 255;
+		return ~(readinputport(3) + ((~(1 << (portout5 * 12 / 256))) << 8));
+  }
 
+  portout5 = readinputport(5) - 10;
+  if (portout5 < 0)
+    portout5 = portout5 + 255;
 	return readinputport(3) + /* Low byte of CN1 */
-		((~(1 << (readinputport(5) * 12 / 256))) << 8);
+		((~(1 << (portout5 * 12 / 256))) << 8);
 }
 
 static READ16_HANDLER( control_2_V_r )
@@ -264,21 +279,57 @@ static READ16_HANDLER( control_2_V_r )
 
 static READ16_HANDLER( control_3_r )
 {
+  int portout6;
 	if (invert_controls)
-		return ~((( ~(1 << (readinputport(6) * 12 / 256)) )<<8)&0xff00);
+  {
+    /* With initial port value of 0, this -10 keeps the 2nd player correctly pointing */
+    /* straight up initially, and puts the value in the middle of one rotary step range */
+    /* to minimize slightly off key / joy step sizes mismatch from adding up too much */
+    /* too soon to cause a missed or no step event. */
+    portout6 = readinputport(6) - 10;
+    if (portout6 < 0)
+      portout6 = portout6 + 255;
+		return ~((( ~(1 << (portout6 * 12 / 256)) )<<8)&0xff00);
+  }
 
-	return (( ~(1 << (readinputport(6) * 12 / 256)) )<<8)&0xff00;
+  portout6 = readinputport(6) - 10;
+  if (portout6 < 0)
+    portout6 = portout6 + 255;
+	return (( ~(1 << (portout6 * 12 / 256)) )<<8)&0xff00;
 }
 
 /* High 4 bits of CN1 & CN2 */
 static READ16_HANDLER( control_4_r )
 {
+  int portout6, portout5;
 	if (invert_controls)
-		return ~(((( ~(1 << (readinputport(6) * 12 / 256))  ) <<4)&0xf000)
-		 + ((( ~(1 << (readinputport(5) * 12 / 256))  )    )&0x0f00));
+  {
+    /* With initial port value of 0, this -10 keeps the 2nd player correctly pointing */
+    /* straight up initially, and puts the value in the middle of one rotary step range */
+    /* to minimize slightly off key / joy step sizes mismatch from adding up too much */
+    /* too soon to cause a missed or no step event. */
+    portout6 = readinputport(6) - 10;
+    if (portout6 < 0)
+      portout6 = portout6 + 255;
+    /* With initial port value of 0, this -10 keeps the 1st player correctly pointing */
+    /* straight up initially, and puts the value in the middle of one rotary step range */
+    /* to minimize slightly off key / joy step sizes mismatch from adding up too much */
+    /* too soon to cause a missed or no step event. */
+    portout5 = readinputport(5) - 10;
+    if (portout5 < 0)
+      portout5 = portout5 + 255;
+		return ~(((( ~(1 << (portout6 * 12 / 256))  ) <<4)&0xf000)
+		 + ((( ~(1 << (portout5 * 12 / 256))  )    )&0x0f00));
+  }
 
-	return ((( ~(1 << (readinputport(6) * 12 / 256))  ) <<4)&0xf000)
-		 + ((( ~(1 << (readinputport(5) * 12 / 256))  )    )&0x0f00);
+  portout6 = readinputport(6) - 10;
+  if (portout6 < 0)
+    portout6 = portout6 + 255;
+  portout5 = readinputport(5) - 10;
+  if (portout5 < 0)
+    portout5 = portout5 + 255;
+	return ((( ~(1 << (portout6 * 12 / 256))  ) <<4)&0xf000)
+		 + ((( ~(1 << (portout5 * 12 / 256))  )    )&0x0f00);
 }
 
 /******************************************************************************/

--- a/src/drivers/alpha68k.c
+++ b/src/drivers/alpha68k.c
@@ -243,9 +243,7 @@ static READ16_HANDLER( kyros_dip_r )
 static READ16_HANDLER( control_1_r )
 {
 	if (invert_controls)
-  {
 		return ~(readinputport(0) + (readinputport(1) << 8));
-  }
 
 	return (readinputport(0) + (readinputport(1) << 8));
 }


### PR DESCRIPTION
Hi @mahoneyt944 

Here is a pull request to fix a small detail on Time Soldiers and Battlefield (same as Time Soldiers, but with Japanese text).

This fix has the character pointing straight up instead of the initial 30 degrees to the left (Time Soldiers uses 12-way rotary joystick to rotate the character every 30 degrees instead of every 45 degrees like Ikari Warriors).

This fix also passes the adjusted port value  so it initially points to the middle of the port range (235-255) that  represents pointing straight up.  This will keep the character from skipping or missing a step from precession since the port numbers are integers and 256 is not evenly divisible by 12.  With an optimal key / joy step of 21 or 22, a step will not be skipped for ~10 360 degree revolutions in one direction which is unlikely to happen.

The initial port value is 0 which is just in the range for the character to point 30 degrees to the left.  This PR subtracts 10 from the port number when passing to the game.  If that ends up being less than 0, 255 is then added to cause it to "wrap" around.  So when the port is initially 0, subtracting 10 = -10, then add 255 since it is negative = 245.  This is in the middle of the port range of 235-255 for pointing straight up.

Port 5 is for the rotation of player 1 and port 6 is for the rotation of player 2.

You can see from this video (time 0:52) of arcade play that the character does start facing straight up:
https://www.youtube.com/watch?v=C9omf1-iO7M

Showing that these two games are the only ones that using analog, ie rotate or IPT_DIAL controls.  None of the other games in apha68k.c have PORT_ANALOG or PORT_ANALOGX defined.
Time Soldiers:
https://github.com/libretro/mame2003-plus-libretro/blob/2a2ba583af473b74376f580a4ee9cb41a50b478f/src/drivers/alpha68k.c#L1088
https://github.com/libretro/mame2003-plus-libretro/blob/2a2ba583af473b74376f580a4ee9cb41a50b478f/src/drivers/alpha68k.c#L1134-L1139

Battlefield:
https://github.com/libretro/mame2003-plus-libretro/blob/2a2ba583af473b74376f580a4ee9cb41a50b478f/src/drivers/alpha68k.c#L1142
https://github.com/libretro/mame2003-plus-libretro/blob/2a2ba583af473b74376f580a4ee9cb41a50b478f/src/drivers/alpha68k.c#L1188-L1193

And lastly, here is an image showing the port number ranges to discrete 30 degree character positions for reference.
![image](https://github.com/libretro/mame2003-plus-libretro/assets/5027366/9de398f4-79b5-4539-8048-1399da8023f0)

Hopefully that is clear, but let me know if there are any questions.  Thanks.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
