### PR TITLE
For Dial and Dial-V ports, 3 instead of 2 malloc lines are allocated …

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1637,7 +1637,12 @@ static unsigned input_port_count(const struct InputPortTiny *src)
 	{
 		int type = src->type & ~IPF_MASK;
 		if (type > IPT_ANALOG_START && type < IPT_ANALOG_END)
-			total += 2;
+    {
+      if ((type == IPT_DIAL) || (type == IPT_DIAL_V))
+			  total += 3;
+      else
+			  total += 2;
+    }
 		else if (type != IPT_EXTENSION)
 			++total;
 		++src;


### PR DESCRIPTION
…now to fix memory allocation issue for ports.

Should fix https://github.com/libretro/mame2003-plus-libretro/issues/1816 .

I no longer get a malloc error with this PR.  But it looks like I still need to get the correct Pole Position 1 and 2 roms to test.  Should be able to verify that shortly.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
