### PR TITLE
Fix potential buffer access in bitreader.c

### DIFF
--- a/src/libretro-deps/libFLAC/bitreader.c
+++ b/src/libretro-deps/libFLAC/bitreader.c
@@ -838,7 +838,7 @@ incomplete_lsbs:
 			cwords = br->consumed_words;
 			words = br->words;
 			ucbits = FLAC__BITS_PER_WORD - br->consumed_bits;
-			b = br->buffer[cwords] << br->consumed_bits;
+			b = cwords < br->capacity ? br->buffer[cwords] << br->consumed_bits : 0;
 		} while(cwords >= words && val < end);
 	}
 


### PR DESCRIPTION
This PR fixes a potential security vulnerability in FLAC__bitreader_read_rice_signed_block that was cloned from [xiph/flac](https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4) but did not receive the security patch.

###Details:
Affected Function: FLAC__bitreader_read_rice_signed_block in bitreader.c
Original Fix: [original commit](https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4)

###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
[original commit](https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4)
[link to original CVE/bug id](https://nvd.nist.gov/vuln/detail/cve-2020-0499)

Please review and merge this PR to ensure your repository is protected against this potential vulnerability