### PR TITLE
fix build with gcc 15

### DIFF
--- a/src/machine/model1_machine.c
+++ b/src/machine/model1_machine.c
@@ -162,7 +162,7 @@ static float ram_get_f(void)
 	return u2f(ram_data[ram_scanadr++]);
 }
 
-static void fadd(void)
+static void l_fadd(void)
 {
 	float a = fifoin_pop_f();
 	float b = fifoin_pop_f();
@@ -172,7 +172,7 @@ static void fadd(void)
 	next_fn();
 }
 
-static void fsub(void)
+static void l_fsub(void)
 {
 	float a = fifoin_pop_f();
 	float b = fifoin_pop_f();
@@ -183,7 +183,7 @@ static void fsub(void)
 	next_fn();
 }
 
-static void fmul(void)
+static void l_fmul(void)
 {
 	float a = fifoin_pop_f();
 	float b = fifoin_pop_f();
@@ -193,7 +193,7 @@ static void fmul(void)
 	next_fn();
 }
 
-static void fdiv(void)
+static void l_fdiv(void)
 {
 	float a = fifoin_pop_f();
 	float b = fifoin_pop_f();
@@ -1596,10 +1596,10 @@ struct function {
 };
 
 static struct function ftab_vf[] = {
-	{   0, fadd,            2 },
-	{   1, fsub,            2 },
-	{   2, fmul,            2 },
-	{   3, fdiv,            2 },
+	{   0, l_fadd,          2 },
+	{   1, l_fsub,          2 },
+	{   2, l_fmul,          2 },
+	{   3, l_fdiv,          2 },
 	{   5, matrix_push,     0 },
 	{   6, matrix_pop,      0 },
 	{   7, matrix_write,   12 },
@@ -1674,10 +1674,10 @@ static struct function ftab_vf[] = {
 /*   f15_swa */
 
 static struct function ftab_swa[] = {
-	{   0, fadd,            2 },
-	{   1, fsub,            2 },
-	{   2, fmul,            2 },
-	{   3, fdiv,            2 },
+	{   0, l_fadd,          2 },
+	{   1, l_fsub,          2 },
+	{   2, l_fmul,          2 },
+	{   3, l_fdiv,          2 },
 	{   5, matrix_push,     0 },
 	{   6, matrix_pop,      0 },
 	{   7, matrix_write,   12 },


### PR DESCRIPTION
Don't overwrite the system declarations of the f functions, prefix the fubctions with l_ denoting that they are local.

- Closes #1899