### PR TITLE
Fix malloc error with input ports

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1637,13 +1637,13 @@ static unsigned input_port_count(const struct InputPortTiny *src)
 	{
 		int type = src->type & ~IPF_MASK;
 		if (type > IPT_ANALOG_START && type < IPT_ANALOG_END)
-    {
-      if ((type == IPT_DIAL) || (type == IPT_DIAL_V))
+    // {
+      // if ((type == IPT_DIAL) || (type == IPT_DIAL_V))
 			  total += 3;
-      else
-			  total += 2;
-    }
-		else if (type != IPT_EXTENSION)
+      // else
+			  // total += 2;
+    // }
+		else if ((type != IPT_EXTENSION) && (type != IPT_EXTENSION_II))
 			++total;
 		++src;
 	}
@@ -1672,13 +1672,8 @@ struct InputPort* input_port_allocate(const struct InputPortTiny *src)
 		InputCode seq_default;
 
 		if (type > IPT_ANALOG_START && type < IPT_ANALOG_END)
-    {
-      if ((type == IPT_DIAL) || (type == IPT_DIAL_V))
-        /* third port stores additional data */
-			  src_end = src + 3;
-      else
-			  src_end = src + 2;
-    }
+      /* third port stores additional data, currently only used by IPT_DIAL and IPT_DIAL_V */
+		  src_end = src + 3;
 		else
 			src_end = src + 1;
 

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -1637,12 +1637,7 @@ static unsigned input_port_count(const struct InputPortTiny *src)
 	{
 		int type = src->type & ~IPF_MASK;
 		if (type > IPT_ANALOG_START && type < IPT_ANALOG_END)
-    // {
-      // if ((type == IPT_DIAL) || (type == IPT_DIAL_V))
-			  total += 3;
-      // else
-			  // total += 2;
-    // }
+		  total += 3;
 		else if ((type != IPT_EXTENSION) && (type != IPT_EXTENSION_II))
 			++total;
 		++src;

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -78,6 +78,9 @@ enum { IPT_END=1,IPT_PORT,
 	IPT_EXTENSION,	/* this is an extension on the previous InputPort, not a real inputport. */
 					/* It is used to store additional parameters for analog inputs */
 
+	IPT_EXTENSION_II,	/* this is an extension onto the previous InputPort extension for analog ports, */
+                    /* not a real inputport. It is used to store additional parameters for analog inputs */
+
 	/* the following are special codes for user interface handling - not to be used by drivers! */
 	IPT_UI_CONFIGURE,
 	IPT_UI_ON_SCREEN_DISPLAY,
@@ -221,14 +224,14 @@ enum { IPT_END=1,IPT_PORT,
 #define PORT_ANALOG(mask,default,type,sensitivity,delta,min,max) \
 	PORT_BIT(mask, default, type) \
 	{ min, max, IPT_EXTENSION | IPF_SENSITIVITY(sensitivity) | IPF_DELTA(delta), IP_NAME_DEFAULT }, \
-	{ 0, 0, IPF_XWAYJOY_OFF, IP_NAME_DEFAULT },
+	{ 0, 0, IPT_EXTENSION_II | IPF_XWAYJOY_OFF, IP_NAME_DEFAULT },
 /* Both zeros above are not used */
 
 
 #define PORT_ANALOGX(mask,default,type,sensitivity,delta,min,max,keydec,keyinc,joydec,joyinc) \
 	PORT_BIT(mask, default, type) \
 	{ min, max, IPT_EXTENSION | IPF_SENSITIVITY(sensitivity) | IPF_DELTA(delta), IP_NAME_DEFAULT }, \
-	{ 0, 0, IPF_XWAYJOY_OFF, IP_NAME_DEFAULT }, \
+	{ 0, 0, IPT_EXTENSION_II | IPF_XWAYJOY_OFF, IP_NAME_DEFAULT }, \
 	PORT_CODE(keydec,joydec) \
 	PORT_CODE(keyinc,joyinc)
 /* Both zeros above are not used */

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -79,7 +79,8 @@ enum { IPT_END=1,IPT_PORT,
 					/* It is used to store additional parameters for analog inputs */
 
 	IPT_EXTENSION_II,	/* this is an extension onto the previous InputPort extension for analog ports, */
-                    /* not a real inputport. It is used to store additional parameters for analog inputs */
+                    /* not a real inputport. It is used to store additional parameters currently */
+                    /* only used by IPT_DIAL and IPT_DIAL_V analog inputs */
 
 	/* the following are special codes for user interface handling - not to be used by drivers! */
 	IPT_UI_CONFIGURE,


### PR DESCRIPTION
This looks to solve the issue https://github.com/libretro/mame2003-plus-libretro/issues/1822 .

I want to dig a little more to make sure I cover proper handling for IPT_EXTENSION_II (third line of input that I added in another PR at spots where IPT_EXTENSION is handled before calling this ready to merge.

I'll post more info about what I did in this PR in the issue noted above in a minute.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md**.
