### PR TITLE
cyclone: use HAVE_ARMv6 flag for backward asm compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DEBUG         ?= 0
 DEBUGGER      ?= 0
 SPLIT_UP_LINK ?= 0
 ARM           ?= 0 # set to 0 or 1 to indicate ARM or not
+HAVE_ARMv6    ?= 0
 CPU_ARCH      ?= 0 # as of November 2018 this flag doesn't seem to be used but is being set to either arm or arm64 for some platforms
 
 LIBS          ?=
@@ -180,6 +181,7 @@ else ifeq ($(platform), rpi0)
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 
 # Raspberry Pi 1
 else ifeq ($(platform), rpi1)
@@ -192,6 +194,7 @@ else ifeq ($(platform), rpi1)
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 
 # Raspberry Pi 2
 else ifeq ($(platform), rpi2)
@@ -204,6 +207,7 @@ else ifeq ($(platform), rpi2)
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 
 # Raspberry Pi 3
 else ifeq ($(platform), rpi3)
@@ -216,6 +220,7 @@ else ifeq ($(platform), rpi3)
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 
 # Raspberry Pi 3 (AArch64)
 else ifeq ($(platform), rpi3_64)
@@ -239,6 +244,7 @@ else ifeq ($(platform), rpi4)
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 
 # Raspberry Pi 4 (AArch64)
 else ifeq ($(platform), rpi4_64)
@@ -271,6 +277,7 @@ else ifeq ($(platform), classic_armv7_a7)
 	ARCH = arm
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 	ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
 		CFLAGS += -march=armv7-a
 	else
@@ -301,6 +308,7 @@ else ifeq ($(platform), s812)
 	ARCH = arm
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 
 # Playstation Classic
 else ifeq ($(platform), classic_armv8_a35)
@@ -322,6 +330,7 @@ else ifeq ($(platform), classic_armv8_a35)
 	ARCH = arm
 	CPU_ARCH := arm
 	ARM = 1
+	HAVE_ARMv6 = 1
 	CFLAGS += -march=armv8-a
 	LDFLAGS += -static-libgcc -static-libstdc++
 
@@ -470,6 +479,7 @@ else ifeq ($(platform), vita)
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 	HAVE_RZLIB := 1
 	ARM = 1
+	HAVE_ARMv6 = 1
 	STATIC_LINKING := 1
 	USE_CYCLONE := 1
 	USE_DRZ80 := 1
@@ -841,6 +851,10 @@ else
 endif
 endif
 
+ifeq ($(HAVE_ARMv6),1)
+	CFLAGS += -DHAVE_ARMv6
+endif
+
 # include the various .mak files
 ifneq (,$(filter $(INCLUDE_DRV),all))
 	include Makefile.common
@@ -857,7 +871,7 @@ CFLAGS += $(INCFLAGS) $(INCFLAGS_PLATFORM)
 # combine the various definitions to one
 CDEFS = $(DEFS) $(CPUDEFS) $(SOUNDDEFS) $(ASMDEFS) $(DBGDEFS)
 
-OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_ASM:.s=.o)
+OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_ASM:.s=.o) $(SOURCES_ASM_PP:.S=.o)
 
 OBJOUT   = -o
 LINKOUT  = -o 

--- a/Makefile.common
+++ b/Makefile.common
@@ -2722,7 +2722,7 @@ endif
 
 ifeq ($(USE_CYCLONE), 1)
 	CPUDEFS += -DHAS_CYCLONE=1
-	SOURCES_ASM += $(CORE_DIR)/cpu/m68000_cyclone/cyclone.s
+	SOURCES_ASM_PP += $(CORE_DIR)/cpu/m68000_cyclone/cyclone.S
 	SOURCES_C += $(CORE_DIR)/cpu/m68000_cyclone/c68000.c
 endif
 

--- a/Makefile.split
+++ b/Makefile.split
@@ -2701,7 +2701,7 @@ endif
 
 ifeq ($(USE_CYCLONE), 1)
 	CPUDEFS += -DHAS_CYCLONE=1
-	SOURCES_ASM += $(CORE_DIR)/cpu/m68000_cyclone/cyclone.s
+	SOURCES_ASM_PP += $(CORE_DIR)/cpu/m68000_cyclone/cyclone.S
 	SOURCES_C += $(CORE_DIR)/cpu/m68000_cyclone/c68000.c
 endif
 

--- a/src/cpu/m68000_cyclone/cyclone.S
+++ b/src/cpu/m68000_cyclone/cyclone.S
@@ -17210,7 +17210,12 @@ Op2100:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -17256,7 +17261,12 @@ Op2110:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17302,7 +17312,12 @@ Op2118:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17349,7 +17364,12 @@ Op2120:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17395,7 +17415,12 @@ Op2128:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17450,7 +17475,12 @@ Op2130:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17493,7 +17523,12 @@ Op2138:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17538,7 +17573,12 @@ Op2139:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17584,7 +17624,12 @@ Op213a:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17638,7 +17683,12 @@ Op213b:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -17679,7 +17729,12 @@ Op213c:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -19831,7 +19886,12 @@ Op2f00:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -19875,7 +19935,12 @@ Op2f10:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -19919,7 +19984,12 @@ Op2f18:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -19964,7 +20034,12 @@ Op2f20:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20008,7 +20083,12 @@ Op2f28:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20061,7 +20141,12 @@ Op2f30:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20102,7 +20187,12 @@ Op2f38:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20145,7 +20235,12 @@ Op2f39:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20189,7 +20284,12 @@ Op2f3a:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20241,7 +20341,12 @@ Op2f3b:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -20280,7 +20385,12 @@ Op2f3c:
   mov r11,r1
   add r0,r8,#2
 ;@ EaWrite: Write r1 into '-(a7)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -20546,7 +20656,12 @@ Op3050:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20574,7 +20689,12 @@ Op3058:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20603,7 +20723,12 @@ Op3060:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20631,7 +20756,12 @@ Op3068:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20668,7 +20798,12 @@ Op3070:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20693,7 +20828,12 @@ Op3078:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20720,7 +20860,12 @@ Op3079:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20748,7 +20893,12 @@ Op307a:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x84] ;@ Call fetch16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -20784,7 +20934,12 @@ Op307b:
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x84] ;@ Call fetch16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r1,r0 ;@ sign extend
+#else
+  mov r1,r0,asl #16
+  mov r1,r1,asr #16 ;@ sign extend
+#endif
 
 ;@ EaCalc : Get register index into r0:
   and r0,r8,#0x1e00
@@ -24880,7 +25035,12 @@ Op4050:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -24924,7 +25084,12 @@ Op4058:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -24969,7 +25134,12 @@ Op4060:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -25013,7 +25183,12 @@ Op4068:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -25066,7 +25241,12 @@ Op4070:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -25107,7 +25287,12 @@ Op4078:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -25150,7 +25335,12 @@ Op4079:
   andeq r10,r10,r3 ;@ fix Z
 
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -25519,7 +25709,12 @@ Op40d0:
   orr r2,r2,#0x8 ;@ A0-7
   ldr r0,[r7,r2,lsl #2]
 ;@ EaWrite: Write r1 into '(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -25553,7 +25748,12 @@ Op40d8:
   add r3,r0,#2 ;@ Post-increment An
   str r3,[r7,r2,lsl #2]
 ;@ EaWrite: Write r1 into '(a0)+' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -25588,7 +25788,12 @@ Op40e0:
   sub r0,r0,#2 ;@ Pre-decrement An
   str r0,[r7,r2,lsl #2]
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -25622,7 +25827,12 @@ Op40e8:
   ldr r2,[r7,r2,lsl #2]
   add r0,r0,r2 ;@ Add on offset
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -25665,7 +25875,12 @@ Op40f0:
   ldr r2,[r7,r2,lsl #2]
   add r0,r2,r3 ;@ r0=Disp+An+Rn
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -25696,7 +25911,12 @@ Op40f8:
 ;@ EaCalc : Get '$3333.w' into r0:
   ldrsh r0,[r4],#2 ;@ Fetch Absolute Short address
 ;@ EaWrite: Write r1 into '$3333.w' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -25729,7 +25949,12 @@ Op40f9:
   ldrh r0,[r4],#2
   orr r0,r0,r2,lsl #16
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r0,#0xff000000
   mov lr,pc
@@ -26743,7 +26968,12 @@ Op4250:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -26771,7 +27001,12 @@ Op4258:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -26800,7 +27035,12 @@ Op4260:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -26828,7 +27068,12 @@ Op4268:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -26865,7 +27110,12 @@ Op4270:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -26890,7 +27140,12 @@ Op4278:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -26917,7 +27172,12 @@ Op4279:
   mov r10,#0x40000000 ;@ NZCV=0100
 
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   str r4,[r7,#0x40] ;@ Save PC
   bic r0,r11,#0xff000000
   mov lr,pc
@@ -27538,7 +27798,12 @@ Op4450:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -27574,7 +27839,12 @@ Op4458:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -27611,7 +27881,12 @@ Op4460:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -27647,7 +27922,12 @@ Op4468:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -27692,7 +27972,12 @@ Op4470:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -27725,7 +28010,12 @@ Op4478:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -27760,7 +28050,12 @@ Op4479:
   mov r1,r1,asr #16
 
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28713,7 +29008,12 @@ Op4650:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28747,7 +29047,12 @@ Op4658:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28782,7 +29087,12 @@ Op4660:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28816,7 +29126,12 @@ Op4668:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28859,7 +29174,12 @@ Op4670:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28890,7 +29210,12 @@ Op4678:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -28923,7 +29248,12 @@ Op4679:
   orreq r10,r10,#0x40000000 ;@ get NZ, clear CV
 
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30548,7 +30878,12 @@ Movemloop4890:
   ;@ Copy register to memory:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
 ;@ EaWrite: Write r1 into '(a0)' (address in r6):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30599,7 +30934,12 @@ Movemloop48a0:
   ;@ Copy register to memory:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
 ;@ EaWrite: Write r1 into '-(a0)' (address in r6):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30656,7 +30996,12 @@ Movemloop48a8:
   ;@ Copy register to memory:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r6):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30716,7 +31061,12 @@ Movemloop48b0:
   ;@ Copy register to memory:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r6):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30764,7 +31114,12 @@ Movemloop48b8:
   ;@ Copy register to memory:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
 ;@ EaWrite: Write r1 into '$3333.w' (address in r6):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30814,7 +31169,12 @@ Movemloop48b9:
   ;@ Copy register to memory:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r6):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -30935,7 +31295,12 @@ Movemloop48e0:
   ldr r1,[r7,r4] ;@ Load value from Dn/An
   add r0,r6,#2
 ;@ EaWrite: Write r1 into '-(a0)' (address in r0):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r0,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -32088,7 +32453,12 @@ Movemloop4c90:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32137,7 +32507,12 @@ Movemloop4c98:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32194,7 +32569,12 @@ Movemloop4ca8:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32254,7 +32634,12 @@ Movemloop4cb0:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32302,7 +32687,12 @@ Movemloop4cb8:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32352,7 +32742,12 @@ Movemloop4cb9:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x6c] ;@ Call read16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32403,7 +32798,12 @@ Movemloop4cba:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x84] ;@ Call fetch16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -32462,7 +32862,12 @@ Movemloop4cbb:
   bic r0,r6,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x84] ;@ Call fetch16(r0) handler
+#ifdef HAVE_ARMv6
   sxth r0,r0 ;@ sign extend
+#else
+  mov r0,r0,asl #16
+  mov r0,r0,asr #16 ;@ sign extend
+#endif
 
   str r0,[r7,r4] ;@ Save value into Dn/An
   add r6,r6,#2 ;@ Post-increment address
@@ -45474,7 +45879,12 @@ Op8150:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -45515,7 +45925,12 @@ Op8158:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -45557,7 +45972,12 @@ Op8160:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -45598,7 +46018,12 @@ Op8168:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -45648,7 +46073,12 @@ Op8170:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -45686,7 +46116,12 @@ Op8178:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -45726,7 +46161,12 @@ Op8179:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49684,7 +50124,12 @@ Op9150:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49726,7 +50171,12 @@ Op9158:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49769,7 +50219,12 @@ Op9160:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49811,7 +50266,12 @@ Op9168:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49862,7 +50322,12 @@ Op9170:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49901,7 +50366,12 @@ Op9178:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -49942,7 +50412,12 @@ Op9179:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56409,7 +56884,12 @@ Opc150:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56450,7 +56930,12 @@ Opc158:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56492,7 +56977,12 @@ Opc160:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56533,7 +57023,12 @@ Opc168:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56583,7 +57078,12 @@ Opc170:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56621,7 +57121,12 @@ Opc178:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -56661,7 +57166,12 @@ Opc179:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60041,7 +60551,12 @@ Opd150:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60082,7 +60597,12 @@ Opd158:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '(a0)+' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60124,7 +60644,12 @@ Opd160:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '-(a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60165,7 +60690,12 @@ Opd168:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($3333,a0)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60215,7 +60745,12 @@ Opd170:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '($33,a0,d3.w*2)' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60253,7 +60788,12 @@ Opd178:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$3333.w' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler
@@ -60293,7 +60833,12 @@ Opd179:
 ;@ Save result:
   mov r1,r1,asr #16
 ;@ EaWrite: Write r1 into '$33333333.l' (address in r11):
+#ifdef HAVE_ARMv6
   uxth r1,r1 ;@ zero extend
+#else
+  mov r1,r1,lsl #16
+  mov r1,r1,lsr #16 ;@ zero extend
+#endif
   bic r0,r11,#0xff000000
   mov lr,pc
   ldr pc,[r7,#0x78] ;@ Call write16(r0,r1) handler


### PR DESCRIPTION
after 5f98dc3cf18cee1e2e9d0264d5851f612642d6e7 the build fails for old armv5 platform when using CYCLONE, so for compatibility use HAVE_ARMv6 in preprocessed cyclone.S (e.g. use in [upstream](https://github.com/notaz/cyclone68000/blob/3ac7cf1bdeecb60e2414980e8dc72ff092f69769/OpAny.cpp#L197))