### PR TITLE
Makefile: platform=miyoo ->USE_CYCLONE & USE_DRZ80

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,11 +532,14 @@ else ifeq ($(platform), miyoo)
 	CC = /opt/miyoo/usr/bin/arm-linux-gcc
 	CXX = /opt/miyoo/usr/bin/arm-linux-g++
 	AR = /opt/miyoo/usr/bin/arm-linux-ar
-	fpic := -fPIC
+	fpic := -fno-PIC
 	LDFLAGS += -shared -Wl,--version-script=link.T -Wl,-no-undefined
 	PLATCFLAGS := -DNO_UNALIGNED_ACCESS
 	PLATCFLAGS += -fomit-frame-pointer -march=armv5te -mtune=arm926ej-s -ffast-math
 	CXXFLAGS += -fno-rtti -fno-exceptions
+	ARM = 1
+	USE_CYCLONE := 1
+	USE_DRZ80 := 1
 
 # Emscripten
 else ifeq ($(platform), emscripten)


### PR DESCRIPTION
add necessary ARM assembly opt. for Miyoo ARMv5 to make core even work.

In our downstream fork we are using also following setup:
```diff
diff --git a/src/mame2003/core_options.c b/src/mame2003/core_options.c
index 2e35ba1a..1ce76792 100644
--- a/src/mame2003/core_options.c
+++ b/src/mame2003/core_options.c
@@ -768,7 +768,11 @@ static struct retro_core_option_v2_definition option_def_cyclone_mode = {
       { "Cyclone+DrZ80(snd)", NULL },
       { NULL, NULL },
    },
+#if defined(LOW_ARM)
+   "Cyclone+DrZ80(snd)"
+#else
    "default"
+#endif
 };

 static struct retro_core_option_v2_definition option_def_override_ad_stick = {

```

Otherwise core hangs with "default" cyclone_mode, but I'm not sure if maintainers would be ok with such change?