### PR TITLE
fix vaportra for mr arcadez

### DIFF
--- a/src/drivers/vaportra.c
+++ b/src/drivers/vaportra.c
@@ -71,9 +71,11 @@ static MEMORY_READ16_START( vaportra_readmem )
 	{ 0x300000, 0x300fff, MRA16_RAM },
 	{ 0x304000, 0x304fff, MRA16_RAM },
 	{ 0x308000, 0x308001, MRA16_NOP },
-	{ 0xff8000, 0xff87ff, MRA16_RAM },
+
 	{ 0xffc000, 0xffffff, MRA16_RAM },
 MEMORY_END
+
+static WRITE16_HANDLER(MWA16_SHAREDRAM0 ) { offset &= 0x7ff; COMBINE_DATA( &spriteram16[offset] ); }
 
 static MEMORY_WRITE16_START( vaportra_writemem )
 	{ 0x000000, 0x07ffff, MWA16_ROM },
@@ -91,8 +93,9 @@ static MEMORY_WRITE16_START( vaportra_writemem )
 	{ 0x300000, 0x3009ff, vaportra_palette_24bit_rg_w, &paletteram16 },
 	{ 0x304000, 0x3049ff, vaportra_palette_24bit_b_w, &paletteram16_2 },
 	{ 0x308000, 0x308001, MWA16_NOP },
-	{ 0x30c000, 0x30c001, buffer_spriteram16_w },
-	{ 0xff8000, 0xff87ff, MWA16_RAM, &spriteram16, &spriteram_size },
+	{ 0x30c000, 0x30c001, buffer_spriteram16_w,  },
+
+	{ 0x318000, 0xff87ff, MWA16_SHAREDRAM0, &spriteram16  },
 	{ 0xffc000, 0xffffff, MWA16_RAM },
 MEMORY_END
 
@@ -447,6 +450,8 @@ static DRIVER_INIT( vaportra )
 
 	for (i=0x00000; i<0x80000; i++)
 		RAM[i]=(RAM[i] & 0x7e) | ((RAM[i] & 0x01) << 7) | ((RAM[i] & 0x80) >> 7);
+	buffered_spriteram16=auto_malloc(0x800);
+	spriteram_size=0x7ff;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
The fix for the xbox port is

```
-       AM_RANGE(0xff8000, 0xff87ff) AM_WRITE(MWA16_RAM) AM_BASE(&spriteram16) AM_SIZE(&spriteram_size)
+       AM_RANGE(0x318000, 0x3187ff) AM_MIRROR(0xce0000) AM_WRITE(MWA16_RAM) AM_BASE(&spriteram16) AM_SIZE(&spriteram_size)
```
 

