### PR TITLE
Sys32 sound

### DIFF
--- a/src/drivers/segas32.c
+++ b/src/drivers/segas32.c
@@ -2884,7 +2884,7 @@ static struct MultiPCM_interface mul32_multipcm_interface =
 	{ MULTIPCM_MODE_MULTI32 },	/* banking mode*/
 	{ (512*1024) },	/* bank size*/
 	{ REGION_SOUND1 },	/* sample region*/
-	{ YM3012_VOL(100, MIXER_PAN_CENTER, 100, MIXER_PAN_CENTER) }
+	{ YM3012_VOL(60, MIXER_PAN_CENTER, 60, MIXER_PAN_CENTER) }
 };
 
 static struct MultiPCM_interface scross_multipcm_interface =
@@ -2894,7 +2894,7 @@ static struct MultiPCM_interface scross_multipcm_interface =
 	{ MULTIPCM_MODE_STADCROSS },	/* banking mode*/
 	{ (512*1024) },	/* bank size*/
 	{ REGION_SOUND1 },	/* sample region*/
-	{ YM3012_VOL(100, MIXER_PAN_CENTER, 100, MIXER_PAN_CENTER) }
+	{ YM3012_VOL(60, MIXER_PAN_CENTER, 60, MIXER_PAN_CENTER) }
 };
 
 

--- a/src/sound/rf5c68.c
+++ b/src/sound/rf5c68.c
@@ -43,6 +43,7 @@ struct rf5c68pcm *chip;
 /*    RF5C68 stream update                      */
 /************************************************/
 
+static INLINE int ILimit(int v, int max, int min) { return v > max ? max : (v < min ? min : v); }
 
 static void rf5c68_update( int num, INT16 **buffer, int length )
 {
@@ -91,33 +92,19 @@ static void rf5c68_update( int num, INT16 **buffer, int length )
 				if (sample & 0x80)
 				{
 					sample &= 0x7f;
-					left[j] += (sample * lv) >> 6;
-					right[j] += (sample * rv) >> 6;
+					left[j] +=  ILimit( ((sample * lv) >> 5) /2, 16383,-16384);
+					right[j] += ILimit( ((sample * rv) >> 5) /2, 16383,-16384);
 				}
 				else
 				{
-					left[j] -= (sample * lv) >> 6;
-					right[j] -= (sample * rv) >> 6;
+					left[j] -=  ILimit( ((sample * lv) >> 5) /2, 16383,-16384);
+					right[j] -= ILimit( ((sample * rv) >> 5) /2, 16383,-16384);
 				}
 			}
 		}
 	}
 
-	/* now clamp and shift the result (output is only 10 bits) */
-	for (j = 0; j < length; j++)
-	{
-		INT16 temp;
 
-		temp = left[j];
-		if (temp > 32767) temp = 32767;
-		else if (temp < -32768) temp = -32768;
-		left[j] = temp & ~0x3f;
-
-		temp = right[j];
-		if (temp > 32767) temp = 32767;
-		else if (temp < -32768) temp = -32768;
-		right[j] = temp & ~0x3f;
-	}
 }
 
 


### PR DESCRIPTION
fix orunner crackle originally thought is was the rf5 core but was the pcm core doing it. Regardless the clipping needed supported properly in the rf5 core.