### PR TITLE
Tidy

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -16,7 +16,7 @@
 /*#define LOG_LOAD */
 
 
-char *chd_error_text[] =
+const char *chd_error_text[] =
 {
 	"CHDERR_NONE",
 	"CHDERR_NO_INTERFACE",

--- a/src/common.c
+++ b/src/common.c
@@ -1539,7 +1539,7 @@ static int read_rom_data(struct rom_load_data *romdata, const struct RomModule *
 			return 0;
 		numbytes -= bytesleft;
 
-		log_cb(RETRO_LOG_DEBUG, LOGPRE "  Copying to %08X\n", (int)base);
+		log_cb(RETRO_LOG_DEBUG, LOGPRE "  Copying to %08lX\n", (FPTR)base);
 
 		/* unmasked cases */
 		if (datamask == 0xff)
@@ -1624,7 +1624,7 @@ static int fill_rom_data(struct rom_load_data *romdata, const struct RomModule *
 	}
 
 	/* fill the data (filling value is stored in place of the hashdata) */
-	memset(base, (UINT32)ROM_GETHASHDATA(romp) & 0xff, numbytes);
+	memset(base, (FPTR)ROM_GETHASHDATA(romp) & 0xff, numbytes);
 	return 1;
 }
 
@@ -1638,7 +1638,7 @@ static int copy_rom_data(struct rom_load_data *romdata, const struct RomModule *
 	UINT8 *base = romdata->regionbase + ROM_GETOFFSET(romp);
 	int srcregion = ROM_GETFLAGS(romp) >> 24;
 	UINT32 numbytes = ROM_GETLENGTH(romp);
-	UINT32 srcoffs = (UINT32)ROM_GETHASHDATA(romp);  /* srcoffset in place of hashdata */
+	UINT32 srcoffs = (UINT32)(FPTR)ROM_GETHASHDATA(romp);
 	UINT8 *srcbase;
 
 	/* make sure we copy within the region space */
@@ -1970,7 +1970,7 @@ int rom_load(const struct RomModule *romp)
 		/* remember the base and length */
 		romdata.regionlength = memory_region_length(regiontype);
 		romdata.regionbase = memory_region(regiontype);
-		log_cb(RETRO_LOG_DEBUG, LOGPRE "Allocated %X bytes @ %08X\n", romdata.regionlength, (int)romdata.regionbase);
+		log_cb(RETRO_LOG_DEBUG, LOGPRE "Allocated %X bytes @ %08lX\n", romdata.regionlength, (FPTR)romdata.regionbase);
 
 		/* clear the region if it's requested */
 		if (ROMREGION_ISERASE(region))

--- a/src/common.h
+++ b/src/common.h
@@ -181,7 +181,7 @@ enum
 #define ROMENTRY_COPY				((const char *)ROMENTRYTYPE_COPY)
 
 /* ----- per-entry macros ----- */
-#define ROMENTRY_GETTYPE(r)			((FPTR)(r)->_name)
+#define ROMENTRY_GETTYPE(r) ((FPTR)(r)->_name)
 #define ROMENTRY_ISSPECIAL(r)		(ROMENTRY_GETTYPE(r) < ROMENTRYTYPE_COUNT)
 #define ROMENTRY_ISFILE(r)			(!ROMENTRY_ISSPECIAL(r))
 #define ROMENTRY_ISREGION(r)		((r)->_name == ROMENTRY_REGION)
@@ -234,7 +234,7 @@ enum
 #define		ROMREGION_DATATYPEDISK	0x00010000
 
 /* ----- per-region macros ----- */
-#define ROMREGION_GETTYPE(r)		((UINT32)(r)->_hashdata)
+#define ROMREGION_GETTYPE(r) ((FPTR)(r)->_hashdata)
 #define ROMREGION_GETLENGTH(r)		((r)->_length)
 #define ROMREGION_GETFLAGS(r)		((r)->_flags)
 #define ROMREGION_GETWIDTH(r)		(8 << (ROMREGION_GETFLAGS(r) & ROMREGION_WIDTHMASK))

--- a/src/lib/zlib/zutil.c
+++ b/src/lib/zlib/zutil.c
@@ -10,7 +10,7 @@
 #  include "gzguts.h"
 #endif
 
-char * const z_errmsg[10] = {
+const char *  z_errmsg[10] = {
    "need dictionary",     /* Z_NEED_DICT       2  */
    "stream end",          /* Z_STREAM_END      1  */
    "",                    /* Z_OK              0  */

--- a/src/lib/zlib/zutil.h
+++ b/src/lib/zlib/zutil.h
@@ -44,7 +44,7 @@ typedef unsigned short ush;
 typedef ush FAR ushf;
 typedef unsigned long  ulg;
 
-extern char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+extern const char *  z_errmsg[10]; /* indexed by 2-zlib_error */
 /* (size given to avoid silly warnings with Visual C++) */
 
 #define ERR_MSG(err) z_errmsg[Z_NEED_DICT-(err)]

--- a/src/mame-memory.c
+++ b/src/mame-memory.c
@@ -920,9 +920,6 @@ void populate_table(struct memport_data *memport, int iswrite, offs_t start, off
 		if (l1start == l1stop)
 		{
 
-		subtable = &tabledata->table[(1 << l1bits) + (subindex << l2bits)];
-		memset(&subtable[l2start], handler, l2stop - l2start + 1);
-
 		/* Refetch base after potential realloc */
 		subtable = &tabledata->table[(1 << l1bits) + (subindex << l2bits)];
 		memset(&subtable[l2start], handler, l2stop - l2start + 1);

--- a/src/mame2003/mame2003.h
+++ b/src/mame2003/mame2003.h
@@ -43,12 +43,17 @@ extern "C" {
 #define CLIB_DECL
 #endif
 
-#ifdef __LP64__
-#define FPTR unsigned long   /* 64bit: sizeof(void *) is sizeof(long)  */
-#else
-#define FPTR unsigned int
-#endif
+//below is standard modern compilers
+#define FPTR uintptr_t
 
+//fallback for c89 compilers only msvc as far as I know
+#if defined _MSC_VER
+	#ifdef __LP64__
+	#define FPTR unsigned long   // 64bit: sizeof(void *) is sizeof(long)  dont think this is the case for msvc 64 bit use #define FPTR uintptr_t for it.  
+	#else
+	#define FPTR unsigned int    // since your using c89 for msvc so youll need to find defines for the 64 bit compilers that set the flags right.
+	#endif                       
+#endif //end defined _MSC_VER
 /***************************************************************************
 
 	Parameters

--- a/src/memory.h
+++ b/src/memory.h
@@ -905,36 +905,12 @@ data32_t	cpu_readop_arg32_safe(offs_t offset);
 
 /* ----- unsafe opcode and opcode argument reading ----- */
 #define cpu_readop_unsafe(A)		(OP_ROM[(A) & mem_amask])
-//#define cpu_readop16_unsafe(A)		(*(data16_t *)&OP_ROM[(A) & mem_amask])
-static INLINE data16_t cpu_readop16_unsafe(offs_t A)
-{
-	data16_t val;
-	memcpy(&val, &OP_ROM[(A) & mem_amask], sizeof(val));
-	return val;
-}
-//#define cpu_readop32_unsafe(A)		(*(data32_t *)&OP_ROM[(A) & mem_amask])
-static INLINE data32_t cpu_readop32_unsafe(offs_t A)
-{
-	data32_t val;
-	memcpy(&val, &OP_ROM[(A) & mem_amask], sizeof(val));
-	return val;
-}
+#define cpu_readop16_unsafe(A)		(*(data16_t *)&OP_ROM[(A) & mem_amask])
+#define cpu_readop32_unsafe(A)		(*(data32_t *)&OP_ROM[(A) & mem_amask])
 #define cpu_readop_arg_unsafe(A)	(OP_RAM[(A) & mem_amask])
-//#define cpu_readop_arg16_unsafe(A)	(*(data16_t *)&OP_RAM[(A) & mem_amask])
-static INLINE data16_t cpu_readop_arg16_unsafe(offs_t A)
-{
-	data16_t val;
-	memcpy(&val, &OP_RAM[(A) & mem_amask], sizeof(val));
-	return val;
-}
+#define cpu_readop_arg16_unsafe(A)	(*(data16_t *)&OP_RAM[(A) & mem_amask])
+#define cpu_readop_arg32_unsafe(A)	(*(data32_t *)&OP_RAM[(A) & mem_amask])
 
-//#define cpu_readop_arg32_unsafe(A)	(*(data32_t *)&OP_RAM[(A) & mem_amask])
-static INLINE data32_t cpu_readop_arg32_unsafe(offs_t A)
-{
-	data32_t val;
-	memcpy(&val, &OP_RAM[(A) & mem_amask], sizeof(val));
-	return val;
-}
 /* ----- opcode and opcode argument reading ----- */
 void activecpu_set_op_base(unsigned val);
 static INLINE data8_t  cpu_readop(offs_t A)		{ if (address_is_unsafe(A)) { activecpu_set_op_base(A); } return cpu_readop_unsafe(A); }

--- a/src/memory.h
+++ b/src/memory.h
@@ -11,6 +11,7 @@
 
 #include "osd_cpu.h"
 #include <stddef.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -904,12 +905,36 @@ data32_t	cpu_readop_arg32_safe(offs_t offset);
 
 /* ----- unsafe opcode and opcode argument reading ----- */
 #define cpu_readop_unsafe(A)		(OP_ROM[(A) & mem_amask])
-#define cpu_readop16_unsafe(A)		(*(data16_t *)&OP_ROM[(A) & mem_amask])
-#define cpu_readop32_unsafe(A)		(*(data32_t *)&OP_ROM[(A) & mem_amask])
+//#define cpu_readop16_unsafe(A)		(*(data16_t *)&OP_ROM[(A) & mem_amask])
+static INLINE data16_t cpu_readop16_unsafe(offs_t A)
+{
+	data16_t val;
+	memcpy(&val, &OP_ROM[(A) & mem_amask], sizeof(val));
+	return val;
+}
+//#define cpu_readop32_unsafe(A)		(*(data32_t *)&OP_ROM[(A) & mem_amask])
+static INLINE data32_t cpu_readop32_unsafe(offs_t A)
+{
+	data32_t val;
+	memcpy(&val, &OP_ROM[(A) & mem_amask], sizeof(val));
+	return val;
+}
 #define cpu_readop_arg_unsafe(A)	(OP_RAM[(A) & mem_amask])
-#define cpu_readop_arg16_unsafe(A)	(*(data16_t *)&OP_RAM[(A) & mem_amask])
-#define cpu_readop_arg32_unsafe(A)	(*(data32_t *)&OP_RAM[(A) & mem_amask])
+//#define cpu_readop_arg16_unsafe(A)	(*(data16_t *)&OP_RAM[(A) & mem_amask])
+static INLINE data16_t cpu_readop_arg16_unsafe(offs_t A)
+{
+	data16_t val;
+	memcpy(&val, &OP_RAM[(A) & mem_amask], sizeof(val));
+	return val;
+}
 
+//#define cpu_readop_arg32_unsafe(A)	(*(data32_t *)&OP_RAM[(A) & mem_amask])
+static INLINE data32_t cpu_readop_arg32_unsafe(offs_t A)
+{
+	data32_t val;
+	memcpy(&val, &OP_RAM[(A) & mem_amask], sizeof(val));
+	return val;
+}
 /* ----- opcode and opcode argument reading ----- */
 void activecpu_set_op_base(unsigned val);
 static INLINE data8_t  cpu_readop(offs_t A)		{ if (address_is_unsafe(A)) { activecpu_set_op_base(A); } return cpu_readop_unsafe(A); }


### PR DESCRIPTION
@arcadez2003 libretro had a hacked mame-memory.c patch to hide a serious bug. A while ago we added something we needed to trampoline in the port read handler using static handlers like MRA_RAM MRA_BANK1 ect. I fixed it the segfault in the original code and managed to trace this and fix using static handlers in static PORT_READ(x)_START(readport ) and write handlers so they wont be an issue anymore. Ive also fixed up the memory.c common.c cheat.c 64 bit issue remaining all them errors did need looked at for a while. The fix was done a day or two ago but I had to do some testing and it all good. @mahoneyt944 I added rules for msvc to use the old style FPTR all other ports now use uintptr_t as they are not confined to c89.