### PR TITLE
update namoc52 and namco54 to mame 091 and tweak polepos sample

### DIFF
--- a/src/drivers/galaga.c
+++ b/src/drivers/galaga.c
@@ -1852,7 +1852,7 @@ static struct namco_interface namco_interface =
 static struct namco_52xx_interface namco_52xx_interface =
 {
 	18432000/12,	/* 1.536 MHz */
-	90,				/* volume */
+	80,				/* volume */
 	REGION_SOUND2,	/* memory region */
 	4000,			/* Playback frequency - from 555 timer 6M */
 	80,				/* High pass filter fc */
@@ -1865,13 +1865,13 @@ static struct namco_52xx_interface namco_52xx_interface =
 static struct namco_54xx_interface namco_54xx_interface =
 {
 	18432000/12,		/* 1.536 MHz */
-	90,				/* volume */
-	{ RES_K(100),	RES_K(47),		RES_K(150) },	/* R24, R33, R42 */
-	{ RES_K(22),	RES_K(10),		RES_K(22) },	/* R23, R34, R41 */
-	{ RES_K(220),	RES_K(150),		RES_K(470) },	/* R22, R35, R40 */
-	{ RES_K(33),	RES_K(33),		RES_K(10)},		/* R21, R36, R37 */
-	{ CAP_U(.001),	CAP_U(.01),		CAP_U(.01) },	/* C31, C29, C27 */
-	{ CAP_U(.001),	CAP_U(.01),		CAP_U(.01) },	/* C30, C28, C26 */
+	80,				/* volume */
+	{ RES_K(150),	RES_K(47),		RES_K(100) },	/* R42, R33, R24 */
+	{ RES_K(22),	RES_K(10),		RES_K(22) },	/* R41, R34, R23 */
+	{ RES_K(470),	RES_K(150),		RES_K(220) },	/* R40, R35, R22 */
+	{ RES_K(10),	RES_K(33),		RES_K(33)},		/* R37, R36, R21 */
+	{ CAP_U(.01),	CAP_U(.01),		CAP_U(.001) },	/* C27, C29, C31 */
+	{ CAP_U(.01),	CAP_U(.01),		CAP_U(.001) },	/* C26, C28, C30 */
 };
 
 static const char *bosco_sample_names[] =

--- a/src/drivers/gaplus.c
+++ b/src/drivers/gaplus.c
@@ -743,7 +743,7 @@ static struct namco_interface namco_interface =
 
 static const char *gaplus_sample_names[] =
 {
-	"*galaga",
+	"*gaplus",
 	"bang.wav",
 	0       /* end of array */
 };

--- a/src/drivers/polepos.c
+++ b/src/drivers/polepos.c
@@ -782,14 +782,26 @@ static struct namco_interface namco_interface =
 static struct namco_52xx_interface namco_52xx_interface =
 {
 	24576000/16,	/* 1.536 MHz */
-	25,				/* volume */
-	REGION_SOUND3	/* memory region */
+	80,				/* volume */
+	REGION_SOUND3,	/* memory region */
+	0,				/* Use internal Playback frequency */
+	100,			/* High pass filter fc */
+	0.3,			/* High pass filter Q */
+	1200,			/* Low pass filter fc */
+	0.8,			/* Low pass filter Q */
+	.5				/* Combined gain of both filters */
 };
 
 static struct namco_54xx_interface namco_54xx_interface =
 {
 	24576000/16,		/* 1.536 MHz */
-	{ 100, 100, 100 }	/* volume of the three outputs */
+	80,					/* volume */
+	{ RES_K(22),	RES_K(15),		RES_K(22) },	/* R121, R133, R139 */
+	{ RES_K(12),	RES_K(15),		RES_K(22) },	/* R125, R137, R143 */
+	{ RES_K(120),	RES_K(120),		RES_K(180) },	/* R122, R134, R140 */
+	{ 470,			470,			470 },			/* R123, R135, R141 */
+	{ CAP_U(.0022),	CAP_U(.022),	CAP_U(.047) },	/* C27,  C29,  C33  */
+	{ CAP_U(.0022),	CAP_U(.022),	CAP_U(.047) },	/* C28,  C30,  C34  */
 };
 
 static struct CustomSound_interface custom_interface =
@@ -802,14 +814,13 @@ static struct CustomSound_interface custom_interface =
 static const char *polepos_sample_names[] =
 {
 	"*polepos",
-	"pp2_17.wav",
 	"pp2_18.wav",
 	0	/* end of array */
 };
 
 static struct Samplesinterface samples_interface =
 {
-	2,	/* 2 channels */
+	1,	/* 1 channel */
 	40, /* volume */
 	polepos_sample_names
 };
@@ -863,7 +874,6 @@ static MACHINE_DRIVER_START( polepos )
 	MDRV_SOUND_ADD(CUSTOM, custom_interface)
 	MDRV_SOUND_ADD(SAMPLES, samples_interface)
 MACHINE_DRIVER_END
-
 
 /*********************************************************************
  * ROM definitions
@@ -2338,4 +2348,4 @@ GAME( 1983, polepos2a,  polepos2, polepos,    polepos2,  polepos2, ROT0, "Namco 
 GAME( 1983, polepos2b,  polepos2, polepos,    polepos2,  0,        ROT0, "bootleg",                 "Pole Position II (bootleg)")
 //GAME( 1984, polepos2bi, polepos2, polepos2bi, polepos2bi,polepos_state, empty_init,    ROT0, "bootleg",                 "Gran Premio F1 (Italian bootleg of Pole Position II)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND )
 //GAME( 1984, polepos2bs, polepos2, polepos2bi, polepos2bi,polepos_state, empty_init,    ROT0, "bootleg (BCN Internacional S.A.)", "Gran Premio F1 (Spanish bootleg of Pole Position II)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND )
-//GAME( 1984, grally,     polepos2, polepos2bi, polepos2bi,polepos_state, empty_init,    ROT0, "bootleg (Niemer)",   
+//GAME( 1984, grally,     polepos2, polepos2bi, polepos2bi,polepos_state, empty_init,    ROT0, "bootleg (Niemer)",        "Gran Rally (Spanish bootleg of Pole Position II)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_COLORS | MACHINE_IMPERFECT_SOUND )

--- a/src/sndhrdw/polepos_sndhrdw.c
+++ b/src/sndhrdw/polepos_sndhrdw.c
@@ -3,6 +3,7 @@
 	Sound handler
 ****************************************************************************/
 #include "driver.h"
+#include "../sound/filter.h"
 
 static int sample_msb = 0;
 static int sample_lsb = 0;
@@ -10,13 +11,30 @@ static int sample_enable = 0;
 
 static int sound_stream;
 
-#define AMP(r)	(r*128/10100)
-static int volume_table[8] =
+#define POLEPOS_R166		1000.0
+#define POLEPOS_R167		2200.0
+#define POLEPOS_R168		4700.0
+/* resistor values when shorted by 4066 running at 5V */
+#define POLEPOS_R166_SHUNT	1.0/(1.0/POLEPOS_R166 + 1.0/250)
+#define POLEPOS_R167_SHUNT	1.0/(1.0/POLEPOS_R166 + 1.0/250)
+#define POLEPOS_R168_SHUNT	1.0/(1.0/POLEPOS_R166 + 1.0/250)
+
+static double volume_table[8] =
 {
-	AMP(2200), AMP(3200), AMP(4400), AMP(5400),
-	AMP(6900), AMP(7900), AMP(9100), AMP(10100)
+	(POLEPOS_R168_SHUNT + POLEPOS_R167_SHUNT + POLEPOS_R166_SHUNT + 2200) / 10000,
+	(POLEPOS_R168_SHUNT + POLEPOS_R167_SHUNT + POLEPOS_R166       + 2200) / 10000,
+	(POLEPOS_R168_SHUNT + POLEPOS_R167       + POLEPOS_R166_SHUNT + 2200) / 10000,
+	(POLEPOS_R168_SHUNT + POLEPOS_R167       + POLEPOS_R166       + 2200) / 10000,
+	(POLEPOS_R168       + POLEPOS_R167_SHUNT + POLEPOS_R166_SHUNT + 2200) / 10000,
+	(POLEPOS_R168       + POLEPOS_R167_SHUNT + POLEPOS_R166       + 2200) / 10000,
+	(POLEPOS_R168       + POLEPOS_R167       + POLEPOS_R166_SHUNT + 2200) / 10000,
+	(POLEPOS_R168       + POLEPOS_R167       + POLEPOS_R166       + 2200) / 10000
 };
 
+static struct filter2_context filter_engine[3];
+
+static double r_filt_out[3] = {RES_K(4.7), RES_K(7.5), RES_K(10)};
+static double r_filt_total = 1.0 / (1.0/RES_K(4.7) + 1.0/RES_K(7.5) + 1.0/RES_K(10));
 
 /************************************/
 /* Stream updater                   */
@@ -24,9 +42,10 @@ static int volume_table[8] =
 static void engine_sound_update(int num, INT16 *buffer, int length)
 {
 	static UINT32 current_position;
-	UINT32 step, clock, slot, volume;
+	UINT32 step, clock, slot;
 	UINT8 *base;
-
+	double volume, i_total;
+	int loop;
 
 	/* if we're not enabled, just fill with 0 */
 	if (!sample_enable || Machine->sample_rate == 0)
@@ -47,7 +66,24 @@ static void engine_sound_update(int num, INT16 *buffer, int length)
 	/* fill in the sample */
 	while (length--)
 	{
-		*buffer++ = (base[(current_position >> 12) & 0x7ff] * volume);
+		filter_engine[0].x0 = (3.4 / 255 * base[(current_position >> 12) & 0x7ff] - 2) * volume;
+		filter_engine[1].x0 = filter_engine[0].x0;
+		filter_engine[2].x0 = filter_engine[0].x0;
+
+		i_total = 0;
+		for (loop = 0; loop < 3; loop++)
+		{
+			filter2_step(&filter_engine[loop]);
+			/* The op-amp powered @ 5V will clip to 0V & 3.5V.
+			 * Adjusted to vRef of 2V, we will clip as follows: */
+			if (filter_engine[loop].y0 > 1.5) filter_engine[loop].y0 = 1.5;
+			if (filter_engine[loop].y0 < -2)  filter_engine[loop].y0 = -2;
+
+			i_total += filter_engine[loop].y0 / r_filt_out[loop];
+		}
+		i_total *= r_filt_total * 32000/2;	/* now contains voltage adjusted by final gain */
+
+		*buffer++ = (int)i_total;
 		current_position += step;
 	}
 }
@@ -57,10 +93,30 @@ static void engine_sound_update(int num, INT16 *buffer, int length)
 /************************************/
 int polepos_sh_start(const struct MachineSound *msound)
 {
-	sound_stream = stream_init("Engine Sound", 25, Machine->sample_rate, 0, engine_sound_update);
+	sound_stream = stream_init("Engine Sound", 77, Machine->sample_rate, 0, engine_sound_update);
 	sample_msb = sample_lsb = 0;
 	sample_enable = 0;
+
+	/* setup the filters */
+	filter_opamp_m_bandpass_setup(RES_K(220), RES_K(33), RES_K(390), CAP_U(.01),  CAP_U(.01),
+									&filter_engine[0]);
+	filter_opamp_m_bandpass_setup(RES_K(150), RES_K(22), RES_K(330), CAP_U(.0047),  CAP_U(.0047),
+									&filter_engine[1]);
+	/* Filter 3 is a little different.  Because of the input capacitor, it is
+	 * a high pass filter. */
+	filter2_setup(FILTER_HIGHPASS, 950, Q_TO_DAMP(.707), 1,
+									&filter_engine[2]);
+
     return 0;
+}
+
+/************************************/
+/* Sound handler reset              */
+/************************************/
+void polepos_sh_reset(void)
+{
+	int loop;
+	for (loop = 0; loop < 3; loop++) filter2_reset(&filter_engine[loop]);
 }
 
 /************************************/
@@ -75,6 +131,7 @@ void polepos_sh_stop(void)
 /************************************/
 WRITE_HANDLER( polepos_engine_sound_lsb_w )
 {
+	/* Update stream first so all samples at old frequency are updated. */
 	stream_update(sound_stream, 0);
 	sample_lsb = data & 62;
     sample_enable = data & 1;

--- a/src/sndintrf.c
+++ b/src/sndintrf.c
@@ -725,7 +725,7 @@ struct snd_interface sndintf[] =
 		namco_52xx_sh_start,
 		namco_52xx_sh_stop,
 		0,
-		0
+		namco_52xx_sh_reset
 	},
 #endif
 #if (HAS_NAMCO_54XX)
@@ -737,7 +737,7 @@ struct snd_interface sndintf[] =
 		namco_54xx_sh_start,
 		namco_54xx_sh_stop,
 		0,
-		0
+		namco_54xx_sh_reset
 	},
 #endif
 #if (HAS_NAMCONA)

--- a/src/sound/filter.c
+++ b/src/sound/filter.c
@@ -1,4 +1,5 @@
 #include "filter.h"
+#include "driver.h"
 
 #include <assert.h>
 #include <math.h>
@@ -131,4 +132,104 @@ filter* filter_lp_fir_alloc(double freq, int order) {
 	f->order = i * 2 + 1;
 
 	return f;
+}
+
+
+void filter2_setup(int type, double fc, double d, double gain,
+					struct filter2_context *filter)
+{
+	double w;	/* cutoff freq, in radians/sec */
+	double w_squared;
+	double den;	/* temp variable */
+	double two_over_T = 2*Machine->sample_rate;
+	double two_over_T_squared = two_over_T * two_over_T;
+
+	/* calculate digital filter coefficents */
+	/*w = 2.0*M_PI*fc; no pre-warping */
+	w = Machine->sample_rate*2.0*tan(M_PI*fc/Machine->sample_rate); /* pre-warping */
+	w_squared = w*w;
+
+	den = two_over_T_squared + d*w*two_over_T + w_squared;
+
+	filter->a1 = 2.0*(-two_over_T_squared + w_squared)/den;
+	filter->a2 = (two_over_T_squared - d*w*two_over_T + w_squared)/den;
+
+	switch (type)
+	{
+		case FILTER_LOWPASS:
+			filter->b0 = filter->b2 = w_squared/den;
+			filter->b1 = 2.0*(filter->b0);
+			break;
+		case FILTER_BANDPASS:
+			filter->b0 = d*w*two_over_T/den;
+			filter->b1 = 0.0;
+			filter->b2 = -(filter->b0);
+			break;
+		case FILTER_HIGHPASS:
+			filter->b0 = filter->b2 = two_over_T_squared/den;
+			filter->b1 = -2.0*(filter->b0);
+			break;
+		default:
+			logerror("filter2_setup() - Invalid filter type for 2nd order filter.");
+			break;
+	}
+
+    filter->b0 *= gain;
+    filter->b1 *= gain;
+    filter->b2 *= gain;
+}
+
+
+/* Reset the input/output voltages to 0. */
+void filter2_reset(struct filter2_context *filter)
+{
+	filter->x0 = 0;
+	filter->x1 = 0;
+	filter->x2 = 0;
+	filter->y0 = 0;
+	filter->y1 = 0;
+	filter->y2 = 0;
+}
+
+
+/* Step the filter. */
+void filter2_step(struct filter2_context *filter)
+{
+	filter->y0 = -filter->a1 * filter->y1 - filter->a2 * filter->y2 +
+	                filter->b0 * filter->x0 + filter->b1 * filter->x1 + filter->b2 * filter->x2;
+	filter->x2 = filter->x1;
+	filter->x1 = filter->x0;
+	filter->y2 = filter->y1;
+	filter->y1 = filter->y0;
+}
+
+
+/* Setup a filter2 structure based on an op-amp multipole bandpass circuit. */
+void filter_opamp_m_bandpass_setup(double r1, double r2, double r3, double c1, double c2,
+					struct filter2_context *filter)
+{
+	double	r_in, fc, d, gain;
+
+	if (r1 == 0)
+	{
+		logerror("filter_opamp_m_bandpass_setup() - r1 can not be 0");
+		return;	/* Filter can not be setup.  Undefined results. */
+	}
+
+	if (r2 == 0)
+	{
+		gain = 1;
+		r_in = r1;
+	}
+	else
+	{
+		gain = r2 / (r1 + r2);
+		r_in = 1.0 / (1.0/r1 + 1.0/r2);
+	}
+
+	fc = 1.0 / (2 * M_PI * sqrt(r_in * r3 * c1 * c2));
+	d = (c1 + c2) / sqrt(r3 / r_in * c1 * c2);
+	gain *= -r3 / r_in * c2 / (c1 + c2);
+
+	filter2_setup(FILTER_BANDPASS, fc, d, gain, filter);
 }

--- a/src/sound/namco.c
+++ b/src/sound/namco.c
@@ -596,11 +596,6 @@ WRITE_HANDLER( polepos_sound_w )
 */
 
 
-WRITE_HANDLER( mappy_sound_enable_w ) /*remove this when drivers are updated this is so our old drivers work */
-{
-	sound_enable = offset;
-}
-
 void mappy_sound_enable(int enable)
 {
 	sound_enable = enable;

--- a/src/sound/namco.h
+++ b/src/sound/namco.h
@@ -19,7 +19,6 @@ WRITE_HANDLER( pengo_sound_w );
 void polepos_sound_enable(int enable);
 WRITE_HANDLER( polepos_sound_w );
 
-WRITE_HANDLER( mappy_sound_enable_w ); 
 void mappy_sound_enable(int enable);
 WRITE_HANDLER( namco_15xx_w );
 

--- a/src/sound/namco52.c
+++ b/src/sound/namco52.c
@@ -34,62 +34,122 @@ OUT = sound output
    GND|21  22|D0
       +------+
 
-[1] in polepos, GND; in bosco, output from a 555 timer
+[1] in polepos, GND; in bosco, 4kHz output from a 555 timer
 [2] in polepos, +5V; in bosco, GND
 [3] in polepos, these are true address lines, in bosco they are chip select lines
     (each one select one of the four ROM chips). Behaviour related to [2]?
 
 TODO:
 - the purpose of the 555 timer in bosco is unknown; maybe modulate the output?
+Jan 12, 2005.  The 555 is probably an external playback frequency.
 
 ***************************************************************************/
 
 #include "driver.h"
-#include "namco52.h"
-
-/* macro to convert 4-bit unsigned samples to 8-bit signed samples */
-#define SAMPLE_CONV4(a) (0x11*((a&0x0f))-0x80)
+#include "filter.h"
 
 
-static INT8 *samples;	/* 4-bit samples will be unpacked to 8-bit here */
-static int channel;		/* channel assigned by the mixer */
 static const struct namco_52xx_interface *intf;	/* pointer to our config data */
-static UINT8 *rom;		/* pointer to sample ROM */
+static UINT8 *rom;			/* pointer to sample ROM */
 static int rom_len;
+static int stream;			/* the output stream */
+static double n52_pb_cycle;	/* playback clock time based on machine sample rate */
+static double n52_step;		/* playback clock step based on machine sample rate */
+/* n52_pb_cycle is incremented by n52_step every machine-sample.
+ * At every integer value of n52_pb_cycle the next 4bit value is used. */
+static int n52_start;		/* current effect start position in the ROM */
+static int n52_end;			/* current effect end position in the ROM */
+static int n52_length;		/* # of 4bit samples in current effect */
+static int n52_pos;			/* current 4bit sample of effect */
+static struct filter2_context n52_hp_filter;
+static struct filter2_context n52_lp_filter;
 
+
+static void namco_52xx_stream_update_one(int num, INT16 *buffer, int length)
+{
+	int i, rom_pos, whole_pb_cycles, buf;
+
+	if (n52_start >= n52_end)
+	{
+		memset(buffer, 0, length * sizeof(INT16));
+		return;
+	}
+
+	for (i = 0; i < length; i++)
+	{
+		n52_pb_cycle += n52_step;
+		if (n52_pb_cycle >= 1)
+		{
+			whole_pb_cycles = (int)n52_pb_cycle;
+			n52_pos += whole_pb_cycles;
+			n52_pb_cycle -= whole_pb_cycles;
+		}
+
+		if (n52_pos > n52_length)
+		{
+			/* sample done */
+			memset(&buffer[i], 0, (length - i) * sizeof(INT16));
+			i = length;
+			namco_52xx_sh_reset();
+		}
+		else
+		{
+			/* filter and fill the buffer */
+			rom_pos = n52_start + (n52_pos >> 1);
+			/* get the 4bit sample from rom and shift to +7/-8 value */
+			n52_hp_filter.x0 = (((n52_pos & 1) ? rom[rom_pos] >> 4 : rom[rom_pos]) & 0x0f) - 0x08;
+			filter2_step(&n52_hp_filter);
+			n52_lp_filter.x0 = n52_hp_filter.y0;
+			filter2_step(&n52_lp_filter);
+			/* convert 4bit filtered to 16bit allowing room for filter gain */
+			buf = (int)(n52_lp_filter.y0 * 0x0fff);
+			if (buf > 32767) buf = 32767;
+			if (buf < -32768) buf = -32768;
+			buffer[i] = buf;
+		}
+	}
+}
+
+
+void namco_52xx_sh_reset(void)
+{
+	n52_pb_cycle = n52_start = n52_end = n52_length = n52_pos = 0;
+
+	filter2_reset(&n52_hp_filter);
+	filter2_reset(&n52_lp_filter);
+}
 
 int namco_52xx_sh_start(const struct MachineSound *msound)
 {
-	int i;
-	unsigned char bits;
-
 	intf = msound->sound_interface;
 	rom     = memory_region(intf->region);
 	rom_len = memory_region_length(intf->region);
 
-	channel = mixer_allocate_channel(intf->mixing_level);
-	mixer_set_name(channel,sound_name(msound));
-
-	samples = auto_malloc(2*rom_len);
-	if (!samples)
+	if (Machine->sample_rate == 0)
 		return 1;
 
-	/* decode the rom samples */
-	for (i = 0;i < rom_len;i++)
+	if (intf->play_rate == 0)
 	{
-		bits = rom[i] & 0x0f;
-		samples[2*i] = SAMPLE_CONV4(bits);
-
-		bits = (rom[i] & 0xf0) >> 4;
-		samples[2*i + 1] = SAMPLE_CONV4(bits);
+		/* If play clock is 0 (grounded) then default to internal clock */
+		n52_step = (double)(intf->baseclock) / 384 / Machine->sample_rate;
 	}
+	else
+	{
+		n52_step = intf->play_rate / Machine->sample_rate;
+	}
+	filter2_setup(FILTER_HIGHPASS, intf->hp_filt_fc, Q_TO_DAMP(intf->hp_filt_q), 1, &n52_hp_filter);
+	filter2_setup(FILTER_LOWPASS,  intf->lp_filt_fc, Q_TO_DAMP(intf->lp_filt_q), intf->filt_gain, &n52_lp_filter);
+
+
+	stream = stream_init(sound_name(msound), intf->mixing_level, Machine->sample_rate, 0, namco_52xx_stream_update_one);
+
+	/* handle failure */
+	if (stream == -1)
+		osd_die("Namco 52xx - Stream init returned an error\n");
+
+	namco_52xx_sh_reset();
 
 	return 0;
-}
-
-
-void namco_52xx_sh_stop(void)
-{
 }
 
 
@@ -97,20 +157,23 @@ void namcoio_52XX_write(int data)
 {
 	data &= 0x0f;
 
-/*logerror("%04x: custom 52XX write %02x\n",activecpu_get_pc(),data); */
-
-	if (Machine->sample_rate == 0)
-		return;
-
 	if (data != 0)
 	{
-		int start = rom[data-1] + (rom[data-1+0x10] << 8);
-		int end   = rom[data] + (rom[data+0x10] << 8);
+		stream_update(stream, 0);
 
-		if (end >= rom_len)
-			end = rom_len;
+		n52_start = rom[data-1] + (rom[data-1+0x10] << 8);
+		n52_end = rom[data] + (rom[data+0x10] << 8);
 
-		if (start < end)
-			mixer_play_sample(channel, samples + start * 2, (end - start) * 2, intf->baseclock/384, 0);
+		if (n52_end >= rom_len)
+			n52_end = rom_len;
+
+		n52_length = (n52_end - n52_start) * 2;
+		n52_pos = 0;
+		n52_pb_cycle= 0;
 	}
+}
+
+
+void namco_52xx_sh_stop(void)
+{
 }

--- a/src/sound/namco52.h
+++ b/src/sound/namco52.h
@@ -1,16 +1,38 @@
 #ifndef namco52_h
 #define namco52_h
 
+/* While a little confusing, this interface uses 2 gains.
+ *
+ * "mixing_level" is the relative level of the signal
+ * compared to other effects before entering the filter.
+ *
+ * "filt_gain" is the combined gain of the filters.
+ *
+ * If I did not do it this way, then the filters could
+ * cause the signal to go beyond the 16bit range.
+ *
+ * If "play_rate" is 0 (ground) then the sample clock rate
+ * defaults to the 52xx internal sample clock. (baseclock/384)
+ */
+
 struct namco_52xx_interface
 {
-	int baseclock;		/* clock */
-	int mixing_level;	/* volume */
-	int region;			/* memory region */
+	int		baseclock;		/* clock */
+	int		mixing_level;	/* volume */
+	int		region;			/* memory region */
+	double	play_rate;		/* Playback frequency */
+	double	hp_filt_fc;
+	double	hp_filt_q;
+	double	lp_filt_fc;
+	double	lp_filt_q;
+	double	filt_gain;
 };
 
 int namco_52xx_sh_start(const struct MachineSound *msound);
+void namco_52xx_sh_reset(void);
 void namco_52xx_sh_stop(void);
 
 void namcoio_52XX_write(int data);
 
 #endif
+

--- a/src/sound/namco54.c
+++ b/src/sound/namco54.c
@@ -555,9 +555,9 @@ void NAMCO54xxUpdateOne(int num, INT16 **buffers, int length)
 			if (filter54[loop].y0 < -2) filter54[loop].y0 = -2;
 		}
 
-		(buf1)[i] = filter54[0].y0 * (32768/2);
-		(buf2)[i] = filter54[1].y0 * (32768/2);
-		(buf3)[i] = filter54[2].y0 * (32768/2);
+		(buf1)[i] = filter54[0].y0 * (16384/2);
+		(buf2)[i] = filter54[1].y0 * (16384/2);
+		(buf3)[i] = filter54[2].y0 * (16384/2);
 
 		advance();
 	}
@@ -630,15 +630,16 @@ logerror("%04x: custom 54XX write %02x\n",activecpu_get_pc(),data);
 				/* 0x7n = Screech sound. n = volume (if 0 then no sound) */
 				/* followed by 0x60 command */
 #if 1
-			if (( data & 0x0f ) == 0)
+			if ( data == 112 ) 
 			{
 				if (sample_playing(0))
 					sample_stop(0);
 			}
 			else
 			{
-				int freq = (int)( ( 44100.0f / 10.0f ) * (float)(data & 0x0f) ); /* this is wrong, it's a volume and not a freq */
-
+				//int freq = (int)( ( 22050.0f / 10.0f ) * (float)(data & 0x0f) ); /* this is wrong, it's a volume and not a freq */
+				int freq = (int)  22050 + (data - 112)* 750;
+				
 				if (!sample_playing(0))
 					sample_start(0, 0, 1);
 				sample_set_freq(0, freq);

--- a/src/sound/namco54.c
+++ b/src/sound/namco54.c
@@ -8,6 +8,8 @@ generator (mostly for explosions).
 CMD = command from CPU
 OUTn = sound outputs (3 channels)
 
+The chip will read the command when the /IRQ is pulled down.
+
       +------+
  EXTAL|1   28|Vcc
   XTAL|2   27|CMD7
@@ -25,36 +27,548 @@ OUT1.3|11  18|OUT2.1
    GND|14  15|CMD2
       +------+
 
+The command format is very simple:
+
+00: nop
+10: play sound type A
+20: play sound type B
+30: set parameters (type A) (followed by 4 bytes)
+40: set parameters (type B) (followed by 4 bytes)
+50: play sound type C, mode A
+60: set parameters (type C) (followed by 5 bytes)
+7x: play sound type C, mode B (pole position)
+80-ff: nop
+
+
+Behaviour:
+----------
+If the chip is instructed to play the sound while it is still playing
+- it will immediately restart playing it from the beginning, i.e. retrigger
+when the same play command is send more than once, fast
+(for example 10,10 or 20,20)
+
+If the chip is instructed to set the parameters with any of the commands: 30,
+40 or 60, while it is playing any sounds then the sound reproduction will be
+hold on until the last of the parameters is written. Then the chip continues
+the sound reproduction as if nothing happend.
+
+The parameters changed during sound reproduction don't take immediate effect.
+For example, if the volume of the sustain parameter was changed while the chip
+is playing the sustain part then the sustain volume will not change.
+However, if the volume of the release part is changed while the chip is playing
+the sustain or the pause parts then the chip will play the release part using
+the newly set volume.
+
+The noise generator output used by the type B is delayed by ~209 clock cycles
+if compared to the noise generator used by the type A.
+
+
 TODO:
-- The chip is not understood yet; this file is little more than a placeholder,
-  playing samples when it receives known command sequences.
+- The type C RNG configuration for the noise generator and a frequency
+  modulation formula [todo 2: (both are approximated for now)]
+
 
 ***************************************************************************/
 
 #include "driver.h"
-#include "namco54.h"
+#include "filter.h"
+
+
+static int fetch;
+static int fetchmode;
+static int type_A_active;
+static int type_B_active;
+static int type_C_active;
+
+static int type_A_state;	/* current envelope state */
+static int type_B_state;	/* current envelope state */
+static int type_C_state;	/* current envelope state */
+
+
+static int type_A_pos;		/* type A 'position' in time within the envelope state */
+static int type_A_add;		/* type A 'position' delta (step per one sample at the target frequency)*/
+static int type_A_curr_vol;	/* type A current volume */
+static int type_A_rel_pos;	/* type A index in release volume table */
+
+
+static int type_B_pos;		/* type B 'position' in time */
+static int type_B_add;		/* type B 'position' delta (step per one sample at the target frequency)*/
+static int type_B_curr_vol;	/* type B current volume */
+static int type_B_rel_pos;	/* type B index in release volume table */
 
 
 
-int namco_54xx_sh_start(const struct MachineSound *msound)
+
+/* noise generators */
+static int RNG;			/* shift register */
+static int RNG_p;		/* shift register 'position' in time */
+static int RNG_f_0;		/* shift register 'speed' per one sample at the target frequency at the zero level */
+static int RNG_f_1;		/* shift register 'speed' per one sample at the target frequency at the one level */
+static int RNG_delay;		/* delay between the type A output change and the following type B output change */
+static int out_prev;		/* work variable (previous noise output state) */
+static int noise_out_A;		/* noise output used in type A */
+static int noise_out_B;		/* noise output used in type B */
+static int noise_B_will_change;	/* in order to implement the delay between the RNG output in type A and the type B */
+static int RNG_p_delay_B;	/* in order to implement the delay between the RNG output in type A and the type B */
+
+
+/* parameters */
+static UINT8 type_A_par[4];
+static UINT8 type_B_par[4];
+static UINT8 type_C_par[5];
+
+
+#define ENV_OFF     0
+#define ENV_SUSTAIN 1
+#define ENV_PAUSE   2
+#define ENV_RELEASE 3
+
+
+
+#define PRECISION_SH	26	/* 6.26 fixed point for all the 'position' calculations */
+#define PRECISION_MASK	((1<<PRECISION_SH)-1)
+
+
+static const struct namco_54xx_interface *intf;
+static double chip_clock;
+static double chip_sampfreq;
+
+static int stream;
+
+
+#define NAMCO54xx_NUMBUF 3
+
+
+/*
+
+TYPE A
+======
+
+The type A sound is based on the output of the RNG implemented as a 15-bits long
+shift register in a following configuration: 1 + x^4 + x^15.
+The binary RNG output is then multiplied by an envelope that is consisted of three 'parts': sustain, pause and release.
+The envelope has its initial volumes and speeds/lengths.
+
+
+The type A parameters description:
+----------------------------------
+0 - length of the 1st part (sustain)
+1 - pause length (a zero-level output part between the sustain and the release parts)
+2 - release part speed
+3 - volumes
+
+
+(general note: nibbles of the parameters need to be swapped for more natural reading.)
+
+
+parameter 0: (values on the right represent the number of samples the sustain part takes at sampfreq=44100, chip clock = 1.8432 MHz)
+08 - 30389
+04 - 15262
+02 - 7541
+01 - 3705
+80 - 1833
+40 - 903
+20 - 430
+10 - 165
+00 - 24 (1003)
+
+parameter 1: (values on the right represent the number of samples that the pause takes at sampfreq=44100, chip clock = 1.8432 MHz)
+08 - 30597
+04 - 15469
+02 - 7940
+01 - 4045
+80 - 2167
+40 - 1176
+20 - 788
+10 - 549
+00 - no pause at all !!!
+
+
+parameter 2: release speed (no of samples per one level) (number of chip clock cycles)
+08 - 30630 (1280209)
+04 - 15443 (645454)
+02 - 7835  (327471)
+01 - 4029  (168395)
+80 - 2139  (89401)
+40 - 1183  (49444)
+20 - 717   (29967)
+10 - 477   (19936)
+00 - no release at all !!!
+
+parameter 3: volumes for the sustain and the release parts
+SR - S is the volume of the sustain part; R is an initial volume of the release part (see: release_table)
+
+*/
+
+static int cycles_per_bit[8]=
 {
+19936,
+29967,
+49444,
+89401,
+168395,
+327471,
+645454,
+1280209
+};
+
+static INT32 speeds[257];	/* calculated at init time */
+
+static UINT8 release_table[16][8]=
+{
+{ 0, 0,0,0,0,0,0,0},
+{ 1, 0,0,0,0,0,0,0},
+{ 2, 1,0,0,0,0,0,0},
+{ 3, 2,1,0,0,0,0,0},
+{ 4, 3,2,1,0,0,0,0},
+{ 5, 3,2,1,0,0,0,0},
+{ 6, 4,3,2,1,0,0,0},
+{ 7, 5,3,2,1,0,0,0},
+{ 8, 6,4,3,2,1,0,0},
+{ 9, 6,4,3,2,1,0,0},
+{10, 7,5,3,2,1,0,0},
+{11, 7,6,4,3,2,1,0},
+{12, 9,6,4,3,2,1,0},
+{13, 9,6,4,3,2,1,0},
+{14,10,7,5,3,2,1,0},
+{15,11,8,6,4,3,2,1}
+};
+
+static struct filter2_context filter54[3];
+
+
+void namco_54xx_sh_reset(void)
+{
+	int loop;
+	for (loop = 0; loop < 3; loop++) filter2_reset(&filter54[loop]);
+
+	fetch = 0;
+	fetchmode = 0;
+
+	type_A_active = 0; /* 0 inactive; 1 active */
+	type_B_active = 0; /* 0 inactive; 1 active */
+	type_C_active = 0; /* 0 inactive; 1 active in mode A; 2 active in mode B */
+
+
+	type_A_state = ENV_OFF;
+	type_B_state = ENV_OFF;
+	type_C_state = ENV_OFF;
+
+
+	/* RNG_f_x are initialized in sh_start */
+	RNG_p = 0;
+	RNG = 0xfff;
+	noise_out_A = RNG&1;
+	noise_out_B = 0;
+	noise_B_will_change = 0;
+	out_prev = 0;
+
+//wonder what are the default params after the reset ?
+
+}
+
+
+static void start_A(void)
+{
+	int v;
+
+	type_A_active = 1; /* 0 inactive; 1 active */
+	type_A_state = ENV_SUSTAIN;
+	type_A_pos = 0;
+
+	v = type_A_par[0];	/* sustain length */
+	v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+	if (v)
+		type_A_add = speeds[v];
+	else
+		type_A_add = speeds[256];  /* zero sustain actually takes some time */
+	type_A_curr_vol = (type_A_par[3]>>4) & 0x0f;	/* sustain volume */
+}
+
+static void start_B(void)
+{
+	int v;
+
+	type_B_active = 1; /* 0 inactive; 1 active */
+	type_B_state = ENV_SUSTAIN;
+	type_B_pos = 0;
+
+	v = type_B_par[0];
+	v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+	if (v)
+		type_B_add = speeds[v];
+	else
+		type_B_add = speeds[256];  /* zero sustain actually takes some time */
+	type_B_curr_vol = (type_B_par[3]>>4) & 0x0f;	/* sustain volume */
+}
+
+
+/* call one time per sample at the _target_ frequency */
+static void noise_step(void)
+{
+int b04, b15;
+int i;
+
+	/* two different lenghts depending on the output level */
+	if (noise_out_A)
+		RNG_p += RNG_f_1;
+	else
+		RNG_p += RNG_f_0;
+
+	i = (RNG_p>>PRECISION_SH);		/* number of the events (shifts of the shift register) */
+	RNG_p &= PRECISION_MASK;
+
+	if (noise_B_will_change == 0)
+		RNG_p_delay_B = RNG_p;		/* preinitalize delay counter */
+
+	while (i)
+	{
+		b15 = (RNG>>0) & 1;
+		b04 = (RNG>>11)& 1;
+		noise_out_A = RNG&1;
+
+		if ( (out_prev != noise_out_A) && (noise_out_A == 0) ) /* OK = 0 for type B */
+		{
+			/* matters if it changes odd number of times, even number of changes is equal to no change at all*/
+			noise_B_will_change ^= 1;
+		}
+		out_prev = noise_out_A;
+
+		RNG = (RNG>>1) | ((b04^b15)<<14);
+
+		i--;
+	}
+	if (noise_B_will_change)
+	{
+		RNG_p_delay_B += RNG_delay;
+		i = (RNG_p_delay_B>>PRECISION_SH);/* number of the events (shifts of the shift register) */
+		if (i)
+		{
+			noise_out_B ^= 1;
+			noise_B_will_change = 0;
+		}
+	}
+}
+
+
+static INT16 calc_A(void)
+{
+//if (type_A_active)
+//	logerror("calc a: env_state=%2i vol=%2i noise=%2i\n", type_A_state, type_A_curr_vol, noise_out_A);
+
+	switch (type_A_state)
+	{
+	case ENV_OFF:
+	default:
+		return 0;
+		break;
+
+	case ENV_SUSTAIN:
+		return (noise_out_A * type_A_curr_vol);
+		break;
+
+	case ENV_PAUSE:
+		return 0;
+		break;
+
+	case ENV_RELEASE:
+		return (noise_out_A * release_table[ type_A_curr_vol ] [ type_A_rel_pos ] );
+		break;
+	}
+}
+static INT16 calc_B(void)
+{
+	switch (type_B_state)
+	{
+	case ENV_OFF:
+	default:
+		return 0;
+		break;
+
+	case ENV_SUSTAIN:
+		return (noise_out_B * type_B_curr_vol);
+		break;
+
+	case ENV_PAUSE:
+		return 0;
+		break;
+
+	case ENV_RELEASE:
+		return (noise_out_B * release_table[ type_B_curr_vol ] [ type_B_rel_pos ] );
+		break;
+	}
+}
+
+static INT16 calc_C(void)
+{
+
 	return 0;
 }
 
 
-void namco_54xx_sh_stop(void)
+
+
+static void advance(void)
 {
+int i,v;
+
+//type A
+	type_A_pos += type_A_add;
+	i = (type_A_pos >> PRECISION_SH);
+	type_A_pos &= PRECISION_MASK;
+
+	if (i)
+	{	//switch to the next envelope state
+
+		//logerror("type A switch, from mode=%2i\n",type_A_state);
+
+		switch(type_A_state)
+		{
+		case ENV_OFF:
+		default:
+			break;
+
+		case ENV_SUSTAIN:
+			type_A_state = ENV_PAUSE;
+			type_A_curr_vol = 0;
+			v = type_A_par[1];	/* pause length */
+			v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+			type_A_add = speeds[v];
+			break;
+
+		case ENV_PAUSE:
+			type_A_state = ENV_RELEASE;
+			type_A_curr_vol = (type_A_par[3]&0x0f);
+			type_A_rel_pos = 0;
+			v = type_A_par[2];	/* release length */
+			v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+			type_A_add = speeds[v];
+			break;
+
+		case ENV_RELEASE:
+			if (type_A_rel_pos<7)
+			{
+				v = type_A_par[2];	/* release length */
+				v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+				type_A_add = speeds[v];
+				type_A_rel_pos++;
+			}
+			else
+			{
+				type_A_state = ENV_OFF;
+			}
+			break;
+		}
+	}
+
+
+//type B
+	type_B_pos += type_B_add;
+	i = (type_B_pos >> PRECISION_SH);
+	type_B_pos &= PRECISION_MASK;
+
+	if (i)
+	{	//switch to the next envelope state
+
+		//logerror("type B switch, from mode=%2i\n",type_B_state);
+
+		switch(type_B_state)
+		{
+		case ENV_OFF:
+		default:
+			break;
+
+		case ENV_SUSTAIN:
+			type_B_state = ENV_PAUSE;
+			type_B_curr_vol = 0;
+			v = type_B_par[1];	/* pause length */
+			v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+			type_B_add = speeds[v];
+			break;
+
+		case ENV_PAUSE:
+			type_B_state = ENV_RELEASE;
+			type_B_curr_vol = (type_B_par[3]&0x0f);
+			type_B_rel_pos = 0;
+			v = type_B_par[2];	/* release length */
+			v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+			type_B_add = speeds[v];
+			break;
+
+		case ENV_RELEASE:
+			if (type_B_rel_pos<7)
+			{
+				v = type_B_par[2];	/* release length */
+				v = ((v&0xf0)>>4) | ((v&0x0f)<<4); /*swap the nibbles */
+				type_B_add = speeds[v];
+				type_B_rel_pos++;
+			}
+			else
+			{
+				type_B_state = ENV_OFF;
+			}
+			break;
+		}
+	}
+
+
+
+
+//TODO type C
+
+
+	noise_step();
+
+}
+
+
+
+void NAMCO54xxUpdateOne(int num, INT16 **buffers, int length)
+{
+	int i, loop;
+	INT16 out1, out2, out3;
+	INT16 *buf1, *buf2, *buf3;
+
+	buf1 = buffers[0];
+	buf2 = buffers[1];
+	buf3 = buffers[2];
+
+	for (i = 0; i < length; i++)
+	{
+		//if (fetch) /* no sound is produced while waiting for the parameters */
+
+		out1 = calc_A();	/* pins 4-7 */
+		out2 = calc_B();	/* pins 8-11 */
+		out3 = calc_C();	/* pins 17-20 */
+
+		/* Convert the binary value to a voltage and filter it. */
+		/* I am assuming a 4V output when a bit is high. */
+		filter54[0].x0 = 4.0/15 * out1 - 2;
+		filter54[1].x0 = 4.0/15 * out2 - 2;
+		filter54[2].x0 = 4.0/15 * out3 - 2;
+		for (loop = 0; loop < 3; loop++)
+		{
+			filter2_step(&filter54[loop]);
+			/* The op-amp powered @ 5V will clip to 0V & 3.5V.
+			 * Adjusted to vRef of 2V, we will clip as follows: */
+			if (filter54[loop].y0 > 1.5) filter54[loop].y0 = 1.5;
+			if (filter54[loop].y0 < -2) filter54[loop].y0 = -2;
+		}
+
+		(buf1)[i] = filter54[0].y0 * (32768/2);
+		(buf2)[i] = filter54[1].y0 * (32768/2);
+		(buf3)[i] = filter54[2].y0 * (32768/2);
+
+		advance();
+	}
 }
 
 
 void namcoio_54XX_write(int data)
 {
-	static int fetch;
-	static int fetchmode;
-	static UINT8 config1[4],config2[4],config3[5];
+logerror("%04x: custom 54XX write %02x\n",activecpu_get_pc(),data);
 
-
-/*logerror("%04x: custom 54XX write %02x\n",activecpu_get_pc(),data); */
+	stream_update(stream, 0);
 
 	if (fetch)
 	{
@@ -62,15 +576,15 @@ void namcoio_54XX_write(int data)
 		{
 			default:
 			case 1:
-				config1[4-(fetch--)] = data;
+				type_A_par[4-(fetch--)] = data;
 				break;
 
 			case 2:
-				config2[4-(fetch--)] = data;
+				type_B_par[4-(fetch--)] = data;
 				break;
 
 			case 3:
-				config3[5-(fetch--)] = data;
+				type_C_par[5-(fetch--)] = data;
 				break;
 		}
 	}
@@ -78,75 +592,162 @@ void namcoio_54XX_write(int data)
 	{
 		switch (data & 0xf0)
 		{
-			case 0x00:	/* nop */
-				break;
+		case 0x00:	/* nop */
+		default:
+			break;
 
-			case 0x10:	/* output sound on pins 4-7 only */
-				if (memcmp(config1,"\x40\x00\x02\xdf",4) == 0)
-					/* bosco */
-					/* galaga */
-					/* xevious */
-					sample_start(0, 0, 0);
-				else if (memcmp(config1,"\x10\x00\x80\xff",4) == 0)
-					/* xevious */
-					sample_start(0, 1, 0);
-				else if (memcmp(config1,"\x80\x80\x01\xff",4) == 0)
-					/* xevious */
-					sample_start(0, 2, 0);
-				break;
+		case 0x10:	/* type A start, output sound on pins 4-7 only */
+			start_A();
+			break;
 
-			case 0x20:	/* output sound on pins 8-11 only */
-				if (memcmp(config2,"\x40\x40\x01\xff",4) == 0)
-					/* xevious */
-					sample_start(1, 3, 0);
-				else if (memcmp(config2,"\x30\x30\x03\xdf",4) == 0)
-					/* bosco */
-					/* galaga */
-					sample_start(1, 1, 0);
-				else if (memcmp(config2,"\x60\x30\x03\x66",4) == 0)
-					/* polepos */
-					sample_start( 0, 0, 0 );
-				break;
+		case 0x20:	/* type B, output sound on pins 8-11 only */
+			start_B();
+			break;
 
-			case 0x30:
-				fetch = 4;
-				fetchmode = 1;
-				break;
+		case 0x30:	/* type A parameters input mode */
+			fetch = 4;
+			fetchmode = 1;
+			break;
 
-			case 0x40:
-				fetch = 4;
-				fetchmode = 2;
-				break;
+		case 0x40:	/* type B parameters input mode */
+			fetch = 4;
+			fetchmode = 2;
+			break;
 
-			case 0x50:	/* output sound on pins 17-20 only */
-				if (memcmp(config3,"\x08\x04\x21\x00\xf1",5) == 0)
-					/* bosco */
-					sample_start(2, 2, 0);
-				break;
+		case 0x50:	/* type C, mode A, output sound on pins 17-20 only */
+			if (memcmp(type_C_par,"\x08\x04\x21\x00\xf1",5) == 0)
+				// bosco
+				sample_start(0, 0, 0);
+			break;
 
-			case 0x60:
-				fetch = 5;
-				fetchmode = 3;
-				break;
+		case 0x60:	/* type C parameters input mode */
+			fetch = 5;
+			fetchmode = 3;
+			break;
 
-			case 0x70:
-				/* polepos */
-				/* 0x7n = Screech sound. n = pitch (if 0 then no sound) */
-				/* followed by 0x60 command? */
-				if (( data & 0x0f ) == 0)
-				{
-					if (sample_playing(1))
-						sample_stop(1);
-				}
-				else
-				{
-					int freq = (int)( ( 44100.0f / 10.0f ) * (float)(data & 0x0f) );
+		case 0x70:	/* type C, mode B, output sound on pins 17-20 only */
+				// polepos
+				/* 0x7n = Screech sound. n = volume (if 0 then no sound) */
+				/* followed by 0x60 command */
+#if 1
+			if (( data & 0x0f ) == 0)
+			{
+				if (sample_playing(0))
+					sample_stop(0);
+			}
+			else
+			{
+				int freq = (int)( ( 44100.0f / 10.0f ) * (float)(data & 0x0f) ); /* this is wrong, it's a volume and not a freq */
 
-					if (!sample_playing(1))
-						sample_start(1, 1, 1);
-					sample_set_freq(1, freq);
-				}
-				break;
+				if (!sample_playing(0))
+					sample_start(0, 0, 1);
+				sample_set_freq(0, freq);
+			}
+#endif
+			break;
 		}
 	}
+}
+
+
+
+
+int namco_54xx_sh_start(const struct MachineSound *msound)
+{
+	char buf[NAMCO54xx_NUMBUF][40];
+	const char *name[NAMCO54xx_NUMBUF];
+	int vol[NAMCO54xx_NUMBUF];
+
+	double scaler, c_value, r_in, r_min;
+	int i;
+
+	intf = msound->sound_interface;
+
+	/* setup the filters */
+	r_min = intf->r4[0];
+	for (i = 0; i < 3; i++)
+	{
+		r_in = intf->r1[i] + ( 1.0 / ( 1.0/4700 + 1.0/10000 + 1.0/22000 + 1.0/47000));
+		filter_opamp_m_bandpass_setup(r_in, intf->r2[i], intf->r3[i], intf->c1[i], intf->c2[i],
+										&filter54[i]);
+		if (intf->r4[i] < r_min) r_min = intf->r4[i];
+	}
+
+	/* setup relative gains */
+	for (i = 0; i < 3; i++)
+	{
+		scaler = r_min / intf->r4[i];
+		filter54[i].b0 *= scaler;
+	    filter54[i].b1 *= scaler;
+	    filter54[i].b2 *= scaler;
+	}
+
+	chip_clock    = intf->baseclock;
+	chip_sampfreq = Machine->sample_rate;
+
+	if( chip_sampfreq == 0 ) chip_sampfreq = 1000;	/* kludge to prevent nasty crashes */
+
+	for (i = 0; i < NAMCO54xx_NUMBUF; i++)
+	{
+		vol[i] = intf->mixing_level;
+		name[i] = buf[i];
+		sprintf(buf[i],"%s Ch %d",sound_name(msound),i);
+	}
+
+	stream = stream_init_multi(NAMCO54xx_NUMBUF, name, vol, chip_sampfreq, 0, NAMCO54xxUpdateOne);
+
+	logerror("Namco 54xx clock=%f sample rate=%f\n", chip_clock, chip_sampfreq);
+
+	/* calculate emulation tables */
+	scaler = chip_clock / chip_sampfreq;
+
+/* 1254 chip clock cycles per _two_ shifts of the RNG (when o follows 1 directly);
+exactly speaking: 0-level lasts for 13 samples while 1-level lasts for 17 samples - this gives 30 samples
+altogether which corresponds to 1254 chip clock cycles. 13 samples = 543 cycles, 17 samples= 711 cycles.
+
+*/
+	c_value = ((double)(1<<PRECISION_SH)) / 543.0;
+	RNG_f_0 = c_value * scaler;	/* scaled to our sample rate */
+	c_value = ((double)(1<<PRECISION_SH)) / 711.0;
+	RNG_f_1 = c_value * scaler;	/* scaled to our sample rate */
+
+	c_value = ((double)(1<<PRECISION_SH)) / 209.0;
+	RNG_delay = c_value * scaler;	/* scaled to our sample rate */
+
+	logerror("rng_f_0  =%08x\n", RNG_f_0);
+	logerror("rng_f_1  =%08x\n", RNG_f_1);
+	logerror("rng_delay=%08x\n", RNG_delay);
+
+	/* 0 means no particular part so we allow 1 cycle */
+	c_value = ((double)(1<<PRECISION_SH)) / 1.0;
+	speeds[0] = c_value * scaler;	/* scaled to our sample rate */
+	logerror("speed[%2i]=%08x\n", 0, speeds[0]);
+
+	for (i = 1; i < 256; i++)
+	{
+		int cycles_num, j;
+
+		cycles_num = 0;
+		for (j=0; j<8; j++)
+		{
+			if (i&(1<<j))
+				cycles_num += cycles_per_bit[j];
+		}
+		c_value = ((double)(1<<PRECISION_SH)) / ((double)cycles_num);
+		speeds[i] = c_value * scaler;	/* scaled to our sample rate */
+		logerror("speed[%2i]=%08x\n", i, speeds[i]);
+	}
+
+	/* special case for sustain param =0, which takes 1003 cycles */
+	c_value = ((double)(1<<PRECISION_SH)) / 1003.0;
+	speeds[256] = c_value * scaler;	/* scaled to our sample rate */
+	logerror("speed[%2i]=%08x\n", 256, speeds[256]);
+
+
+	namco_54xx_sh_reset();
+	return 0;
+}
+
+void namco_54xx_sh_stop(void)
+{
 }

--- a/src/sound/namco54.h
+++ b/src/sound/namco54.h
@@ -1,13 +1,42 @@
 #ifndef namco54_h
 #define namco54_h
 
+
+/*
+ * The 4 bit output of each channel is passed through a bandpass filter.
+ * D0 - D3 are probably TTL level.  I will round it up to 4V until measured.
+ * R1, R2, R3, C1, C2 select the filter specs.  R4 is for mixing.
+ *
+ *         4.7k
+ *   D3 >--ZZZZ--.                       .--------+---------.
+ *               |                       |        |         |
+ *          10k  |                      --- c1    Z         |
+ *   D2 >--ZZZZ--+                      ---       Z r3      |
+ *               |                       |        Z         |
+ *          22k  |      r1               |  c2    |  |\ 5V  |
+ *   D1 >--ZZZZ--+-----ZZZZ----+---------+--||----+  | \|   |
+ *               |             Z                  '--|- \   |     r4
+ *          47k  |             Z r2                  |   >--+----ZZZZ--> out
+ *   D0 >--ZZZZ--'             Z                  .--|+ /
+ *                             |                  |  | /|
+ *                            gnd          2V >---'  |/ gnd
+ *
+ */
+
 struct namco_54xx_interface
 {
-	int baseclock;			/* clock */
-	int mixing_level[3];	/* volume of the 3 output ports */
+	int		baseclock;		/* clock */
+	int		mixing_level;	/* volume */
+	double	r1[3];
+	double	r2[3];
+	double	r3[3];
+	double	r4[3];
+	double	c1[3];
+	double	c2[3];
 };
 
 int namco_54xx_sh_start(const struct MachineSound *msound);
+void namco_54xx_sh_reset(void);
 void namco_54xx_sh_stop(void);
 
 void namcoio_54XX_write(int data);


### PR DESCRIPTION
This has been checked at https://github.com/libretro/mame2003-plus-libretro/issues/1823#issuecomment-2308376719. The new polepos sample I took from mame should be used but feel free to test the original and the alt in that thread ill include the sample I took from mame in this pull request.

[polepos.zip](https://github.com/user-attachments/files/16736807/polepos.zip)

 