### PR TITLE
Disable automatic savestate loading

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,7 +223,6 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
-    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,6 +223,7 @@ android-arm64-v8a:
     - .core-defs
   only:
     - master
+    - Test
 
 # Android 64-bit x86
 android-x86_64:

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -487,7 +487,15 @@ bool retro_serialize(void *data, size_t size)
 
 bool retro_unserialize(const void * data, size_t size)
 {
-    int cpunum;
+	int cpunum;
+
+	/* disable autostate loading */
+	if (cpu_getcurrentframe() == 0 ) 
+	{
+        usrintf_showmessage("Autostate loading disabled by core.");
+        return false;
+	}
+
 	/* if successful, load it */
 	if ( (retro_serialize_size() ) && ( data ) && ( size ) && ( !state_save_load_begin((void*)data, size) ) )
 	{

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -489,10 +489,10 @@ bool retro_unserialize(const void * data, size_t size)
 {
 	int cpunum;
 
-	/* disable autostate loading */
+	/* disable automatic savestate loading */
 	if (cpu_getcurrentframe() == 0 ) 
 	{
-        usrintf_showmessage("Autostate loading disabled by core.");
+        log_cb(RETRO_LOG_WARN, LOGPRE "Core is incompatible with automatic savestate loading.\n");
         return false;
 	}
 

--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -490,7 +490,7 @@ bool retro_unserialize(const void * data, size_t size)
 	int cpunum;
 
 	/* disable automatic savestate loading */
-	if (cpu_getcurrentframe() == 0 ) 
+	if (cpu_getcurrentframe() == 0) 
 	{
         log_cb(RETRO_LOG_WARN, LOGPRE "Core is incompatible with automatic savestate loading.\n");
         return false;


### PR DESCRIPTION
Feature is not compatible with many games and causes working games to load incorrectly or crash at startup.